### PR TITLE
MXM: update min required version for mxm as 2.1+

### DIFF
--- a/config/ompi_check_mxm.m4
+++ b/config/ompi_check_mxm.m4
@@ -63,11 +63,11 @@ AC_DEFUN([OMPI_CHECK_MXM],[
             [AC_LANG_PROGRAM([[#include <mxm/api/mxm_version.h>]],
                 [[
 #ifndef MXM_VERSION
-#error "MXM Version is less than 1.5, please upgrade"
+#error "MXM Version is less than 2.1, please upgrade"
 #endif
 #
-#if MXM_API < MXM_VERSION(1,5)
-#error "MXM Version is less than 1.5, please upgrade"
+#if MXM_API < MXM_VERSION(2,1)
+#error "MXM Version is less than 2.1, please upgrade"
 #endif
                 ]])],
             [ompi_mxm_version_ok="yes"],


### PR DESCRIPTION
This commit was SVN r32193.
(cherry picked from commit 1b51e472ac88061572bdb4fec7528b5ad3654f49)

open-mpi/ompi@1b51e472ac88061572bdb4fec7528b5ad3654f49
reviewed by miked.
@miked-mellanox @jladd-mlnx 
