### PR TITLE
memchecker: per RFC, use calloc for OBJ_NEW

### DIFF
--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -464,7 +464,11 @@ static inline opal_object_t *opal_obj_new(opal_class_t * cls)
     opal_object_t *object;
     assert(cls->cls_sizeof >= sizeof(opal_object_t));
 
+#if OPAL_WANT_MEMCHECKER
+    object = (opal_object_t *) calloc(1, cls->cls_sizeof);
+#else
     object = (opal_object_t *) malloc(cls->cls_sizeof);
+#endif
     if (0 == cls->cls_initialized) {
         opal_class_initialize(cls);
     }

--- a/opal/mca/memchecker/valgrind/configure.m4
+++ b/opal/mca/memchecker/valgrind/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2004-2008 High Performance Computing Center Stuttgart, 
 #                         University of Stuttgart.  All rights reserved.
-# Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -45,7 +45,7 @@ AC_DEFUN([MCA_opal_memchecker_valgrind_CONFIG],[
                   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include "valgrind/memcheck.h"
 ]],
-                     [[char buffer = 0xff;
+                     [[char buffer = 0x0f;
                        VALGRIND_CHECK_MEM_IS_ADDRESSABLE(&buffer, sizeof(buffer));]])],
                      [AC_MSG_RESULT([yes])
                       opal_memchecker_valgrind_happy=yes],


### PR DESCRIPTION
I think that this is worthy of bringing to v1.8 because it will significantly reduce valgrind output for those who do `--enable-memchecker` builds.  Hence, it can easily be considered a bug fix, not an enhancement.

---

With --enable-memchecker builds, use calloc(3) for OBJ_NEW instead of malloc(3).  This cuts down on a lot of valgrind/memory checker false positive output.

Also make a minor change in the valgrind configure.m4; have it assign 0xf to a char.  The prior assignment (of 0xff) was warning about an overflow.  This didn't really matter, but we might as well make the test not have a gratuitious warning in it.

(cherry picked from commit a422d893b8e63347deb71bbaaa14ca25ddb1f192)
