### PR TITLE
MTL/MXM: disable "bulk_connect" by default.

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm_component.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm_component.c
@@ -90,11 +90,11 @@ static int ompi_mtl_mxm_component_register(void)
 {
     unsigned long cur_ver = mxm_get_version();
 
+    ompi_mtl_mxm.bulk_connect = 0;
+
     if (cur_ver < MXM_VERSION(3,2)) {
-        ompi_mtl_mxm.bulk_connect    = 0;
         ompi_mtl_mxm.bulk_disconnect = 0;
     } else {
-        ompi_mtl_mxm.bulk_connect    = 1;
         ompi_mtl_mxm.bulk_disconnect = 1;
     }
 


### PR DESCRIPTION
(cherry picked from commit a215a4831dfae9dd0a3fee7b31ee784d4e5394a4)
