### PR TITLE
Fix the application abort routine so we actually abort

### DIFF
--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -97,6 +97,10 @@ fi
 AC_DEFINE_UNQUOTED(OSHMEM_PARAM_CHECK, $shmem_param_check,
     [Whether we want to check OSHMEM parameters always or never])
 
+#
+# check for on_exit
+#
+AC_CHECK_FUNCS([on_exit])
 
 #
 #  OSHMEM profiling support

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -196,11 +196,12 @@ static void* shmem_opal_thread(void* argc)
 }
 #endif
 
-int inGlobalExit;
+int oshmem_shmem_inglobalexit;
+int oshmem_shmem_globalexit_status;
 
 static void sighandler__SIGUSR1(int signum)
 {
-    if (0 != inGlobalExit)
+    if (0 != oshmem_shmem_inglobalexit)
     {
 	return;
     }

--- a/oshmem/shmem/c/globalexit.c
+++ b/oshmem/shmem/c/globalexit.c
@@ -14,11 +14,11 @@
 
 #include "orte/mca/errmgr/errmgr.h"
 
-extern int inGlobalExit;
+extern int oshmem_shmem_inglobalexit;
 
 void globalexit(int status)
 {
-    inGlobalExit++;
+    oshmem_shmem_inglobalexit++;
 
     orte_errmgr.abort(status, NULL);
     

--- a/oshmem/shmem/c/shmem_finalize.c
+++ b/oshmem/shmem/c/shmem_finalize.c
@@ -22,10 +22,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+extern int oshmem_shmem_globalexit_status;
+
 void shmem_finalize(void)
 {
     OPAL_CR_FINALIZE_LIBRARY();
-
+    if (oshmem_shmem_globalexit_status != 0)
+    {
+        return;
+    }
     oshmem_shmem_finalize();
 }
 

--- a/oshmem/shmem/c/shmem_init.c
+++ b/oshmem/shmem/c/shmem_init.c
@@ -29,10 +29,17 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+extern int oshmem_shmem_globalexit_status;
+
 void start_pes(int npes)
 {
     /* spec says that npes are ignored for now */
     shmem_init();
+}
+
+static void shmem_onexit(int exitcode, void *arg)
+{
+    oshmem_shmem_globalexit_status = exitcode;
 }
 
 void shmem_init(void)
@@ -56,5 +63,8 @@ void shmem_init(void)
     }
 
     OPAL_CR_INIT_LIBRARY();
+#if HAVE_ON_EXIT
+    on_exit(shmem_onexit, NULL);
+#endif
 }
 


### PR DESCRIPTION
AKA the trunk from Devedar. This contains commits:

open-mpi/ompi@cbb3e95
open-mpi/ompi@8dfed1c

from the trunk. This fixes the OSHMEM global exit when launched under srun.
