### PR TITLE
MTL MXM: fix check-help-string.pl errors and warnings.

### DIFF
--- a/ompi/mca/mtl/mxm/help-mtl-mxm.txt
+++ b/ompi/mca/mtl/mxm/help-mtl-mxm.txt
@@ -46,10 +46,14 @@ Initialization of MXM library failed.
 
   Error: %s
 
-[error polling network]
-Error %s occurred in attempting to make network progress (mxm_mq_ipeek).
-
 [error posting receive]
+Unable to post application receive buffer
+
+  Error:      %s
+  Buffer:     %p
+  Length:     %d
+
+[error posting message receive]
 Unable to post application receive buffer
 
   Error:      %s
@@ -61,7 +65,3 @@ Unable to post application send buffer
 
   Error:      %s
 
-[error while waiting in send]
-Error while waiting in send
-
-  Error:      %s


### PR DESCRIPTION
This commit was SVN r32533.
open-mpi/ompi@a914c683569d5cc58f466422b2523785af2a94c9

@miked-mellanox @jladd-mlnx please review
