### PR TITLE
btl/sm: re-enable the use of CMA and knem

### DIFF
--- a/ompi/mca/btl/sm/btl_sm_component.c
+++ b/ompi/mca/btl/sm/btl_sm_component.c
@@ -142,13 +142,23 @@ static inline unsigned int mca_btl_sm_param_register_uint(
     return *storage;
 }
 
+#if OPAL_BTL_SM_HAVE_KNEM || OPAL_BTL_SM_HAVE_CMA
+static void mca_btl_sm_dummy_get (void)
+{
+    /* If a backtrace ends at this function something has gone wrong with
+     * the btl bootstrapping. Check that the btl_get function was set to
+     * something reasonable. */
+    abort ();
+}
+#endif
+
 static int mca_btl_sm_component_verify(void) {
 #if OMPI_BTL_SM_HAVE_KNEM || OMPI_BTL_SM_HAVE_CMA
     if (mca_btl_sm_component.use_knem || mca_btl_sm_component.use_cma) {
         mca_btl_sm.super.btl_flags |= MCA_BTL_FLAGS_GET;
         /* set a dummy value for btl_get to prevent mca_btl_base_param_verify from
          * unsetting the MCA_BTL_FLAGS_GET flags. */
-        mca_btl_sm.super.btl_get = (mca_btl_base_module_get_fn_t) 1;
+        mca_btl_sm.super.btl_get = (mca_btl_base_module_get_fn_t) mca_btl_sm_dummy_get;
     }
 
     if (mca_btl_sm_component.use_knem && mca_btl_sm_component.use_cma) {
@@ -895,6 +905,16 @@ mca_btl_sm_component_init(int *num_btls,
            so no problems with accidentally overwriting this set earlier */
         mca_btl_sm.super.btl_get = mca_btl_sm_get_sync;
     }
+#else
+    /* If the user explicitly asked for CMA and we can't provide it
+     *   error */
+    if (mca_btl_sm_component.use_cma > 0) {
+        mca_btl_sm.super.btl_flags &= ~MCA_BTL_FLAGS_GET;
+        opal_show_help("help-mpi-btl-sm.txt",
+                       "CMA requested but not available",
+                       true, opal_process_info.nodename);
+        return NULL;
+    }
 #endif /* OMPI_BTL_SM_HAVE_CMA */
 
 #if OPAL_CUDA_SUPPORT
@@ -924,6 +944,9 @@ mca_btl_sm_component_init(int *num_btls,
     /* If "use_knem" is positive, then it's an error if knem support
        is not available -- deactivate the sm btl. */
     if (mca_btl_sm_component.use_knem > 0) {
+        opal_show_help("help-mpi-btl-sm.txt",
+                       "knem requested but not available",
+                       true, opal_process_info.nodename);
         return NULL;
     } else if (0 == mca_btl_sm_component.use_cma) {
         /* disable get when not using knem or cma */

--- a/ompi/mca/btl/sm/btl_sm_component.c
+++ b/ompi/mca/btl/sm/btl_sm_component.c
@@ -146,6 +146,9 @@ static int mca_btl_sm_component_verify(void) {
 #if OMPI_BTL_SM_HAVE_KNEM || OMPI_BTL_SM_HAVE_CMA
     if (mca_btl_sm_component.use_knem || mca_btl_sm_component.use_cma) {
         mca_btl_sm.super.btl_flags |= MCA_BTL_FLAGS_GET;
+        /* set a dummy value for btl_get to prevent mca_btl_base_param_verify from
+         * unsetting the MCA_BTL_FLAGS_GET flags. */
+        mca_btl_sm.super.btl_get = (mca_btl_base_module_get_fn_t) 1;
     }
 
     if (mca_btl_sm_component.use_knem && mca_btl_sm_component.use_cma) {
@@ -922,6 +925,10 @@ mca_btl_sm_component_init(int *num_btls,
        is not available -- deactivate the sm btl. */
     if (mca_btl_sm_component.use_knem > 0) {
         return NULL;
+    } else if (0 == mca_btl_sm_component.use_cma) {
+        /* disable get when not using knem or cma */
+        mca_btl_sm.super.btl_get = NULL;
+        mca_btl_sm.super.btl_flags &= ~MCA_BTL_FLAGS_GET;
     }
 
     /* Otherwise, use_knem was 0 (and we didn't get here) or use_knem

--- a/ompi/mca/btl/sm/help-mpi-btl-sm.txt
+++ b/ompi/mca/btl/sm/help-mpi-btl-sm.txt
@@ -90,3 +90,25 @@ parameter to 0 to run without /dev/knem support.
   Local host:  %s
   System call: %s
   Errno:       %d (%s)
+#
+[knem requested but not available]
+WARNING: Linux kernel Knem support was requested via the
+mca_btl_sm_use_knem MCA parameter, but Knem support was either not
+compiled into this Open MPI installation, or Knem support was unable
+to be activated in this process.
+
+The shared memory BTL will now deactivate itself, likely resulting in
+lower performance for on-node communication.
+
+  Local host: %s
+#
+[CMA requested but not available]
+WARNING: Linux kernel CMA support was requested via the
+mca_btl_sm_use_cma MCA parameter, but CMA support was either not
+compiled into this Open MPI installation, or CMA support was unable
+to be activated in this process.
+
+The shared memory BTL will now deactivate itself, likely resulting in
+lower performance for on-node communication.
+
+  Local host: %s


### PR DESCRIPTION
At some point we added a sanity check to the btl base to ensure that
the btl flags match the available functions (this prevents user's from
specifying get or put when no function exists). This check was
disabling get for the sm btl since at the time of the check there is
no btl_get function. The simplest fix is to set a dummy value to btl_get
that will be overwritten with the proper value on btl initialization.

Includes master references:
open-mpi/ompi@d7c7bb399388e7f85aa856c38865c8062bf7c0e6
open-mpi/ompi@998e69a6facdecdaa95996ac996b5a249c42f8e0
