### PR TITLE
MPI_Ibarrier.3in: add missing man page

### DIFF
--- a/ompi/mpi/man/man3/MPI_Barrier.3in
+++ b/ompi/mpi/man/man3/MPI_Barrier.3in
@@ -1,9 +1,9 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .TH MPI_Barrier 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
-\fBMPI_Barrier\fP \- Blocks until all processes have reached this routine.
+\fBMPI_Barrier, MPI_Ibcarrier\fP \- Synchronization between MPI processes in a group
 
 .SH SYNTAX
 .ft R
@@ -12,11 +12,16 @@
 #include <mpi.h>
 int MPI_Barrier(MPI_Comm \fIcomm\fP)
 
+int MPI_Ibarrier(MPI_Comm \fIcomm\fP)
+
 .fi
 .SH Fortran Syntax
 .nf
 INCLUDE 'mpif.h'
 MPI_BARRIER(\fICOMM\fP,\fI IERROR\fP)
+	INTEGER	\fICOMM\fP,\fI IERROR\fP
+
+MPI_IBARRIER(\fICOMM\fP,\fI IERROR\fP)
 	INTEGER	\fICOMM\fP,\fI IERROR\fP
 
 .fi
@@ -31,6 +36,8 @@ void MPI.COMM_WORLD.Barrier()
 #include <mpi.h>
 void MPI::Comm::Barrier() const = 0
 
+void MPI::Comm::Ibarrier() const = 0
+
 .fi
 .SH INPUT PARAMETER
 .ft R
@@ -41,12 +48,16 @@ Communicator (handle).
 .SH OUTPUT PARAMETER
 .ft R
 .TP 1i
+request
+Request (handle, non-blocking only).
+.TP 1i
 IERROR
 Fortran only: Error status (integer). 
 
 .SH DESCRIPTION
 .ft R
-Blocks the caller until all group members have called it; the call returns at any process only after all group members have entered the call.
+An MPI barrier completes after all group members have entered the
+barrier.
 
 .SH WHEN COMMUNICATOR IS AN INTER-COMMUNICATOR
 .sp

--- a/ompi/mpi/man/man3/MPI_Ibarrier.3in
+++ b/ompi/mpi/man/man3/MPI_Ibarrier.3in
@@ -1,0 +1,1 @@
+.so man3/MPI_Ibarrier.3

--- a/ompi/mpi/man/man3/Makefile.extra
+++ b/ompi/mpi/man/man3/Makefile.extra
@@ -36,6 +36,7 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Attr_get.3 \
         mpi/man/man3/MPI_Attr_put.3 \
         mpi/man/man3/MPI_Barrier.3 \
+        mpi/man/man3/MPI_Ibarrier.3 \
         mpi/man/man3/MPI_Bcast.3 \
         mpi/man/man3/MPI_Ibcast.3 \
         mpi/man/man3/MPI_Bsend.3 \


### PR DESCRIPTION
Add MPI_Ibarrier.3in to reference MPI_Barrier.3, and update MPI_Barrier.3in to include bindings for MPI_Ibarrier.  Slightly update the text to be inclusive of the non-blocking case.

Fixes open-mpi/ompi#242.

(cherry picked from commit 952be15d7f539ec1be3199eddee7baadb8c8cf91)
