### PR TITLE
OSHMEM: spml ikrit: complete puts b4 memheap destruction

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -629,6 +629,7 @@ int mca_spml_ikrit_deregister(sshmem_mkey_t *mkeys)
 {
     int i;
 
+    MCA_SPML_CALL(fence());
     if (!mkeys)
         return OSHMEM_SUCCESS;
 


### PR DESCRIPTION
Force completion of all puts before deregestering memheap/bss memory

Fixes a possible race condition where put request completion callback
is called when request context is already cleared.

cherry picked from commit open-mpi/ompi@5af4d02bd3b601a18f6fb03b1837fceb6534261e

@miked-mellanox @jladd-mlnx 
