### PR TITLE
pmi: correctly handle NULL OPAL_BYTE_OBJECT object

### DIFF
--- a/opal/mca/db/pmi/db_pmi.c
+++ b/opal/mca/db/pmi/db_pmi.c
@@ -2,6 +2,8 @@
 /*
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -361,6 +363,7 @@ static void cache_keys_locally(const opal_identifier_t *uid)
             if (size == 0xffff) {
                 bo.bytes = NULL;
                 bo.size = 0;
+                size = 0;
             } else {
                 bo.bytes = (uint8_t*)tmp3;
                 bo.size = size;


### PR DESCRIPTION
This is a backport of open-mpi/ompi@7508c6f3ad56a06f26d0d573c1b0860ad0170153

https://github.com/open-mpi/ompi/issues/235

@rhc54 could you please review this ?
