### PR TITLE
Minor usnic fixes

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_component.c
+++ b/ompi/mca/btl/usnic/btl_usnic_component.c
@@ -240,32 +240,33 @@ static int usnic_modex_send(void)
     size_t size;
     ompi_btl_usnic_addr_t* addrs = NULL;
 
+    if (0 == mca_btl_usnic_component.num_modules) {
+        return OMPI_SUCCESS;
+    }
+
     size = mca_btl_usnic_component.num_modules * 
         sizeof(ompi_btl_usnic_addr_t);
-    if (size != 0) {
-        addrs = (ompi_btl_usnic_addr_t*) malloc(size);
-        if (NULL == addrs) {
-            return OMPI_ERR_OUT_OF_RESOURCE;
-        }
-
-        for (i = 0; i < mca_btl_usnic_component.num_modules; i++) {
-            ompi_btl_usnic_module_t* module = 
-                mca_btl_usnic_component.usnic_active_modules[i];
-            addrs[i] = module->local_addr;
-            opal_output_verbose(5, USNIC_OUT,
-                                "btl:usnic: modex_send DQP:%d, CQP:%d, subnet = 0x%016" PRIx64 " interface =0x%016" PRIx64,
-                                addrs[i].qp_num[USNIC_DATA_CHANNEL], 
-                                addrs[i].qp_num[USNIC_PRIORITY_CHANNEL], 
-                                ntoh64(addrs[i].gid.global.subnet_prefix),
-                                ntoh64(addrs[i].gid.global.interface_id));
-        }
+    addrs = (ompi_btl_usnic_addr_t*) malloc(size);
+    if (NULL == addrs) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    rc = ompi_modex_send(&mca_btl_usnic_component.super.btl_version, 
+    for (i = 0; i < mca_btl_usnic_component.num_modules; i++) {
+        ompi_btl_usnic_module_t* module =
+            mca_btl_usnic_component.usnic_active_modules[i];
+        addrs[i] = module->local_addr;
+        opal_output_verbose(5, USNIC_OUT,
+                            "btl:usnic: modex_send DQP:%d, CQP:%d, subnet = 0x%016" PRIx64 " interface =0x%016" PRIx64,
+                            addrs[i].qp_num[USNIC_DATA_CHANNEL],
+                            addrs[i].qp_num[USNIC_PRIORITY_CHANNEL],
+                            ntoh64(addrs[i].gid.global.subnet_prefix),
+                            ntoh64(addrs[i].gid.global.interface_id));
+    }
+
+    rc = ompi_modex_send(&mca_btl_usnic_component.super.btl_version,
                          addrs, size);
-    if (NULL != addrs) {
-        free(addrs);
-    }
+    free(addrs);
+
     return rc;
 }
 

--- a/ompi/mca/btl/usnic/btl_usnic_proc.c
+++ b/ompi/mca/btl/usnic/btl_usnic_proc.c
@@ -187,7 +187,14 @@ static ompi_btl_usnic_proc_t *create_proc(ompi_proc_t *ompi_proc)
                          ompi_proc, (void*)&proc->proc_modex,
                          &size);
 
-    if (OMPI_SUCCESS != rc) {
+    /* If this proc simply doesn't have this key, then they're not
+       running the usnic BTL -- just ignore them.  Otherwise, show an
+       error message. */
+    if (OPAL_ERR_DATA_VALUE_NOT_FOUND == rc ||
+        OPAL_ERR_NOT_FOUND == rc) {
+        OBJ_RELEASE(proc);
+        return NULL;
+    } else if (OPAL_SUCCESS != rc) {
         opal_show_help("help-mpi-btl-usnic.txt", "internal error during init",
                        true,
                        ompi_process_info.nodename,


### PR DESCRIPTION
Two commits:
1. Do not send zero-length modex messages if there are no usnic devices.  On master, open-mpi/ompi@ec4268b59cf42749b3975acc75be013e31925cf8
2. Do not error if a peer did not supply a usnic modex message -- it just means that there are no usNIC BTL modules in that peer.  This has actually be on master/trunk for forever; I just noticed today that it was not on the v1.8 branch.

Reviewed by @goodell 
