### PR TITLE
OSHMEM: fix check-help-string.pl errors and warnings.

### DIFF
--- a/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
+++ b/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
@@ -9,12 +9,6 @@
 #
 
 
-[no uuid present]
-Error obtaining unique transport key from ORTE (orte_precondition_transports %s
-the environment).
-
-  Local host: %s
-
 [unable to create endpoint]
 MXM was unable to create an endpoint. Please make sure that the network link is
 active on the node and the hardware is functioning. 
@@ -23,16 +17,6 @@ active on the node and the hardware is functioning.
 
 [unable to get endpoint address]
 MXM was unable to get endpoint address
-
-  Error: %s
-
-[unable to extract endpoint ib address]
-MXM was unable to read IB settings for endpoint 
-
-  Error: %s
-
-[unable to extract endpoint local address]
-MXM was unable to read shmem settings for endpoint 
 
   Error: %s
 
@@ -51,26 +35,6 @@ Initialization of MXM library failed.
 
   Error: %s
 
-[error polling network]
-Error %s occurred in attempting to make network progress (mxm_mq_ipeek).
-
-[error posting receive]
-Unable to post application receive buffer
-
-  Error:      %s
-  Buffer:     %p
-  Length:     %d
-
-[error posting send]
-Unable to post application send buffer
-
-  Error:      %s
-
-[error while waiting in send]
-Unable while waiting in send
-
-  Error:      %s
-  
 [mxm tls]
 ERROR: MXM shared memory transport can not be used
 bacause it is not fully compliant with OSHMEM spec

--- a/oshmem/mca/spml/yoda/help-oshmem-spml-yoda.txt
+++ b/oshmem/mca/spml/yoda/help-oshmem-spml-yoda.txt
@@ -8,18 +8,6 @@
 # 
 # $HEADER$
 #
-[eager_limit_too_small]
-The "eager limit" MCA parameter in the %s BTL was set to a value which
-is too low for Open SHMEM to function properly.  Please re-run your job
-with a higher eager limit value for this BTL; the exact MCA parameter
-name and its corresponding minimum value is shown below.
-
-  Local host:              %s
-  BTL name:                %s
-  BTL eager limit value:   %d (set via btl_%s_eager_limit)
-  BTL eager limit minimum: %d
-  MCA parameter name:      btl_%s_eager_limit 
-
 [internal_oom_error]
 '%s' operation failed. Unable to allocate buffer, need %d bytes.
 Try increasing 'spml_yoda_bml_alloc_threshold' value or setting it to '0' to

--- a/oshmem/runtime/help-shmem-runtime.txt
+++ b/oshmem/runtime/help-shmem-runtime.txt
@@ -21,13 +21,6 @@ developer):
   %s
   --> Returned "%s" (%d) instead of "Success" (0)
 #
-[shmem_finalize:invoked_multiple_times]
-The function SHMEM_FINALIZE was invoked multiple times in a single
-process on host %s, PID %d.  
-
-This indicates an erroneous SHMEM program; SHMEM_FINALIZE is only allowed
-to be invoked exactly once in a process.
-#
 [heterogeneous-support-unavailable]
 This installation of Open SHMEM was configured without support for
 heterogeneous architectures, but at least one node in the allocation
@@ -37,23 +30,6 @@ Node: %s
 
 In order to operate in a heterogeneous environment, please reconfigure
 Open SHMEM with --enable-heterogeneous.
-#
-[shmem_init:warn-fork]
-A SHMEM process has executed an operation involving a call to the
-"fork()" system call to create a child process.  Open SHMEM is currently
-operating in a condition that could result in memory corruption or
-other system errors; your SHMEM job may hang, crash, or produce silent
-data corruption.  The use of fork() (or system() or other calls that
-create child processes) is strongly discouraged.  
-
-The process that invoked fork was:
-
-  Local host:          %s (PID %d)
-  My PE:               %d
-
-If you are *absolutely sure* that your application will successfully
-and correctly survive a call to fork(), you may disable this warning
-by setting the mpi_warn_on_fork MCA parameter to 0.
 #
 [oshmem shmem abort:cannot guarantee all killed]
 A SHMEM process is aborting at a time when it cannot guarantee that all

--- a/oshmem/shmem/c/help-shmem-api.txt
+++ b/oshmem/shmem/c/help-shmem-api.txt
@@ -10,12 +10,5 @@
 #
 # This is the US/English general help file for Open SHMEM.
 #
-[shmem-function-after-finalize]
-Calling any SHMEM-function after calling shmem_finalize is erroneous. 
-%s was called. 
-#
-[shmem-initialize-twice]
-Calling shmem_init twice is erroneous.
-#
 [shmem-abort]
 SHMEM_ABORT was invoked on rank %d (pid %d, host=%s) with errorcode %d.

--- a/oshmem/tools/oshmem_info/Makefile.am
+++ b/oshmem/tools/oshmem_info/Makefile.am
@@ -51,6 +51,8 @@ if PROJECT_OSHMEM
 # Only build/install the binary and man pages if we're building oshmem
 bin_PROGRAMS += oshmem_info
 nodist_man_MANS += $(man_pages)
+dist_ompidata_DATA = \
+     help-oshmem-info.txt
 endif
 
 
@@ -58,7 +60,6 @@ endif
 # changes; a "good enough" way to know if configure was run again (and
 # therefore the release date or version may have changed)
 $(nodist_man_MANS): $(top_builddir)/opal/include/opal_config.h
-
 
 oshmem_info_SOURCES = \
         oshmem_info.h \

--- a/oshmem/tools/oshmem_info/help-oshmem-info.txt
+++ b/oshmem/tools/oshmem_info/help-oshmem-info.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2014      Mellanox Technologies, Inc.
+#                         All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+
+[lib-call-fail]
+A library call unexpectedly failed.  This is a terminal error; please
+show this message to an OSHMEM wizard:
+
+         Library call: %s
+          Source file: %s
+   Source line number: %d
+
+Aborting...

--- a/oshmem/tools/oshmem_info/oshmem_info.c
+++ b/oshmem/tools/oshmem_info/oshmem_info.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
 
     /* Initialize the argv parsing handle */
     if (OPAL_SUCCESS != opal_init_util(&argc, &argv)) {
-        opal_show_help("help-opal_info.txt", "lib-call-fail", true,
+        opal_show_help("help-oshmem-info.txt", "lib-call-fail", true,
                        "opal_init_util", __FILE__, __LINE__, NULL);
         exit(ret);
     }
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     info_cmd_line = OBJ_NEW(opal_cmd_line_t);
     if (NULL == info_cmd_line) {
         ret = errno;
-        opal_show_help("help-opal_info.txt", "lib-call-fail", true,
+        opal_show_help("help-oshmem-info.txt", "lib-call-fail", true,
                        "opal_cmd_line_create", __FILE__, __LINE__, NULL);
         exit(ret);
     }


### PR DESCRIPTION
This commit was SVN r32511.
(cherry picked from commit e974bec57e7f9ff7fd9705291f6d11a2ecc69308)

open-mpi/ompi@e974bec57e7f9ff7fd9705291f6d11a2ecc69308
@miked-mellanox @jladd-mlnx 
