### PR TITLE
OSHMEM: spml ikrit: add hardware rdma endpoint

### DIFF
--- a/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
@@ -89,7 +89,7 @@ int mca_atomic_mxm_cswap(void *target,
     /* mxm request init */
     sreq.base.state = MXM_REQ_NEW;
     sreq.base.mq = mca_spml_self->mxm_mq;
-    sreq.base.conn = mca_spml_self->mxm_peers[pe]->mxm_conn;
+    sreq.base.conn = mca_spml_self->mxm_peers[pe]->mxm_hw_rdma_conn;
     sreq.base.completed_cb = NULL;
     sreq.base.data_type = MXM_REQ_DATA_BUFFER;
 

--- a/oshmem/mca/atomic/mxm/atomic_mxm_fadd.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_fadd.c
@@ -91,7 +91,7 @@ int mca_atomic_mxm_fadd(void *target,
     /* mxm request init */
     sreq.base.state = MXM_REQ_NEW;
     sreq.base.mq = mca_spml_self->mxm_mq;
-    sreq.base.conn = mca_spml_self->mxm_peers[pe]->mxm_conn;
+    sreq.base.conn = mca_spml_self->mxm_peers[pe]->mxm_hw_rdma_conn;
     sreq.base.completed_cb = NULL;
     sreq.base.data_type = MXM_REQ_DATA_BUFFER;
 

--- a/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
+++ b/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
@@ -35,9 +35,16 @@ Initialization of MXM library failed.
 
   Error: %s
 
-[mxm tls]
+[mxm shm tls]
 ERROR: MXM shared memory transport can not be used
 bacause it is not fully compliant with OSHMEM spec
 
 MXM transport setting: %s
+
+[mxm tls]
+ERROR: valid mxm transports are:
+"ud" "ud,self" "rc" or "dc"
+
+transport setting is: %s=%s
+
 

--- a/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
+++ b/oshmem/mca/spml/ikrit/help-oshmem-spml-ikrit.txt
@@ -7,44 +7,39 @@
 #
 # $HEADER$
 #
-
-
 [unable to create endpoint]
 MXM was unable to create an endpoint. Please make sure that the network link is
 active on the node and the hardware is functioning. 
 
   Error: %s
-
+#
 [unable to get endpoint address]
 MXM was unable to get endpoint address
 
   Error: %s
-
+#
 [mxm mq create]
 Failed to create MQ for endpoint
 
   Error: %s
-
+#
 [errors during mxm_progress]
-
 Error %s occurred in attempting to make network progress (mxm_progress).
-
-
+#
 [mxm init]
 Initialization of MXM library failed.
 
   Error: %s
-
+#
 [mxm shm tls]
 ERROR: MXM shared memory transport can not be used
 bacause it is not fully compliant with OSHMEM spec
 
 MXM transport setting: %s
-
+#
 [mxm tls]
 ERROR: valid mxm transports are:
 "ud" "ud,self" "rc" or "dc"
 
 transport setting is: %s=%s
-
-
+#

--- a/oshmem/mca/spml/ikrit/spml_ikrit.h
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.h
@@ -55,6 +55,7 @@ BEGIN_C_DECLS
 struct mxm_peer {
     opal_list_item_t    super;
     mxm_conn_h          mxm_conn;
+    mxm_conn_h          mxm_hw_rdma_conn;
     int                 pe;
     int32_t             n_active_puts;
     int                 need_fence;
@@ -68,8 +69,10 @@ struct mca_spml_ikrit_t {
 
     mxm_context_opts_t *mxm_ctx_opts;
     mxm_ep_opts_t *mxm_ep_opts;
+    mxm_ep_opts_t *mxm_ep_hw_rdma_opts;
     mxm_h mxm_context;
     mxm_ep_h mxm_ep;
+    mxm_ep_h mxm_hw_rdma_ep;
     mxm_mq_h mxm_mq;
     mxm_peer_t **mxm_peers;
 
@@ -92,6 +95,8 @@ struct mca_spml_ikrit_t {
     int   ud_only;  /* only ud transport is used. In this case 
                        it is possible to speedup mkey exchange 
                        and not to register memheap */
+    int hw_rdma_channel;  /* true if we provide separate channel that
+                       has true one sided capability */
     int np;
 #if MXM_API >= MXM_VERSION(2,0)
     int unsync_conn_max;

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -111,13 +111,15 @@ static inline int set_mxm_tls()
 
 static inline int check_mxm_hw_tls(char *v, char *tls)
 {
-    if ((0 == strcmp(tls, "rc") || 0 == strcmp(tls, "dc"))) 
+    if ((0 == strcmp(tls, "rc") || 0 == strcmp(tls, "dc"))) {
         return OSHMEM_SUCCESS;
+    }
 
     if (strstr(tls, "ud") &&
             (NULL == strstr(tls, "rc") && NULL == strstr(tls, "dc") &&
-             NULL == strstr(tls, "shm"))) 
+             NULL == strstr(tls, "shm"))) {
         return OSHMEM_SUCCESS;
+    }
 
     orte_show_help("help-oshmem-spml-ikrit.txt", "mxm tls", true,
                     v, tls);
@@ -194,10 +196,11 @@ static int mca_spml_ikrit_component_register(void)
                                        "create separate reliable connection channel",
                                        &mca_spml_ikrit.hw_rdma_channel);
 
-    if (!mca_spml_ikrit.hw_rdma_channel) 
+    if (!mca_spml_ikrit.hw_rdma_channel) {
         v = "ud,self";
-    else
+    } else {
         v = "rc,ud,self";
+    }
     mca_spml_ikrit_param_register_string("mxm_tls",
                                          v,
                                          "[string] TL channels for MXM",
@@ -321,8 +324,9 @@ static int mca_spml_ikrit_component_close(void)
 #else
         mxm_config_free_ep_opts(mca_spml_ikrit.mxm_ep_opts);
         mxm_config_free_context_opts(mca_spml_ikrit.mxm_ctx_opts);
-        if (mca_spml_ikrit.hw_rdma_channel)
+        if (mca_spml_ikrit.hw_rdma_channel) {
             mxm_config_free_ep_opts(mca_spml_ikrit.mxm_ep_hw_rdma_opts);
+        }
 #endif
     }
     mca_spml_ikrit.mxm_context = NULL;

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -104,6 +104,19 @@ static inline int set_mxm_tls()
     }
     return check_mxm_tls("MXM_TLS");
 }
+
+static inline void set_mxm_rc_tls()
+{
+    char *tls;
+
+    tls = getenv("MXM_OSHMEM_HW_RDMA_TLS");
+    if (NULL != tls) {
+        return;
+    }
+
+    setenv("MXM_OSHMEM_HW_RDMA_TLS", "rc", 1);
+    return;
+}
 #endif
 
 static inline void mca_spml_ikrit_param_register_int(const char* param_name,
@@ -156,7 +169,9 @@ static int mca_spml_ikrit_component_register(void)
     mca_spml_ikrit_param_register_int("priority", 20,
                                       "[integer] ikrit priority",
                                       &mca_spml_ikrit.priority);
-
+    mca_spml_ikrit_param_register_int("hw_rdma_channel", 1,
+                                       "create separate reliable connection channel",
+                                       &mca_spml_ikrit.hw_rdma_channel);
     mca_spml_ikrit_param_register_string("mxm_tls",
                                          "rc,ud,self",
                                          "[string] TL channels for MXM",
@@ -215,15 +230,21 @@ static int mca_spml_ikrit_component_open(void)
 
     mca_spml_ikrit.ud_only = 0;
 #if MXM_API < MXM_VERSION(2,1)
+    mca_spml_ikrit.rc_channel = 0;
     if ((MXM_OK != mxm_config_read_context_opts(&mca_spml_ikrit.mxm_ctx_opts)) ||
         (MXM_OK != mxm_config_read_ep_opts(&mca_spml_ikrit.mxm_ep_opts)))
 #else
     if (OSHMEM_SUCCESS != set_mxm_tls()) {
         return OSHMEM_ERROR;
     }
-    if (MXM_OK != mxm_config_read_opts(&mca_spml_ikrit.mxm_ctx_opts,
-                                       &mca_spml_ikrit.mxm_ep_opts,
-                                       "OSHMEM", NULL, 0))
+    set_mxm_rc_tls();
+
+    if ((mca_spml_ikrit.hw_rdma_channel && MXM_OK != mxm_config_read_opts(&mca_spml_ikrit.mxm_ctx_opts,
+                &mca_spml_ikrit.mxm_ep_hw_rdma_opts,
+                "OSHMEM_HW_RDMA", NULL, 0)) ||
+            MXM_OK != mxm_config_read_opts(&mca_spml_ikrit.mxm_ctx_opts,
+                &mca_spml_ikrit.mxm_ep_opts,
+                "OSHMEM", NULL, 0))
 #endif
     {
         SPML_ERROR("Failed to parse MXM configuration");
@@ -273,6 +294,8 @@ static int mca_spml_ikrit_component_close(void)
 #else
         mxm_config_free_ep_opts(mca_spml_ikrit.mxm_ep_opts);
         mxm_config_free_context_opts(mca_spml_ikrit.mxm_ctx_opts);
+        if (mca_spml_ikrit.hw_rdma_channel)
+            mxm_config_free_ep_opts(mca_spml_ikrit.mxm_ep_hw_rdma_opts);
 #endif
     }
     mca_spml_ikrit.mxm_context = NULL;
@@ -301,6 +324,20 @@ static int spml_ikrit_mxm_init(void)
                        true,
                        mxm_error_string(err));
         return OSHMEM_ERROR;
+    }
+    if (mca_spml_ikrit.hw_rdma_channel) {
+        err = mxm_ep_create(mca_spml_ikrit.mxm_context,
+                mca_spml_ikrit.mxm_ep_hw_rdma_opts,
+                &mca_spml_ikrit.mxm_hw_rdma_ep);
+        if (MXM_OK != err) {
+            orte_show_help("help-oshmem-spml-ikrit.txt",
+                    "unable to create endpoint",
+                    true,
+                    mxm_error_string(err));
+            return OSHMEM_ERROR;
+        }
+    } else {
+        mca_spml_ikrit.mxm_hw_rdma_ep = mca_spml_ikrit.mxm_ep;
     }
 
     return OSHMEM_SUCCESS;
@@ -334,6 +371,9 @@ static int mca_spml_ikrit_component_fini(void)
     opal_progress_unregister(spml_ikrit_progress);
     if (NULL != mca_spml_ikrit.mxm_ep) {
         mxm_ep_destroy(mca_spml_ikrit.mxm_ep);
+    }
+    if (mca_spml_ikrit.hw_rdma_channel) {
+        mxm_ep_destroy(mca_spml_ikrit.mxm_hw_rdma_ep);
     }
 
     if(!mca_spml_ikrit.enabled)

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -74,7 +74,7 @@ static inline int check_mxm_tls(char *var)
                     "%s=%s",
                     var, getenv(var)
                     )) {
-            orte_show_help("help-oshmem-spml-ikrit.txt", "mxm tls", true,
+            orte_show_help("help-oshmem-spml-ikrit.txt", "mxm shm tls", true,
                     str);
             free(str);
         }
@@ -102,21 +102,40 @@ static inline int set_mxm_tls()
         setenv("MXM_OSHMEM_TLS", mca_spml_ikrit.mxm_tls, 1);
         return OSHMEM_SUCCESS;
     }
-    return check_mxm_tls("MXM_TLS");
-}
-
-static inline void set_mxm_rc_tls()
-{
-    char *tls;
-
-    tls = getenv("MXM_OSHMEM_HW_RDMA_TLS");
-    if (NULL != tls) {
-        return;
+    if (OSHMEM_SUCCESS == check_mxm_tls("MXM_TLS")) {
+        setenv("MXM_OSHMEM_TLS", tls, 1);
+        return OSHMEM_SUCCESS;
     }
-
-    setenv("MXM_OSHMEM_HW_RDMA_TLS", "rc", 1);
-    return;
+    return OSHMEM_ERROR;
 }
+
+static inline int check_mxm_hw_tls(char *v, char *tls)
+{
+    if ((0 == strcmp(tls, "rc") || 0 == strcmp(tls, "dc"))) 
+        return OSHMEM_SUCCESS;
+
+    if (strstr(tls, "ud") &&
+            (NULL == strstr(tls, "rc") && NULL == strstr(tls, "dc") &&
+             NULL == strstr(tls, "shm"))) 
+        return OSHMEM_SUCCESS;
+
+    orte_show_help("help-oshmem-spml-ikrit.txt", "mxm tls", true,
+                    v, tls);
+    return OSHMEM_ERROR;
+}
+
+static inline int set_mxm_hw_rdma_tls()
+{
+    if (!mca_spml_ikrit.hw_rdma_channel) {
+        return check_mxm_hw_tls("MXM_OSHMEM_TLS", getenv("MXM_OSHMEM_TLS"));
+    }
+    setenv("MXM_OSHMEM_HW_RDMA_RC_QP_LIMIT", "-1", 0);
+    setenv("MXM_OSHMEM_HW_RDMA_TLS", "rc", 0);
+
+    return check_mxm_hw_tls("MXM_OSHMEM_HW_RDMA_TLS", 
+            getenv("MXM_OSHMEM_HW_RDMA_TLS"));
+}
+
 #endif
 
 static inline void mca_spml_ikrit_param_register_int(const char* param_name,
@@ -151,6 +170,8 @@ static inline void  mca_spml_ikrit_param_register_string(const char* param_name,
 
 static int mca_spml_ikrit_component_register(void)
 {
+    char *v;
+
     mca_spml_ikrit_param_register_int("free_list_num", 1024,
                                       0,
                                       &mca_spml_ikrit.free_list_num);
@@ -172,8 +193,13 @@ static int mca_spml_ikrit_component_register(void)
     mca_spml_ikrit_param_register_int("hw_rdma_channel", 0,
                                        "create separate reliable connection channel",
                                        &mca_spml_ikrit.hw_rdma_channel);
+
+    if (!mca_spml_ikrit.hw_rdma_channel) 
+        v = "ud,self";
+    else
+        v = "rc,ud,self";
     mca_spml_ikrit_param_register_string("mxm_tls",
-                                         "rc,ud,self",
+                                         v,
                                          "[string] TL channels for MXM",
                                          &mca_spml_ikrit.mxm_tls);
 
@@ -230,15 +256,16 @@ static int mca_spml_ikrit_component_open(void)
 
     mca_spml_ikrit.ud_only = 0;
 #if MXM_API < MXM_VERSION(2,1)
-    mca_spml_ikrit.rc_channel = 0;
+    mca_spml_ikrit.hw_rdma_channel = 0;
     if ((MXM_OK != mxm_config_read_context_opts(&mca_spml_ikrit.mxm_ctx_opts)) ||
         (MXM_OK != mxm_config_read_ep_opts(&mca_spml_ikrit.mxm_ep_opts)))
 #else
     if (OSHMEM_SUCCESS != set_mxm_tls()) {
         return OSHMEM_ERROR;
     }
-    set_mxm_rc_tls();
-
+    if (OSHMEM_SUCCESS != set_mxm_hw_rdma_tls()) {
+        return OSHMEM_ERROR;
+    }
     if ((mca_spml_ikrit.hw_rdma_channel && MXM_OK != mxm_config_read_opts(&mca_spml_ikrit.mxm_ctx_opts,
                 &mca_spml_ikrit.mxm_ep_hw_rdma_opts,
                 "OSHMEM_HW_RDMA", NULL, 0)) ||

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -169,7 +169,7 @@ static int mca_spml_ikrit_component_register(void)
     mca_spml_ikrit_param_register_int("priority", 20,
                                       "[integer] ikrit priority",
                                       &mca_spml_ikrit.priority);
-    mca_spml_ikrit_param_register_int("hw_rdma_channel", 1,
+    mca_spml_ikrit_param_register_int("hw_rdma_channel", 0,
                                        "create separate reliable connection channel",
                                        &mca_spml_ikrit.hw_rdma_channel);
     mca_spml_ikrit_param_register_string("mxm_tls",

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -23,6 +23,7 @@
 #include "oshmem/mca/spml/ikrit/spml_ikrit.h"
 
 #include "orte/util/show_help.h"
+#include "opal/util/opal_environ.h"
 
 static int mca_spml_ikrit_component_register(void);
 static int mca_spml_ikrit_component_open(void);
@@ -99,11 +100,11 @@ static inline int set_mxm_tls()
 
     tls = getenv("MXM_TLS");
     if (NULL == tls) {
-        setenv("MXM_OSHMEM_TLS", mca_spml_ikrit.mxm_tls, 1);
+        opal_setenv("MXM_OSHMEM_TLS", mca_spml_ikrit.mxm_tls, 1, &environ);
         return OSHMEM_SUCCESS;
     }
     if (OSHMEM_SUCCESS == check_mxm_tls("MXM_TLS")) {
-        setenv("MXM_OSHMEM_TLS", tls, 1);
+        opal_setenv("MXM_OSHMEM_TLS", tls, 1, &environ);
         return OSHMEM_SUCCESS;
     }
     return OSHMEM_ERROR;
@@ -131,8 +132,8 @@ static inline int set_mxm_hw_rdma_tls()
     if (!mca_spml_ikrit.hw_rdma_channel) {
         return check_mxm_hw_tls("MXM_OSHMEM_TLS", getenv("MXM_OSHMEM_TLS"));
     }
-    setenv("MXM_OSHMEM_HW_RDMA_RC_QP_LIMIT", "-1", 0);
-    setenv("MXM_OSHMEM_HW_RDMA_TLS", "rc", 0);
+    opal_setenv("MXM_OSHMEM_HW_RDMA_RC_QP_LIMIT", "-1", 0, &environ);
+    opal_setenv("MXM_OSHMEM_HW_RDMA_TLS", "rc", 0, &environ);
 
     return check_mxm_hw_tls("MXM_OSHMEM_HW_RDMA_TLS", 
             getenv("MXM_OSHMEM_HW_RDMA_TLS"));


### PR DESCRIPTION
Commits add mxm endpoint that can be used for transports with hw rdma capabilites. Atomic operations are set to use this endpoint. 

It is now possible to run UD transport to get a good scalability and RC to benefit from IB hardware atomics.

Commits from: open-mpi/ompi@1bcc88cfb1a0868e733802d343ddf16ffd2b93a0 
to: open-mpi/ompi@643e64497d531830111ed7a1ddf5bebceea9d4a3

@miked-mellanox @jladd-mlnx
