### PR TITLE
tools: fix cli args parsing

### DIFF
--- a/contrib/dist/make_dist_tarball
+++ b/contrib/dist/make_dist_tarball
@@ -70,7 +70,7 @@ while test "$1" != ""; do
         --no-ompi) want_ompi=0 ;;
         --autogen-args) autogen_args=$2; shift ;;
         --distdir) distdir=$2; shift ;;
-        --dirtyok) dirty_ok=1; shift ;;
+        --dirtyok) dirty_ok=1 ;;
         --verok) gnu_version_ignore=1;;
         *)
             cat <<EOF


### PR DESCRIPTION
No need to "shift" if argument does not expect parameter on the command line.
(cherry picked from commit master@6372ac926c6a6622222915ac4f9301021f731c35)

Reviewed by Jeff, RM-approved
