### PR TITLE
btl/vader: bring up to date with fixes/updates from trunk

### DIFF
--- a/config/ompi_check_cma.m4
+++ b/config/ompi_check_cma.m4
@@ -5,7 +5,7 @@
 #                         reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
-# Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+# Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -34,6 +34,7 @@ AC_DEFUN([OMPI_CHECK_CMA],[
             AC_DEFINE_UNQUOTED([OMPI_CMA_NEED_SYSCALL_DEFS],
                 [$ompi_check_cma_need_defs],
                 [Need CMA syscalls defined])
+            AC_CHECK_HEADERS([sys/prctl.h])
     else
         AC_MSG_RESULT([no])
     fi

--- a/config/ompi_check_knem.m4
+++ b/config/ompi_check_knem.m4
@@ -1,0 +1,67 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
+# Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_CHECK_KNEM(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if knem support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([OMPI_CHECK_KNEM],[
+    OPAL_VAR_SCOPE_PUSH([ompi_check_knem_happy ompi_check_knem_$1_save_CPPFLAGS ompi_check_knem_dir])
+    AC_ARG_WITH([knem],
+        [AC_HELP_STRING([--with-knem(=DIR)],
+             [Build knem Linux kernel module support, searching for headers in DIR])])
+
+    OMPI_CHECK_WITHDIR([knem], [$with_knem], [include/knem_io.h])
+    ompi_check_knem_$1_save_CPPFLAGS="$CPPFLAGS"
+
+    AS_IF([test "$with_knem" != "no"],
+          [AS_IF([test ! -z "$with_knem" -a "$with_knem" != "yes"],
+                 [ompi_check_knem_dir="$with_knem"])
+
+           _OMPI_CHECK_PACKAGE_HEADER([$1],
+                              [knem_io.h],
+                              [$ompi_check_knem_dir],
+                              [ompi_check_knem_happy="yes"],
+                              [ompi_check_knem_happy="no"])],
+          [ompi_check_knem_happy="no"])
+
+    CPPFLAGS="$CPPFLAGS $$1_CPPFLAGS"
+
+    # need at least version 0x0000000b
+    AS_IF([test "$ompi_check_knem_happy" = "yes"],
+          [AC_CACHE_CHECK([for knem ABI version 0xb or later],
+                          [ompi_cv_knem_version_ok],
+                          [AC_PREPROC_IFELSE(
+                            [AC_LANG_PROGRAM([
+#include <knem_io.h>
+                             ],[
+#if KNEM_ABI_VERSION < 0xc
+#error "Version less than 0xc"
+#endif
+                             ])],
+                            [ompi_cv_knem_version_ok=yes],
+                            [ompi_cv_knem_version_ok=no])])])
+
+    CPPFLAGS="$ompi_check_knem_$1_save_CPPFLAGS"
+
+    AS_IF([test "$ompi_check_knem_happy" = "yes" -a "$ompi_cv_knem_version_ok" = "yes"],
+          [$2],
+          [AS_IF([test ! -z "$with_knem" -a "$with_knem" != "no"],
+                 [AC_MSG_ERROR([KNEM support requested but not found.  Aborting])])
+           $3])
+    OPAL_VAR_SCOPE_POP
+])dnl

--- a/ompi/mca/btl/sm/configure.m4
+++ b/ompi/mca/btl/sm/configure.m4
@@ -5,64 +5,14 @@
 #                         reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
+# Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
-
-# OMPI_CHECK_KNEM(prefix, [action-if-found], [action-if-not-found])
-# --------------------------------------------------------
-# check if knem support can be found.  sets prefix_{CPPFLAGS,
-# LDFLAGS, LIBS} as needed and runs action-if-found if there is
-# support, otherwise executes action-if-not-found
-AC_DEFUN([OMPI_CHECK_KNEM],[
-    OPAL_VAR_SCOPE_PUSH([ompi_check_knem_happy ompi_check_knem_$1_save_CPPFLAGS ompi_check_knem_dir])
-    AC_ARG_WITH([knem],
-        [AC_HELP_STRING([--with-knem(=DIR)],
-             [Build knem Linux kernel module support, searching for headers in DIR])])
-
-    OMPI_CHECK_WITHDIR([knem], [$with_knem], [include/knem_io.h])
-    ompi_check_knem_$1_save_CPPFLAGS="$CPPFLAGS"
-
-    AS_IF([test "$with_knem" != "no"],
-          [AS_IF([test ! -z "$with_knem" -a "$with_knem" != "yes"],
-                 [ompi_check_knem_dir="$with_knem"])
-
-           _OMPI_CHECK_PACKAGE_HEADER([$1],
-                              [knem_io.h],
-                              [$ompi_check_knem_dir],
-                              [ompi_check_knem_happy="yes"],
-                              [ompi_check_knem_happy="no"])],
-          [ompi_check_knem_happy="no"])
-
-    CPPFLAGS="$CPPFLAGS $$1_CPPFLAGS"
-
-    # need at least version 0x0000000b
-    AS_IF([test "$ompi_check_knem_happy" = "yes"],
-          [AC_CACHE_CHECK([for knem ABI version 0xb or later],
-                          [ompi_cv_knem_version_ok],
-                          [AC_PREPROC_IFELSE(
-                            [AC_LANG_PROGRAM([
-#include <knem_io.h>
-                             ],[
-#if KNEM_ABI_VERSION < 0xc
-#error "Version less than 0xc"
-#endif
-                             ])],
-                            [ompi_cv_knem_version_ok=yes],
-                            [ompi_cv_knem_version_ok=no])])])
-
-    CPPFLAGS="$ompi_check_knem_$1_save_CPPFLAGS"
-
-    AS_IF([test "$ompi_check_knem_happy" = "yes" -a "$ompi_cv_knem_version_ok" = "yes"],
-          [$2],
-          [AS_IF([test ! -z "$with_knem" -a "$with_knem" != "no"],
-                 [AC_MSG_ERROR([KNEM support requested but not found.  Aborting])])
-           $3])
-    OPAL_VAR_SCOPE_POP
-])dnl
 
 # MCA_btl_sm_CONFIG([action-if-can-compile],
 #                   [action-if-cant-compile])

--- a/ompi/mca/btl/vader/Makefile.am
+++ b/ompi/mca/btl/vader/Makefile.am
@@ -9,8 +9,8 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011      Los Alamos National Security, LLC. All rights
+# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 # 
@@ -21,7 +21,7 @@
 
 AM_CPPFLAGS = $(btl_vader_CPPFLAGS)
 
-dist_ompidata_DATA = help-mpi-btl-vader.txt
+dist_ompidata_DATA = help-btl-vader.txt
 
 libmca_btl_vader_la_sources = \
     btl_vader_module.c \
@@ -37,7 +37,9 @@ libmca_btl_vader_la_sources = \
     btl_vader_get.c \
     btl_vader_put.c \
     btl_vader_xpmem.c \
-    btl_vader_xpmem.h
+    btl_vader_xpmem.h \
+    btl_vader_knem.c \
+    btl_vader_knem.h
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/ompi/mca/btl/vader/btl_vader_component.c
+++ b/ompi/mca/btl/vader/btl_vader_component.c
@@ -100,6 +100,14 @@ mca_btl_vader_component_t mca_btl_vader_component = {
     }  /* end super */
 };
 
+static void mca_btl_vader_dummy_rdma (void)
+{
+    /* If a backtrace ends at this function something has gone wrong with
+     * the btl bootstrapping. Check that the btl_get function was set to
+     * something reasonable. */
+    abort ();
+}
+
 static int mca_btl_vader_component_register (void)
 {
     mca_base_var_enum_t *new_enum;
@@ -241,8 +249,8 @@ static int mca_btl_vader_component_register (void)
         mca_btl_vader.super.btl_bandwidth = 40000; /* Mbs */
 
         /* Set dummy values so the RDMA flag doesn't get unset by mca_btl_base_param_verify() */
-        mca_btl_vader.super.btl_get = (mca_btl_base_module_get_fn_t) 1;
-        mca_btl_vader.super.btl_put = (mca_btl_base_module_get_fn_t) 1;
+        mca_btl_vader.super.btl_get = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
+        mca_btl_vader.super.btl_put = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
     } else {
         mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_SEND_INPLACE;
         mca_btl_vader.super.btl_bandwidth = 10000; /* Mbs */

--- a/ompi/mca/btl/vader/btl_vader_component.c
+++ b/ompi/mca/btl/vader/btl_vader_component.c
@@ -15,6 +15,9 @@
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,18 +26,28 @@
  */
 #include "ompi_config.h"
 
-#include "ompi/constants.h"
 #include "opal/util/output.h"
-
-#include "opal/mca/base/mca_base_param.h"
+#include "opal/util/show_help.h"
+#include "opal/threads/mutex.h"
 #include "ompi/mca/btl/base/btl_base_error.h"
 
 #include "btl_vader.h"
 #include "btl_vader_frag.h"
 #include "btl_vader_fifo.h"
 #include "btl_vader_fbox.h"
+#include "btl_vader_xpmem.h"
 
 #include <sys/mman.h>
+#include <fcntl.h>
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
+/* NTH: OS X does not define MAP_ANONYMOUS */
+#if !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
 
 static int mca_btl_vader_component_progress (void);
 static int mca_btl_vader_component_open(void);
@@ -43,6 +56,21 @@ static int mca_btl_vader_component_register(void);
 static mca_btl_base_module_t** mca_btl_vader_component_init(int *num_btls,
                                                             bool enable_progress_threads,
                                                             bool enable_mpi_threads);
+
+/* This enumeration is in order of preference */
+static mca_base_var_enum_value_t single_copy_mechanisms[] = {
+#if OMPI_BTL_VADER_HAVE_XPMEM
+    {.value = MCA_BTL_VADER_XPMEM, .string = "xpmem"},
+#endif
+#if OMPI_BTL_VADER_HAVE_CMA
+    {.value = MCA_BTL_VADER_CMA, .string = "cma"},
+#endif
+#if OMPI_BTL_VADER_HAVE_KNEM
+    {.value = MCA_BTL_VADER_KNEM, .string = "knem"},
+#endif
+    {.value = MCA_BTL_VADER_NONE, .string = "none"},
+    {.value = 0, .string = NULL}
+};
 
 /*
  * Shared Memory (VADER) component instance.
@@ -74,8 +102,10 @@ mca_btl_vader_component_t mca_btl_vader_component = {
 
 static int mca_btl_vader_component_register (void)
 {
+    mca_base_var_enum_t *new_enum;
+
     (void) mca_base_var_group_component_register(&mca_btl_vader_component.super.btl_version,
-                                                 "XPMEM shared memory byte transport later");
+                                                 "Enhanced shared memory byte transport later");
 
     /* register VADER component variables */
     mca_btl_vader_component.vader_free_list_num = 8;
@@ -86,7 +116,7 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_btl_vader_component.vader_free_list_num);
-    mca_btl_vader_component.vader_free_list_max = 16384;
+    mca_btl_vader_component.vader_free_list_max = 4096;
     (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
                                            "free_list_max", "Maximum number of fragments "
                                            "to allocate for shared memory communication.",
@@ -110,6 +140,7 @@ static int mca_btl_vader_component_register (void)
                                            NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_btl_vader_component.memcpy_limit);
+#if OMPI_BTL_VADER_HAVE_XPMEM
     mca_btl_vader_component.log_attach_align = 21;
     (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
                                            "log_align", "Log base 2 of the alignment to use for xpmem "
@@ -118,6 +149,7 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_btl_vader_component.log_attach_align);
+#endif
 
 #if OMPI_BTL_VADER_HAVE_XPMEM && 64 == MCA_BTL_VADER_BITNESS
     mca_btl_vader_component.segment_size = 1 << 24;
@@ -145,34 +177,78 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_btl_vader_component.max_inline_send);
 
-    mca_btl_vader.super.btl_exclusivity               = MCA_BTL_EXCLUSIVITY_HIGH;
-#if OMPI_BTL_VADER_HAVE_XPMEM
-    mca_btl_vader.super.btl_eager_limit               = 32 * 1024;
-    mca_btl_vader.super.btl_rndv_eager_limit          = mca_btl_vader.super.btl_eager_limit;
-    mca_btl_vader.super.btl_max_send_size             = mca_btl_vader.super.btl_eager_limit;
-    mca_btl_vader.super.btl_min_rdma_pipeline_size    = mca_btl_vader.super.btl_eager_limit;
-#else
-    mca_btl_vader.super.btl_eager_limit               = 4 * 1024;
-    mca_btl_vader.super.btl_rndv_eager_limit          = 32 * 1024;
-    mca_btl_vader.super.btl_max_send_size             = 32 * 1024;
-    mca_btl_vader.super.btl_min_rdma_pipeline_size    = 32 * 1024;
+    mca_btl_vader_component.fbox_threshold = 16;
+    (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
+                                           "fbox_threshold", "Number of sends required "
+                                           "before an eager send buffer is setup for a peer "
+                                           "(default: 16)", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
+                                           0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_vader_component.fbox_threshold);
+
+    mca_btl_vader_component.fbox_max = 32;
+    (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
+                                           "fbox_max", "Maximum number of eager send buffers "
+                                           "to allocate (default: 32)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_vader_component.fbox_max);
+
+    mca_btl_vader_component.fbox_size = 4096;
+    (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
+                                           "fbox_size", "Size of per-peer fast transfer buffers (default: 4k)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_5, MCA_BASE_VAR_SCOPE_LOCAL, &mca_btl_vader_component.fbox_size);
+
+    (void) mca_base_var_enum_create ("btl_vader_single_copy_mechanisms", single_copy_mechanisms, &new_enum);
+
+    /* Default to the best available mechanism (see the enumerator for ordering) */
+    mca_btl_vader_component.single_copy_mechanism = single_copy_mechanisms[0].value;
+    (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
+                                           "single_copy_mechanism", "Single copy mechanism to use (defaults to best available)",
+                                           MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                           OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_GROUP, &mca_btl_vader_component.single_copy_mechanism);
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+    /* Currently disabling DMA mode by default; it's not clear that this is useful in all applications and architectures. */
+    mca_btl_vader_component.knem_dma_min = 0;
+    (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version, "knem_dma_min",
+                                           "Minimum message size (in bytes) to use the knem DMA mode; "
+                                           "ignored if knem does not support DMA mode (0 = do not use the "
+                                           "knem DMA mode, default: 0)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_btl_vader_component.knem_dma_min);
 #endif
+
+    mca_btl_vader.super.btl_exclusivity               = MCA_BTL_EXCLUSIVITY_HIGH;
+
+    if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+        mca_btl_vader.super.btl_eager_limit               = 32 * 1024;
+        mca_btl_vader.super.btl_rndv_eager_limit          = mca_btl_vader.super.btl_eager_limit;
+        mca_btl_vader.super.btl_max_send_size             = mca_btl_vader.super.btl_eager_limit;
+        mca_btl_vader.super.btl_min_rdma_pipeline_size    = mca_btl_vader.super.btl_eager_limit;
+    } else {
+        mca_btl_vader.super.btl_eager_limit               = 4 * 1024;
+        mca_btl_vader.super.btl_rndv_eager_limit          = 32 * 1024;
+        mca_btl_vader.super.btl_max_send_size             = 32 * 1024;
+        mca_btl_vader.super.btl_min_rdma_pipeline_size    = 32 * 1024;
+    }
 
     mca_btl_vader.super.btl_rdma_pipeline_send_length = mca_btl_vader.super.btl_eager_limit;
     mca_btl_vader.super.btl_rdma_pipeline_frag_size   = mca_btl_vader.super.btl_eager_limit;
 
-#if OMPI_BTL_VADER_HAVE_XPMEM || OMPI_BTL_VADER_HAVE_CMA
-    mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_SEND_INPLACE;
-#else
-    mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_SEND_INPLACE;
-#endif
+    if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
+        mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_SEND_INPLACE;
+        /* Single copy mechanisms should provide better bandwidth */
+        mca_btl_vader.super.btl_bandwidth = 40000; /* Mbs */
 
-    mca_btl_vader.super.btl_seg_size  = sizeof (mca_btl_base_segment_t);
-#if OMPI_BTL_VADER_HAVE_XPMEM || OMPI_BTL_VADER_HAVE_CMA
-    mca_btl_vader.super.btl_bandwidth = 40000; /* Mbs */
-#else
-    mca_btl_vader.super.btl_bandwidth = 10000; /* Mbs */
-#endif
+        /* Set dummy values so the RDMA flag doesn't get unset by mca_btl_base_param_verify() */
+        mca_btl_vader.super.btl_get = (mca_btl_base_module_get_fn_t) 1;
+        mca_btl_vader.super.btl_put = (mca_btl_base_module_get_fn_t) 1;
+    } else {
+        mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_SEND_INPLACE;
+        mca_btl_vader.super.btl_bandwidth = 10000; /* Mbs */
+    }
+
+    mca_btl_vader.super.btl_seg_size  = sizeof (mca_btl_vader_segment_t);
     mca_btl_vader.super.btl_latency   = 1;     /* Microsecs */
 
     /* Call the BTL based to register its MCA params */
@@ -192,8 +268,13 @@ static int mca_btl_vader_component_open(void)
     /* initialize objects */
     OBJ_CONSTRUCT(&mca_btl_vader_component.vader_frags_eager, ompi_free_list_t);
     OBJ_CONSTRUCT(&mca_btl_vader_component.vader_frags_user, ompi_free_list_t);
-#if !OMPI_BTL_VADER_HAVE_XPMEM
     OBJ_CONSTRUCT(&mca_btl_vader_component.vader_frags_max_send, ompi_free_list_t);
+    OBJ_CONSTRUCT(&mca_btl_vader_component.vader_frags_rdma, ompi_free_list_t);
+    OBJ_CONSTRUCT(&mca_btl_vader_component.lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&mca_btl_vader_component.pending_endpoints, opal_list_t);
+    OBJ_CONSTRUCT(&mca_btl_vader_component.pending_fragments, opal_list_t);
+#if OMPI_BTL_VADER_HAVE_KNEM
+    mca_btl_vader.knem_fd = -1;
 #endif
 
     return OMPI_SUCCESS;
@@ -208,41 +289,155 @@ static int mca_btl_vader_component_close(void)
 {
     OBJ_DESTRUCT(&mca_btl_vader_component.vader_frags_eager);
     OBJ_DESTRUCT(&mca_btl_vader_component.vader_frags_user);
-#if !OMPI_BTL_VADER_HAVE_XPMEM
     OBJ_DESTRUCT(&mca_btl_vader_component.vader_frags_max_send);
-#endif
+    OBJ_DESTRUCT(&mca_btl_vader_component.vader_frags_rdma);
+    OBJ_DESTRUCT(&mca_btl_vader_component.lock);
+    OBJ_DESTRUCT(&mca_btl_vader_component.pending_endpoints);
+    OBJ_DESTRUCT(&mca_btl_vader_component.pending_fragments);
 
     if (NULL != mca_btl_vader_component.my_segment) {
         munmap (mca_btl_vader_component.my_segment, mca_btl_vader_component.segment_size);
     }
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+    mca_btl_vader_knem_fini ();
+#endif
 
     return OMPI_SUCCESS;
 }
 
 static int mca_btl_base_vader_modex_send (void)
 {
-    struct vader_modex_t modex;
+    union vader_modex_t modex;
     int modex_size;
 
 #if OMPI_BTL_VADER_HAVE_XPMEM
-    modex.seg_id = mca_btl_vader_component.my_seg_id;
-    modex.segment_base = mca_btl_vader_component.my_segment;
+    if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+        modex.xpmem.seg_id = mca_btl_vader_component.my_seg_id;
+        modex.xpmem.segment_base = mca_btl_vader_component.my_segment;
 
-    modex_size = sizeof (modex);
-#else
-    /* need to pack the modex data in 1.7 since seg_name is not at the end of the struct */
-    int offset = offsetof (opal_shmem_ds_t, seg_name);
+        modex_size = sizeof (modex);
+    } else {
+#endif
+        /* need to pack the modex data in 1.8 since seg_name is not at the end of the stuct */
+        int offset = offsetof (opal_shmem_ds_t, seg_name) + strlen (mca_btl_vader_component.seg_ds.seg_name) + 1;
 
-    modex_size = sizeof (opal_shmem_ds_t) - OPAL_PATH_MAX + strlen (mca_btl_vader_component.seg_ds.seg_name) + 1;
-    memmove (modex.buffer, &mca_btl_vader_component.seg_ds, offset);
-    memmove (modex.buffer + offset, &mca_btl_vader_component.seg_ds.seg_base_addr, sizeof (mca_btl_vader_component.seg_ds.seg_base_addr));
+        modex_size = sizeof (modex.shmem.segment_base) + offset;
 
-    offset += sizeof (mca_btl_vader_component.seg_ds.seg_base_addr);
-    strncpy (modex.buffer + offset, mca_btl_vader_component.seg_ds.seg_name, sizeof (modex.buffer) - offset);
+        /* pack segment data */
+        modex.shmem.segment_base = mca_btl_vader_component.seg_ds.seg_base_addr;
+        memmove (modex.shmem.buffer, &mca_btl_vader_component.seg_ds, offset);
+#if OMPI_BTL_VADER_HAVE_XPMEM
+    }
 #endif
 
-    return ompi_modex_send(&mca_btl_vader_component.super.btl_version, &modex, modex_size);
+    return ompi_modex_send (&mca_btl_vader_component.super.btl_version, &modex, modex_size);
 }
+
+#if OMPI_BTL_VADER_HAVE_XPMEM || OMPI_BTL_VADER_HAVE_CMA || OMPI_BTL_VADER_HAVE_KNEM
+static void mca_btl_vader_select_next_single_copy_mechanism (void)
+{
+    for (int i = 0 ; single_copy_mechanisms[i].value != MCA_BTL_VADER_NONE ; ++i) {
+        if (single_copy_mechanisms[i].value == mca_btl_vader_component.single_copy_mechanism) {
+            mca_btl_vader_component.single_copy_mechanism = single_copy_mechanisms[i+1].value;
+            return;
+        }
+    }
+}
+
+static void mca_btl_vader_check_single_copy (void)
+{
+    int initial_mechanism = mca_btl_vader_component.single_copy_mechanism;
+    int rc;
+
+#if OMPI_BTL_VADER_HAVE_XPMEM
+    if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+        /* try to create an xpmem segment for the entire address space */
+        mca_btl_vader_component.my_seg_id = xpmem_make (0, VADER_MAX_ADDRESS, XPMEM_PERMIT_MODE, (void *)0666);
+
+        if (-1 == mca_btl_vader_component.my_seg_id) {
+            if (MCA_BTL_VADER_XPMEM == initial_mechanism) {
+                opal_show_help("help-btl-vader.txt", "xpmem-make-failed",
+                               true, ompi_process_info.nodename, errno,
+                               strerror(errno));
+            }
+
+            mca_btl_vader_select_next_single_copy_mechanism ();
+        } else {
+            mca_btl_vader.super.btl_get = mca_btl_vader_get_xpmem;
+            mca_btl_vader.super.btl_put = mca_btl_vader_get_xpmem;
+        }
+
+    }
+#endif
+
+#if OMPI_BTL_VADER_HAVE_CMA
+    if (MCA_BTL_VADER_CMA == mca_btl_vader_component.single_copy_mechanism) {
+        /* Check if we have the proper permissions for CMA */
+        char buffer = {0};
+        bool cma_happy = false;
+        int fd;
+
+        /* check system setting for current ptrace scope */
+        fd = open ("/proc/sys/kernel/yama/ptrace_scope", O_RDONLY);
+        if (0 > fd) {
+            read (fd, &buffer, 1);
+            close (fd);
+        }
+
+        /* ptrace scope 0 will allow an attach from any of the process owner's
+         * processes. ptrace scope 1 limits attachers to the process tree
+         * starting at the parent of this process. */
+        if ('0' != buffer) {
+#if defined PR_SET_PTRACER
+            /* try setting the ptrace scope to allow attach */
+            int ret = prctl (PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);
+            if (0 == ret) {
+                cma_happy = true;
+            }
+#endif
+        } else {
+            cma_happy = true;
+        }
+
+        if (!cma_happy) {
+            mca_btl_vader_select_next_single_copy_mechanism ();
+
+            if (MCA_BTL_VADER_CMA == initial_mechanism) {
+	        opal_show_help("help-btl-vader.txt", "cma-permission-denied",
+			       true, ompi_process_info.nodename);
+            }
+        } else {
+            /* ptrace_scope will allow CMA */
+            mca_btl_vader.super.btl_get = mca_btl_vader_get_cma;
+            mca_btl_vader.super.btl_put = mca_btl_vader_put_cma;
+        }
+    }
+#endif
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+    if (MCA_BTL_VADER_KNEM == mca_btl_vader_component.single_copy_mechanism) {
+        /* mca_btl_vader_knem_init will set the appropriate get/put functions */
+        rc = mca_btl_vader_knem_init ();
+        if (OMPI_SUCCESS != rc) {
+            if (MCA_BTL_VADER_KNEM == initial_mechanism) {
+                opal_show_help("help-btl-vader.txt", "knem requested but not available",
+			       true, ompi_process_info.nodename);
+            }
+
+            /* disable single copy */
+            mca_btl_vader_select_next_single_copy_mechanism ();
+        }
+    }
+#endif
+
+    if (MCA_BTL_VADER_NONE == mca_btl_vader_component.single_copy_mechanism) {
+        mca_btl_vader.super.btl_flags &= ~MCA_BTL_FLAGS_RDMA;
+        mca_btl_vader.super.btl_get = NULL;
+        mca_btl_vader.super.btl_put = NULL;
+    }
+}
+#endif
 
 /*
  *  VADER component initialization
@@ -259,16 +454,18 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
 
     /* disable if there are no local peers */
     if (0 == MCA_BTL_VADER_NUM_LOCAL_PEERS) {
+        BTL_VERBOSE(("No peers to communicate with. Disabling vader."));
         return NULL;
     }
 
+#if OMPI_BTL_VADER_HAVE_XPMEM
     /* limit segment alignment to be between 4k and 16M */
-    
-    if (mca_btl_vader_component.log_attach_align < 12) {
-        mca_btl_vader_component.log_attach_align = 12;
-    } else if (mca_btl_vader_component.log_attach_align > 25) {
-        mca_btl_vader_component.log_attach_align = 25;
+    if (component->log_attach_align < 12) {
+        component->log_attach_align = 12;
+    } else if (component->log_attach_align > 25) {
+        component->log_attach_align = 25;
     }
+#endif
 
     btls = (mca_btl_base_module_t **) calloc (1, sizeof (mca_btl_base_module_t *));
     if (NULL == btls) {
@@ -276,31 +473,25 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     }
 
     /* ensure a sane segment size */
-    if (mca_btl_vader_component.segment_size < (2 << 20)) {
-        mca_btl_vader_component.segment_size = (2 << 20);
+    if (component->segment_size < (2 << 20)) {
+        component->segment_size = (2 << 20);
     }
 
-    if (mca_btl_vader_component.segment_size > (1ul << MCA_BTL_VADER_OFFSET_BITS)) {
-        mca_btl_vader_component.segment_size = 2ul << MCA_BTL_VADER_OFFSET_BITS;
+    component->fbox_size = (component->fbox_size + MCA_BTL_VADER_FBOX_ALIGNMENT_MASK) & ~MCA_BTL_VADER_FBOX_ALIGNMENT_MASK;
+
+    if (component->segment_size > (1ul << MCA_BTL_VADER_OFFSET_BITS)) {
+        component->segment_size = 2ul << MCA_BTL_VADER_OFFSET_BITS;
     }
 
-#if OMPI_BTL_VADER_HAVE_XPMEM
-    /* create an xpmem segment for the entire memory space */
-    component->my_seg_id = xpmem_make (0, 0xffffffffffffffffll, XPMEM_PERMIT_MODE,
-                                       (void *)0666);
-    if (-1 == component->my_seg_id) {
-        free (btls);
-        return NULL;
-    }
+    /* no fast boxes allocated initially */
+    component->num_fbox_in_endpoints = 0;
+    component->fbox_count = 0;
 
-    component->my_segment = mmap (NULL, mca_btl_vader_component.segment_size, PROT_READ |
-                                  PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
-    if ((void *)-1 == component->my_segment) {
-        free (btls);
-        return NULL;
-    }
-#else
-    {
+#if OMPI_BTL_VADER_HAVE_XPMEM || OMPI_BTL_VADER_HAVE_CMA || OMPI_BTL_VADER_HAVE_KNEM
+    mca_btl_vader_check_single_copy ();
+#endif
+
+    if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
         char *sm_file;
 
         rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", ompi_process_info.proc_session_dir,
@@ -310,33 +501,38 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
             return NULL;
         }
 
-        rc = opal_shmem_segment_create (&mca_btl_vader_component.seg_ds, sm_file, mca_btl_vader_component.segment_size);
+        rc = opal_shmem_segment_create (&component->seg_ds, sm_file, component->segment_size);
         free (sm_file);
         if (OPAL_SUCCESS != rc) {
+            BTL_VERBOSE(("Could not create shared memory segment"));
             free (btls);
             return NULL;
         }
 
-        component->my_segment = opal_shmem_segment_attach (&mca_btl_vader_component.seg_ds);
+        component->my_segment = opal_shmem_segment_attach (&component->seg_ds);
         if (NULL == component->my_segment) {
+            BTL_VERBOSE(("Could not attach to just created shared memory segment"));
             goto failed;
         }
+    } else {
+        /* when using xpmem it is safe to use an anonymous segment */
+        component->my_segment = mmap (NULL, component->segment_size, PROT_READ |
+                                      PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+        if ((void *)-1 == component->my_segment) {
+            BTL_VERBOSE(("Could not create anonymous memory segment"));
+            free (btls);
+            return NULL;
+        }
     }
-#endif
 
     component->segment_offset = 0;
 
-    memset (component->my_segment + MCA_BTL_VADER_FIFO_SIZE, 0, MCA_BTL_VADER_NUM_LOCAL_PEERS *
-            MCA_BTL_VADER_FBOX_PEER_SIZE);
-
     /* initialize my fifo */
-    rc = vader_fifo_init ((struct vader_fifo_t *) component->my_segment);
-    if (OMPI_SUCCESS != rc) {
-        goto failed;
-    }
+    vader_fifo_init ((struct vader_fifo_t *) component->my_segment);
 
     rc = mca_btl_base_vader_modex_send ();
     if (OMPI_SUCCESS != rc) {
+        BTL_VERBOSE(("Error sending modex"));
         goto failed;
     }
 
@@ -351,10 +547,11 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     return btls;
 failed:
 #if OMPI_BTL_VADER_HAVE_XPMEM
-    munmap (component->my_segment, mca_btl_vader_component.segment_size);
-#else
-    opal_shmem_unlink (&mca_btl_vader_component.seg_ds);
+    if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+        munmap (component->my_segment, component->segment_size);
+    } else
 #endif
+        opal_shmem_unlink (&component->seg_ds);
 
     if (btls) {
         free (btls);
@@ -363,70 +560,143 @@ failed:
     return NULL;
 }
 
-static inline int mca_btl_vader_poll_fifo (void)
+void mca_btl_vader_poll_handle_frag (mca_btl_vader_hdr_t *hdr, struct mca_btl_base_endpoint_t *endpoint)
 {
+    mca_btl_base_segment_t segments[2];
+    mca_btl_base_descriptor_t frag = {.des_dst = segments, .des_dst_cnt = 1};
     const mca_btl_active_message_callback_t *reg;
+
+    if (hdr->flags & MCA_BTL_VADER_FLAG_COMPLETE) {
+        mca_btl_vader_frag_complete (hdr->frag);
+        return;
+    }
+
+    reg = mca_btl_base_active_message_trigger + hdr->tag;
+    segments[0].seg_addr.pval = (void *) (hdr + 1);
+    segments[0].seg_len       = hdr->len;
+
+    if (hdr->flags & MCA_BTL_VADER_FLAG_SINGLE_COPY) {
+        mca_mpool_base_registration_t *xpmem_reg;
+
+        xpmem_reg = vader_get_registation (endpoint, hdr->sc_iov.iov_base,
+                                           hdr->sc_iov.iov_len, 0,
+                                           &segments[1].seg_addr.pval);
+
+        segments[1].seg_len       = hdr->sc_iov.iov_len;
+        frag.des_dst_cnt = 2;
+
+        /* recv upcall */
+        reg->cbfunc(&mca_btl_vader.super, hdr->tag, &frag, reg->cbdata);
+        vader_return_registration (xpmem_reg, endpoint);
+    } else {
+        reg->cbfunc(&mca_btl_vader.super, hdr->tag, &frag, reg->cbdata);
+    }
+
+    if (OPAL_UNLIKELY(MCA_BTL_VADER_FLAG_SETUP_FBOX & hdr->flags)) {
+        mca_btl_vader_endpoint_setup_fbox_recv (endpoint, relative2virtual(hdr->fbox_base));
+        mca_btl_vader_component.fbox_in_endpoints[mca_btl_vader_component.num_fbox_in_endpoints++] = endpoint;
+    }
+
+    hdr->flags = MCA_BTL_VADER_FLAG_COMPLETE;
+    vader_fifo_write_back (hdr, endpoint);
+}
+
+static int mca_btl_vader_poll_fifo (void)
+{
     struct mca_btl_base_endpoint_t *endpoint;
     mca_btl_vader_hdr_t *hdr;
 
     /* poll the fifo until it is empty or a limit has been hit (8 is arbitrary) */
-    for (int fifo_count = 0 ; fifo_count < 16 ; ++fifo_count) {
-        mca_btl_vader_frag_t frag = {.base = {.des_dst = frag.segments, .des_dst_cnt = 1}};
-
+    for (int fifo_count = 0 ; fifo_count < 31 ; ++fifo_count) {
         hdr = vader_fifo_read (mca_btl_vader_component.my_fifo, &endpoint);
         if (NULL == hdr) {
             return fifo_count;
         }
 
-        if (hdr->flags & MCA_BTL_VADER_FLAG_COMPLETE) {
-            mca_btl_vader_frag_complete (hdr->frag);
-            continue;
-        }
- 
-        reg = mca_btl_base_active_message_trigger + hdr->tag;
-        frag.segments[0].seg_addr.pval = (void *) (hdr + 1);
-        frag.segments[0].seg_len       = hdr->len;
-
-        if (hdr->flags & MCA_BTL_VADER_FLAG_SINGLE_COPY) {
-            mca_mpool_base_registration_t *xpmem_reg;
-
-            xpmem_reg = vader_get_registation (endpoint, hdr->sc_iov.iov_base,
-                                               hdr->sc_iov.iov_len, 0,
-                                               &frag.segments[1].seg_addr.pval);
-
-            frag.segments[1].seg_len       = hdr->sc_iov.iov_len;
-
-            /* recv upcall */
-            frag.base.des_dst_cnt = 2;
-            reg->cbfunc(&mca_btl_vader.super, hdr->tag, &(frag.base), reg->cbdata);
-            vader_return_registration (xpmem_reg, endpoint);
-        } else {
-            reg->cbfunc(&mca_btl_vader.super, hdr->tag, &(frag.base), reg->cbdata);
-        }
-
-        /* return the fragment */
-        hdr->flags = MCA_BTL_VADER_FLAG_COMPLETE;
-        vader_fifo_write_back (hdr, endpoint); 
+        mca_btl_vader_poll_handle_frag (hdr, endpoint);
     }
 
     return 1;
 }
 
+/**
+ * Progress pending messages on an endpoint
+ *
+ * @param ep (IN)       Vader BTL endpoint
+ *
+ * This is called with the component lock held so the component lock does
+ * not need to be aquired before modifying the pending_endpoints list.
+ */
+static void mca_btl_vader_progress_waiting (mca_btl_base_endpoint_t *ep)
+{
+    mca_btl_vader_frag_t *frag;
+
+    if (OPAL_UNLIKELY(NULL == ep)) {
+        return;
+    }
+
+    OPAL_THREAD_LOCK(&ep->lock);
+    ep->waiting = false;
+    while (NULL != (frag = (mca_btl_vader_frag_t *) opal_list_remove_first (&ep->pending_frags))) {
+        OPAL_THREAD_UNLOCK(&ep->lock);
+        if (!vader_fifo_write_ep (frag->hdr, ep)) {
+            opal_list_prepend (&ep->pending_frags, (opal_list_item_t *) frag);
+            opal_list_append (&mca_btl_vader_component.pending_endpoints, &ep->super);
+            ep->waiting = true;
+            break;
+        }
+        OPAL_THREAD_LOCK(&ep->lock);
+    }
+    OPAL_THREAD_UNLOCK(&ep->lock);
+}
+
+/**
+ * Progress pending messages on all waiting endpoints
+ *
+ * @param ep (IN)       Vader BTL endpoint
+ */
+static void mca_btl_vader_progress_endpoints (void)
+{
+    int count;
+
+    count = opal_list_get_size (&mca_btl_vader_component.pending_endpoints);
+    if (OPAL_LIKELY(0 == count)) {
+        return;
+    }
+
+    OPAL_THREAD_LOCK(&mca_btl_vader_component.lock);
+    for (int i = 0 ; i < count ; ++i) {
+        mca_btl_vader_progress_waiting ((mca_btl_base_endpoint_t *) opal_list_remove_first (&mca_btl_vader_component.pending_endpoints));
+    }
+    OPAL_THREAD_LOCK(&mca_btl_vader_component.lock);
+}
+
 static int mca_btl_vader_component_progress (void)
 {
-    bool fboxed;
+    static int32_t lock = 0;
+    int count = 0;
 
-    /* check for messages in fast boxes */
-    for (int spin_count = 5 ; spin_count ; --spin_count) {
-        fboxed = (int) mca_btl_vader_check_fboxes ();
-        if (fboxed) {
-            break;
+    if (opal_using_threads()) {
+        if (opal_atomic_swap_32 (&lock, 1)) {
+            return 0;
         }
     }
 
-    if (VADER_FIFO_FREE == mca_btl_vader_component.my_fifo->fifo_head) {
-        return (int) fboxed;
+    /* check for messages in fast boxes */
+    if (mca_btl_vader_component.num_fbox_in_endpoints) {
+        count = mca_btl_vader_check_fboxes ();
     }
 
-    return mca_btl_vader_poll_fifo () + (int) fboxed;
+    mca_btl_vader_progress_endpoints ();
+
+    if (VADER_FIFO_FREE == mca_btl_vader_component.my_fifo->fifo_head) {
+        lock = 0;
+        return count;
+    }
+
+    count += mca_btl_vader_poll_fifo ();
+    opal_atomic_mb ();
+    lock = 0;
+
+    return count;
 }

--- a/ompi/mca/btl/vader/btl_vader_endpoint.h
+++ b/ompi/mca/btl/vader/btl_vader_endpoint.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -26,11 +26,11 @@
 #ifndef MCA_BTL_VADER_ENDPOINT_H
 #define MCA_BTL_VADER_ENDPOINT_H
 
-#if OMPI_BTL_VADER_HAVE_XPMEM
-#include <xpmem.h>
-#else
-#include "opal/mca/shmem/base/base.h"
-#endif
+#include "ompi_config.h"
+#include "btl_vader_xpmem.h"
+
+#define MCA_BTL_VADER_FBOX_ALIGNMENT      32
+#define MCA_BTL_VADER_FBOX_ALIGNMENT_MASK (MCA_BTL_VADER_FBOX_ALIGNMENT - 1)
 
 struct vader_fifo_t;
 
@@ -42,28 +42,73 @@ struct vader_fifo_t;
 
 struct mca_btl_vader_fbox_t;
 
-struct mca_btl_base_endpoint_t {
-    int peer_smp_rank;  /**< My peer's SMP process rank.  Used for accessing
-                         *   SMP specfic data structures. */
-    char         *segment_base;
-    struct vader_fifo_t *fifo;
-#if OMPI_BTL_VADER_HAVE_XPMEM
-    xpmem_apid_t    apid;
-#else
-    pid_t           pid;
-    opal_shmem_ds_t seg_ds;
-#endif
-    struct mca_btl_vader_fbox_t * restrict fbox_out;
-    struct mca_btl_vader_fbox_t * restrict fbox_in;
-    int           next_fbox_out;
-    int           next_fbox_in;
-#if OMPI_BTL_VADER_HAVE_XPMEM
-    struct mca_rcache_base_module_t *rcache;
-#endif
+typedef struct mca_btl_base_endpoint_t {
+    opal_list_item_t super;
 
-    /* enforce ordering */
-    uint16_t next_sequence;
-    uint16_t expected_sequence;
-};
+    /* per peer buffers */
+    struct {
+        unsigned char *buffer; /**< starting address of peer's fast box out */
+        unsigned int start, seq;
+        uint32_t *startp;
+    } fbox_in;
+
+    struct {
+        unsigned char *buffer; /**< starting address of peer's fast box in */
+        unsigned int start, end, seq;
+        uint32_t *startp;      /**< pointer to location storing start offset */
+    } fbox_out;
+
+    int32_t peer_smp_rank;  /**< my peer's SMP process rank.  Used for accessing
+                             *   SMP specfic data structures. */
+    uint32_t send_count;    /**< number of fragments sent to this peer */
+    char *segment_base;     /**< start of the peer's segment (in the address space
+                             *   of this process) */
+
+    struct vader_fifo_t *fifo; /**< */
+
+    opal_mutex_t lock;      /**< lock to protect endpoint structures from concurrent
+                             *   access */
+
+    union {
+#if OMPI_BTL_VADER_HAVE_XPMEM
+        struct {
+            struct mca_rcache_base_module_t *rcache;
+            xpmem_apid_t    apid;       /**< xpmem apid for remote peer */
+        } xpmem;
+#endif
+        struct {
+            pid_t           pid;        /**< pid of remote peer (used for CMA) */
+            opal_shmem_ds_t *seg_ds;    /**< stored segment information for detach */
+        } other;
+    } segment_data;
+
+    opal_list_t pending_frags; /**< fragments pending fast box space */
+    bool waiting;           /**< endpoint is on the component wait list */
+} mca_btl_base_endpoint_t;
+
+typedef mca_btl_base_endpoint_t mca_btl_vader_endpoint_t;
+
+OBJ_CLASS_DECLARATION(mca_btl_vader_endpoint_t);
+
+static inline void mca_btl_vader_endpoint_setup_fbox_recv (struct mca_btl_base_endpoint_t *endpoint, void *base)
+{
+    endpoint->fbox_in.buffer = base;
+    endpoint->fbox_in.startp = (uint32_t *) base;
+    endpoint->fbox_in.start = MCA_BTL_VADER_FBOX_ALIGNMENT;
+    endpoint->fbox_in.seq = 0;
+}
+
+static inline void mca_btl_vader_endpoint_setup_fbox_send (struct mca_btl_base_endpoint_t *endpoint, void *base)
+{
+    endpoint->fbox_out.buffer = base;
+    endpoint->fbox_out.start = MCA_BTL_VADER_FBOX_ALIGNMENT;
+    endpoint->fbox_out.end = MCA_BTL_VADER_FBOX_ALIGNMENT;
+    endpoint->fbox_out.startp = (uint32_t *) base;
+    endpoint->fbox_out.startp[0] = MCA_BTL_VADER_FBOX_ALIGNMENT;
+    endpoint->fbox_out.seq = 0;
+
+    /* zero out the first header in the fast box */
+    memset ((char *) base + MCA_BTL_VADER_FBOX_ALIGNMENT, 0, MCA_BTL_VADER_FBOX_ALIGNMENT);
+}
 
 #endif /* MCA_BTL_VADER_ENDPOINT_H */

--- a/ompi/mca/btl/vader/btl_vader_fbox.h
+++ b/ompi/mca/btl/vader/btl_vader_fbox.h
@@ -13,150 +13,271 @@
 #define MCA_BTL_VADER_FBOX_H
 
 #include "btl_vader.h"
-#include "btl_vader_endpoint.h"
-#include "btl_vader_xpmem.h"
 
-#include <string.h>
-
-/* these hard-coded settings are based on the ideal setup for an Opteron 61xx chip and
- * may need to be adjusted for other systems. adding an MCA variable is possible but
- * can cost 20-40 ns on the fast path. this size is limited to 256 maximum bytes */
-#define MCA_BTL_VADER_FBOX_SIZE 64
-/* there should be a power of two number of fast boxes to simplify the math in the
- * critical path */
-#define MCA_BTL_VADER_LAST_FBOX 63
 #define MCA_BTL_VADER_POLL_COUNT 31
-/* two bytes are reserved for tag and size (update if the header is modified) */
-#define MCA_BTL_VADER_FBOX_HDR_SIZE 4
-#define MCA_BTL_VADER_FBOX_MAX_SIZE (MCA_BTL_VADER_FBOX_SIZE - MCA_BTL_VADER_FBOX_HDR_SIZE)
-/* total size of all the fast boxes assigned to a particular peer */
-#define MCA_BTL_VADER_FBOX_PEER_SIZE (MCA_BTL_VADER_FBOX_SIZE * (MCA_BTL_VADER_LAST_FBOX + 1))
 
-typedef struct mca_btl_vader_fbox_t {
-    union {
-        struct {
-            uint8_t  size;
-            uint8_t  tag;
-            uint16_t seqn;
-        } hdr_data;
-        uint32_t ival;
-    } hdr;
+typedef union mca_btl_vader_fbox_hdr_t {
+    struct {
+        uint16_t  tag;
+        uint16_t  size;
+        uint32_t  seq;
+    } data;
+    uint64_t ival;
+} mca_btl_vader_fbox_hdr_t;
 
-    uint8_t data[MCA_BTL_VADER_FBOX_MAX_SIZE];
-} mca_btl_vader_fbox_t;
+#define MCA_BTL_VADER_FBOX_HDR(x) ((mca_btl_vader_fbox_hdr_t *) (x))
 
-#define MCA_BTL_VADER_FBOX_OUT_PTR(ep, fbox) ((ep)->fbox_out + (fbox))
-#define MCA_BTL_VADER_FBOX_IN_PTR(ep, fbox) ((ep)->fbox_in + (fbox))
-#define MCA_BTL_VADER_NEXT_FBOX(fbox) (((fbox) + 1) & MCA_BTL_VADER_LAST_FBOX)
+#define MCA_BTL_VADER_FBOX_OFFSET_MASK 0x7fffffff
+#define MCA_BTL_VADER_FBOX_HB_MASK     0x80000000
 
-static inline mca_btl_vader_fbox_t * restrict mca_btl_vader_reserve_fbox (struct mca_btl_base_endpoint_t *ep, const size_t size)
+/* if the two offsets are equal and the high bit matches the buffer is empty else the buffer is full.
+ * note that start will never be end - 1 so this simplified conditional will always produce the correct
+ * result */
+#define BUFFER_FREE(s,e,hbm,size) (((s + !hbm) > (e)) ? (s) - (e) : (size - (e)))
+
+/** macro for checking if the high bit is set */
+#define MCA_BTL_VADER_FBOX_OFFSET_HBS(v) (!!((v) & MCA_BTL_VADER_FBOX_HB_MASK))
+
+void mca_btl_vader_poll_handle_frag (mca_btl_vader_hdr_t *hdr, mca_btl_base_endpoint_t *ep);
+
+/* attempt to reserve a contiguous segment from the remote ep */
+static inline unsigned char *mca_btl_vader_reserve_fbox (mca_btl_base_endpoint_t *ep, size_t size)
 {
-    const int next_fbox = ep->next_fbox_out;
-    mca_btl_vader_fbox_t * restrict fbox = MCA_BTL_VADER_FBOX_OUT_PTR(ep, next_fbox);
+    const unsigned int fbox_size = mca_btl_vader_component.fbox_size;
+    unsigned int start, end, buffer_free;
+    size_t data_size = size;
+    unsigned char *dst;
+    bool hbs, hbm;
 
-    opal_atomic_mb ();
-
-    /* todo -- need thread locks/atomics here for the multi-threaded case */
-    if (OPAL_LIKELY(size <= MCA_BTL_VADER_FBOX_MAX_SIZE && 0 == fbox->hdr.ival)) {
-        /* mark this fast box as in use */
-        fbox->hdr.hdr_data.size = size;
-        ep->next_fbox_out = MCA_BTL_VADER_NEXT_FBOX(next_fbox);
-        opal_atomic_mb ();
-        return fbox;
+    /* don't try to use the per-peer buffer for messages that will fill up more than 25% of the buffer */
+    if (OPAL_UNLIKELY(NULL == ep->fbox_out.buffer || size > (fbox_size >> 2))) {
+        return NULL;
     }
 
-    return NULL;
+    OPAL_THREAD_LOCK(&ep->lock);
+
+    /* the high bit helps determine if the buffer is empty or full */
+    hbs = MCA_BTL_VADER_FBOX_OFFSET_HBS(ep->fbox_out.end);
+    hbm = MCA_BTL_VADER_FBOX_OFFSET_HBS(ep->fbox_out.start) == hbs;
+
+    /* read current start and end offsets and check for free space */
+    start = ep->fbox_out.start & MCA_BTL_VADER_FBOX_OFFSET_MASK;
+    end = ep->fbox_out.end & MCA_BTL_VADER_FBOX_OFFSET_MASK;
+    buffer_free = BUFFER_FREE(start, end, hbm, fbox_size);
+
+    /* need space for the fragment + the header */
+    size = (size + sizeof (mca_btl_vader_fbox_hdr_t) + MCA_BTL_VADER_FBOX_ALIGNMENT_MASK) & ~MCA_BTL_VADER_FBOX_ALIGNMENT_MASK;
+
+    dst = ep->fbox_out.buffer + end;
+
+    if (OPAL_UNLIKELY(buffer_free < size)) {
+        /* check if we need to free up space for this fragment */
+        BTL_VERBOSE(("not enough room for a fragment of size %u. in use buffer segment: {start: %x, end: %x, high bit matches: %d}",
+                     (unsigned) size, start, end, (int) hbm));
+
+        /* read the current start pointer from the remote peer and recalculate the available buffer space */
+        start = ep->fbox_out.start = ep->fbox_out.startp[0];
+
+        /* recalculate how much buffer space is available */
+        start &= MCA_BTL_VADER_FBOX_OFFSET_MASK;
+        hbm = MCA_BTL_VADER_FBOX_OFFSET_HBS(ep->fbox_out.start) == hbs;
+        buffer_free = BUFFER_FREE(start, end, hbm, fbox_size);
+
+        opal_atomic_rmb ();
+
+        /* if this is the end of the buffer and the fragment doesn't fit then mark the remaining buffer space to
+         * be skipped and check if the fragment can be written at the beginning of the buffer. */
+        if (OPAL_UNLIKELY(buffer_free > 0 && buffer_free < size && start <= end)) {
+            mca_btl_vader_fbox_hdr_t tmp = {.data = {.size = buffer_free - sizeof (mca_btl_vader_fbox_hdr_t),
+                                                     .seq = ep->fbox_out.seq++, .tag = 0xff}};
+
+            BTL_VERBOSE(("message will not fit in remaining buffer space. skipping to beginning"));
+
+            MCA_BTL_VADER_FBOX_HDR(dst)->ival = tmp.ival;
+
+            end = MCA_BTL_VADER_FBOX_ALIGNMENT;
+            /* toggle the high bit */
+            hbs = !hbs;
+            /* toggle the high bit match */
+            buffer_free = BUFFER_FREE(start, end, !hbm, fbox_size);
+            dst = ep->fbox_out.buffer + end;
+        }
+
+        if (OPAL_UNLIKELY(buffer_free < size)) {
+            ep->fbox_out.end = (hbs << 31) | end;
+            OPAL_THREAD_UNLOCK(&ep->lock);
+            return NULL;
+        }
+    }
+
+    BTL_VERBOSE(("writing fragment of size %u to offset %u {start: 0x%x, end: 0x%x (hbs: %d)} of peer's buffer. free = %u",
+                 (unsigned int) size, end, start, end, hbs, buffer_free));
+
+    /* write out part of the header now. the tag will be written when the data is available */
+    {
+        mca_btl_vader_fbox_hdr_t tmp = {.data = {.size = data_size, .tag = 0, .seq = ep->fbox_out.seq++}};
+
+        MCA_BTL_VADER_FBOX_HDR(dst)->ival = tmp.ival;
+    }
+
+    end += size;
+
+    if (OPAL_UNLIKELY(fbox_size == end)) {
+        /* toggle the high bit */
+        hbs = !hbs;
+        /* reset the end pointer to the beginning of the buffer */
+        end = MCA_BTL_VADER_FBOX_ALIGNMENT;
+    } else if (buffer_free > size) {
+        MCA_BTL_VADER_FBOX_HDR(ep->fbox_out.buffer + end)->ival = 0;
+    }
+
+    /* align the buffer */
+    ep->fbox_out.end = ((uint32_t) hbs << 31) | end;
+    OPAL_THREAD_UNLOCK(&ep->lock);
+
+    return dst + sizeof (mca_btl_vader_fbox_hdr_t);
 }
 
-static inline void mca_btl_vader_fbox_send (mca_btl_vader_fbox_t * restrict fbox, unsigned char tag,
-                                            struct mca_btl_base_endpoint_t *endpoint)
+static inline void mca_btl_vader_fbox_send (unsigned char * restrict fbox, unsigned char tag)
 {
     /* ensure data writes have completed before we mark the data as available */
     opal_atomic_wmb ();
-    fbox->hdr.hdr_data.seqn = endpoint->next_sequence++;
-    fbox->hdr.hdr_data.tag = tag;
-    opal_atomic_wmb ();
+
+    /* the header proceeds the fbox buffer */
+    MCA_BTL_VADER_FBOX_HDR ((intptr_t) fbox)[-1].data.tag = tag;
 }
 
-static inline int mca_btl_vader_fbox_sendi (struct mca_btl_base_endpoint_t *endpoint, char tag,
-                                            void * restrict header, const size_t header_size,
-                                            void * restrict payload, const size_t payload_size)
+static inline bool mca_btl_vader_fbox_sendi (mca_btl_base_endpoint_t *ep, unsigned char tag,
+                                             void * restrict header, const size_t header_size,
+                                             void * restrict payload, const size_t payload_size)
 {
-    mca_btl_vader_fbox_t * restrict fbox;
+    const size_t total_size = header_size + payload_size;
+    unsigned char * restrict fbox;
 
-    fbox = mca_btl_vader_reserve_fbox(endpoint, header_size + payload_size);
+    fbox = mca_btl_vader_reserve_fbox(ep, total_size);
     if (OPAL_UNLIKELY(NULL == fbox)) {
-        return 0;
+        return false;
     }
 
-    memcpy (fbox->data, header, header_size);
+    memcpy (fbox, header, header_size);
     if (payload) {
         /* inline sends are typically just pml headers (due to MCA_BTL_FLAGS_SEND_INPLACE) */
-        memcpy (fbox->data + header_size, payload, payload_size);
+        memcpy (fbox + header_size, payload, payload_size);
     }
 
     /* mark the fbox as sent */
-    mca_btl_vader_fbox_send (fbox, tag, endpoint);
+    mca_btl_vader_fbox_send (fbox, tag);
 
     /* send complete */
-    return 1;
+    return true;
 }
 
 static inline bool mca_btl_vader_check_fboxes (void)
 {
-    const mca_btl_active_message_callback_t *reg;
-    struct mca_btl_base_endpoint_t *endpoint;
-    mca_btl_vader_fbox_t * restrict fbox;
-    mca_btl_base_segment_t segment;
-    mca_btl_base_descriptor_t desc;
+    const unsigned int fbox_size = mca_btl_vader_component.fbox_size;
     bool processed = false;
-    int next_fbox;
 
-    for (endpoint = mca_btl_vader_component.endpoints ; endpoint->peer_smp_rank != -1 ; ++endpoint) {
-        next_fbox = endpoint->next_fbox_in;
-        fbox = MCA_BTL_VADER_FBOX_IN_PTR(endpoint, next_fbox);
+    for (unsigned int i = 0 ; i < mca_btl_vader_component.num_fbox_in_endpoints ; ++i) {
+        mca_btl_base_endpoint_t *ep = mca_btl_vader_component.fbox_in_endpoints[i];
+        unsigned int start = ep->fbox_in.start & MCA_BTL_VADER_FBOX_OFFSET_MASK;
 
-        if (NULL == endpoint->fbox_in || 0 == fbox->hdr.hdr_data.tag) {
-            continue;
-        }
+        /* save the current high bit state */
+        bool hbs = MCA_BTL_VADER_FBOX_OFFSET_HBS(ep->fbox_in.start);
+        int poll_count;
 
-        desc.des_dst = &segment;
-        desc.des_dst_cnt = 1;
+        for (poll_count = 0 ; poll_count <= MCA_BTL_VADER_POLL_COUNT ; ++poll_count) {
+            const mca_btl_vader_fbox_hdr_t hdr = {.ival = MCA_BTL_VADER_FBOX_HDR(ep->fbox_in.buffer + start)->ival};
 
-        processed = true;
-
-        /* process all fast-box messages */
-        for (int count = 0 ; count <= MCA_BTL_VADER_POLL_COUNT && 0 != fbox->hdr.hdr_data.tag ; ++count) {
-            if (OPAL_UNLIKELY(endpoint->expected_sequence != fbox->hdr.hdr_data.seqn)) {
+            /* check for a valid tag a sequence number */
+            if (0 == hdr.data.tag || hdr.data.seq != ep->fbox_in.seq) {
                 break;
             }
-            opal_atomic_mb ();
-            ++endpoint->expected_sequence;
 
-            reg = mca_btl_base_active_message_trigger + fbox->hdr.hdr_data.tag;
+            ++ep->fbox_in.seq;
 
-            segment.seg_addr.pval = fbox->data;
-            segment.seg_len       = fbox->hdr.hdr_data.size;
+            /* force all prior reads to complete before continuing */
+            opal_atomic_rmb ();
 
-            reg->cbfunc(&mca_btl_vader.super, fbox->hdr.hdr_data.tag, &desc, reg->cbdata);
+            BTL_VERBOSE(("got frag from %d with header {.tag = %d, .size = %d, .seq = %u} from offset %u",
+                         ep->peer_smp_rank, hdr.data.tag, hdr.data.size, hdr.data.seq, start));
 
-            if (segment.seg_len > MCA_BTL_VADER_FBOX_MAX_SIZE) {
-                fbox[1].hdr.ival = 0;
-                opal_atomic_mb ();
-                ++next_fbox;
+            /* the 0xff tag indicates we should skip the rest of the buffer */
+            if (OPAL_LIKELY((0xfe & hdr.data.tag) != 0xfe)) {
+                mca_btl_base_segment_t segment;
+                mca_btl_base_descriptor_t desc = {.des_dst = &segment, .des_dst_cnt = 1};
+                const mca_btl_active_message_callback_t *reg =
+                    mca_btl_base_active_message_trigger + hdr.data.tag;
+
+                /* fragment fits entirely in the remaining buffer space. some
+                 * btl users do not handle fragmented data so we can't split
+                 * the fragment without introducing another copy here. this
+                 * limitation has not appeared to cause any performance
+                 * degradation. */
+                segment.seg_len = hdr.data.size;
+                segment.seg_addr.pval = (void *) (ep->fbox_in.buffer + start + sizeof (hdr));
+
+                /* call the registered callback function */
+                reg->cbfunc(&mca_btl_vader.super, hdr.data.tag, &desc, reg->cbdata);
+            } else if (OPAL_LIKELY(0xfe == hdr.data.tag)) {
+                /* process fragment header */
+                fifo_value_t *value = (fifo_value_t *)(ep->fbox_in.buffer + start + sizeof (hdr));
+                mca_btl_vader_hdr_t *hdr = relative2virtual(*value);
+                mca_btl_vader_poll_handle_frag (hdr, ep);
             }
-            fbox->hdr.ival = 0;
 
-            next_fbox = MCA_BTL_VADER_NEXT_FBOX(next_fbox);
-            fbox = (mca_btl_vader_fbox_t * restrict) MCA_BTL_VADER_FBOX_IN_PTR(endpoint, next_fbox);
+            start = (start + hdr.data.size + sizeof (hdr) + MCA_BTL_VADER_FBOX_ALIGNMENT_MASK) & ~MCA_BTL_VADER_FBOX_ALIGNMENT_MASK;
+            if (OPAL_UNLIKELY(fbox_size == start)) {
+                /* jump to the beginning of the buffer */
+                start = MCA_BTL_VADER_FBOX_ALIGNMENT;
+                /* toggle the high bit */
+                hbs = !hbs;
+            }
         }
 
-        opal_atomic_mb ();
+        if (poll_count) {
+            BTL_VERBOSE(("left off at offset %u (hbs: %d)", start, hbs));
 
-        endpoint->next_fbox_in = next_fbox;
+            /* save where we left off */
+            /* let the sender know where we stopped */
+            ep->fbox_in.start = ep->fbox_in.startp[0] = ((uint32_t) hbs << 31) | start;
+            processed = true;
+        }
     }
 
+    /* return the number of fragments processed */
     return processed;
+}
+
+static inline void mca_btl_vader_try_fbox_setup (mca_btl_base_endpoint_t *ep, mca_btl_vader_hdr_t *hdr)
+{
+    if (NULL == ep->fbox_out.buffer && mca_btl_vader_component.fbox_threshold == ++ep->send_count) {
+
+        /* protect access to mca_btl_vader_component.segment_offset */
+        OPAL_THREAD_LOCK(&mca_btl_vader_component.lock);
+
+        if (mca_btl_vader_component.segment_size >= mca_btl_vader_component.segment_offset + mca_btl_vader_component.fbox_size &&
+            mca_btl_vader_component.fbox_max > mca_btl_vader_component.fbox_count) {
+            /* verify the remote side will accept another fbox */
+            if (0 <= opal_atomic_add_32 (&ep->fifo->fbox_available, -1)) {
+                void *fbox_base = mca_btl_vader_component.my_segment + mca_btl_vader_component.segment_offset;
+                mca_btl_vader_component.segment_offset += mca_btl_vader_component.fbox_size;
+
+                /* zero out the fast box */
+                memset (fbox_base, 0, mca_btl_vader_component.fbox_size);
+                mca_btl_vader_endpoint_setup_fbox_send (ep, fbox_base);
+
+                hdr->flags |= MCA_BTL_VADER_FLAG_SETUP_FBOX;
+                hdr->fbox_base = virtual2relative((char *) ep->fbox_out.buffer);
+                ++mca_btl_vader_component.fbox_count;
+            } else {
+                opal_atomic_add_32 (&ep->fifo->fbox_available, 1);
+            }
+
+            opal_atomic_wmb ();
+        }
+
+        OPAL_THREAD_UNLOCK(&mca_btl_vader_component.lock);
+    }
 }
 
 #endif /* !defined(MCA_BTL_VADER_FBOX_H) */

--- a/ompi/mca/btl/vader/btl_vader_fifo.h
+++ b/ompi/mca/btl/vader/btl_vader_fifo.h
@@ -70,10 +70,20 @@
 typedef struct vader_fifo_t {
     volatile fifo_value_t fifo_head;
     volatile fifo_value_t fifo_tail;
+    volatile int32_t      fbox_available;
 } vader_fifo_t;
 
 /* large enough to ensure the fifo is on its own cache line */
 #define MCA_BTL_VADER_FIFO_SIZE 128
+
+/***
+ * One or more FIFO components may be a pointer that must be
+ * accessed by multiple processes.  Since the shared region may
+ * be mmapped differently into each process's address space,
+ * these pointers will be relative to some base address.  Here,
+ * we define inline functions to translate between relative
+ * addresses and virtual addresses.
+ */
 
 /* This only works for finding the relative address for a pointer within my_segment */
 static inline fifo_value_t virtual2relative (char *addr)
@@ -91,18 +101,26 @@ static inline void *relative2virtual (fifo_value_t offset)
     return (void *)(intptr_t)((offset & MCA_BTL_VADER_OFFSET_MASK) + mca_btl_vader_component.endpoints[offset >> MCA_BTL_VADER_OFFSET_BITS].segment_base);
 }
 
+#include "btl_vader_fbox.h"
+
+/**
+ * vader_fifo_read:
+ *
+ * @brief reads a single fragment from a local fifo
+ *
+ * @param[inout]   fifo - FIFO to read from
+ * @param[out]     ep   - returns the endpoint the fifo element was read from
+ *
+ * @returns a fragment header or NULL
+ *
+ * This function does not currently support multiple readers.
+ */
 static inline mca_btl_vader_hdr_t *vader_fifo_read (vader_fifo_t *fifo, struct mca_btl_base_endpoint_t **ep)
 {
     mca_btl_vader_hdr_t *hdr;
     fifo_value_t value;
-    static volatile int32_t lock = 0;
-
-    if (opal_atomic_swap_32 (&lock, 1)) {
-        return NULL;
-    }
 
     if (VADER_FIFO_FREE == fifo->fifo_head) {
-        lock = 0;
         return NULL;
     }
 
@@ -113,13 +131,7 @@ static inline mca_btl_vader_hdr_t *vader_fifo_read (vader_fifo_t *fifo, struct m
     *ep = &mca_btl_vader_component.endpoints[value >> MCA_BTL_VADER_OFFSET_BITS];
     hdr = (mca_btl_vader_hdr_t *) relative2virtual (value);
 
-    if (OPAL_UNLIKELY(!(hdr->flags & MCA_BTL_VADER_FLAG_COMPLETE) && ((*ep)->expected_sequence != hdr->seqn))) {
-        lock = 0;
-        return NULL;
-    }
-
     fifo->fifo_head = VADER_FIFO_FREE;
-    ++(*ep)->expected_sequence;
 
     assert (hdr->next != value);
 
@@ -138,16 +150,14 @@ static inline mca_btl_vader_hdr_t *vader_fifo_read (vader_fifo_t *fifo, struct m
     }
 
     opal_atomic_wmb ();
-    lock = 0;
     return hdr; 
 }
 
-static inline int vader_fifo_init (vader_fifo_t *fifo)
+static inline void vader_fifo_init (vader_fifo_t *fifo)
 {
     fifo->fifo_head = fifo->fifo_tail = VADER_FIFO_FREE;
+    fifo->fbox_available = mca_btl_vader_component.fbox_max;
     mca_btl_vader_component.my_fifo = fifo;
-
-    return OMPI_SUCCESS;
 }
 
 static inline void vader_fifo_write (vader_fifo_t *fifo, fifo_value_t value)
@@ -170,15 +180,44 @@ static inline void vader_fifo_write (vader_fifo_t *fifo, fifo_value_t value)
     opal_atomic_wmb ();
 }
 
-/* write a frag (relative to this process' base) to another rank's fifo */
-static inline void vader_fifo_write_ep (mca_btl_vader_hdr_t *hdr, struct mca_btl_base_endpoint_t *ep)
+/**
+ * vader_fifo_write_ep:
+ *
+ * @brief write a frag (relative to this process' base) to another rank's fifo
+ *
+ * @param[in]  hdr - fragment header to write
+ * @param[in]  ep  - endpoint to write the fragment to
+ *
+ * This function is used to send a fragment to a remote peer. {hdr} must belong
+ * to the current process.
+ */
+static inline bool vader_fifo_write_ep (mca_btl_vader_hdr_t *hdr, struct mca_btl_base_endpoint_t *ep)
 {
+    fifo_value_t rhdr = virtual2relative ((char *) hdr);
+    if (ep->fbox_out.buffer) {
+        /* if there is a fast box for this peer then use the fast box to send the fragment header.
+         * this is done to ensure fragment ordering */
+        opal_atomic_wmb ();
+        return mca_btl_vader_fbox_sendi (ep, 0xfe, &rhdr, sizeof (rhdr), NULL, 0);
+    }
+    mca_btl_vader_try_fbox_setup (ep, hdr);
     hdr->next = VADER_FIFO_FREE;
-    hdr->seqn = ep->next_sequence++;
-    vader_fifo_write (ep->fifo, virtual2relative ((char *) hdr));
+    vader_fifo_write (ep->fifo, rhdr);
+
+    return true;
 }
 
-/* write a frag (relative to the remote process' base) to the remote fifo. note the remote peer must own hdr */
+/**
+ * vader_fifo_write_back:
+ *
+ * @brief write a frag (relative to the remote process' base) to the remote fifo
+ *
+ * @param[in]  hdr - fragment header to write
+ * @param[in]  ep  - endpoint the fragment belongs to
+ *
+ * This function is used to return a fragment to the sending process. It differs from vader_fifo_write_ep
+ * in that it uses the {ep} to produce the relative address.
+ */
 static inline void vader_fifo_write_back (mca_btl_vader_hdr_t *hdr, struct mca_btl_base_endpoint_t *ep)
 {
     hdr->next = VADER_FIFO_FREE;

--- a/ompi/mca/btl/vader/btl_vader_frag.h
+++ b/ompi/mca/btl/vader/btl_vader_frag.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -30,45 +30,73 @@ enum {
     MCA_BTL_VADER_FLAG_INLINE      = 0,
     MCA_BTL_VADER_FLAG_SINGLE_COPY = 1,
     MCA_BTL_VADER_FLAG_COMPLETE    = 2,
+    MCA_BTL_VADER_FLAG_SETUP_FBOX  = 4,
 };
 
 struct mca_btl_vader_frag_t;
 struct mca_btl_vader_fbox_t;
 
+/**
+ * FIFO fragment header
+ */
 struct mca_btl_vader_hdr_t {
-    volatile intptr_t next; /* next item in fifo. many peers may touch this */
+    /** next item in fifo. many peers may touch this */
+    volatile intptr_t next;
+    /** pointer back the the fragment */
     struct mca_btl_vader_frag_t *frag;
-    mca_btl_base_tag_t tag; /* tag associated with this fragment (used to lookup callback) */
-    uint8_t flags;          /* vader send flags */
-    uint16_t seqn;
-    int32_t len;            /* length of data following this header */
-    struct iovec sc_iov;    /* io vector containing pointer to single-copy data */
+    /** tag associated with this fragment (used to lookup callback) */
+    mca_btl_base_tag_t tag;
+    /** vader send flags (inline, complete, setup fbox, etc) */
+    uint8_t flags;
+    /** length of data following this header */
+    int32_t len;
+    /** io vector containing pointer to single-copy data */
+    struct iovec sc_iov;
+    /** if the fragment indicates to setup a fast box the base is stored here */
+    intptr_t fbox_base;
 };
 typedef struct mca_btl_vader_hdr_t mca_btl_vader_hdr_t;
+
+struct mca_btl_vader_segment_t {
+    mca_btl_base_segment_t base;
+#if OMPI_BTL_VADER_HAVE_KNEM
+    uint64_t cookie;
+#endif
+};
+typedef struct mca_btl_vader_segment_t mca_btl_vader_segment_t;
 
 /**
  * shared memory send fragment derived type.
  */
 struct mca_btl_vader_frag_t {
+    /** base object */
     mca_btl_base_descriptor_t base;
-    mca_btl_base_segment_t segments[2];
+    /** storage for segment data (max 2) */
+    mca_btl_vader_segment_t segments[2];
+    /** endpoint this fragment is active on */
     struct mca_btl_base_endpoint_t *endpoint;
-    struct mca_btl_vader_fbox_t *fbox;
-    mca_btl_vader_hdr_t *hdr; /* in the shared memory region */
+    /** fast box in use (or NULL) */
+    unsigned char * restrict fbox;
+    /** fragment header (in the shared memory region) */
+    mca_btl_vader_hdr_t *hdr;
+    /** free list this fragment was allocated within */
     ompi_free_list_t *my_list;
+#if OMPI_BTL_VADER_HAVE_KNEM
+    uint64_t cookie;
+#endif
 };
 
 typedef struct mca_btl_vader_frag_t mca_btl_vader_frag_t;
 
 static inline int mca_btl_vader_frag_alloc (mca_btl_vader_frag_t **frag, ompi_free_list_t *list,
-                              struct mca_btl_base_endpoint_t *endpoint) {
+                                            struct mca_btl_base_endpoint_t *endpoint) {
     ompi_free_list_item_t *item;
 
     OMPI_FREE_LIST_GET_MT(list, item);
     *frag = (mca_btl_vader_frag_t *) item;
     if (OPAL_LIKELY(NULL != item)) {
-        if (NULL == (*frag)->hdr) {
-            OMPI_FREE_LIST_RETURN_MT(list, (ompi_free_list_item_t *)*frag);
+        if (OPAL_UNLIKELY(NULL == (*frag)->hdr)) {
+            OMPI_FREE_LIST_RETURN_MT(list, item);
             *frag = NULL;
             return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
         }
@@ -79,15 +107,39 @@ static inline int mca_btl_vader_frag_alloc (mca_btl_vader_frag_t **frag, ompi_fr
     return OMPI_SUCCESS;
 }
 
+static inline int mca_btl_vader_frag_alloc_rdma (mca_btl_vader_frag_t **frag, ompi_free_list_t *list,
+                                                 struct mca_btl_base_endpoint_t *endpoint) {
+    ompi_free_list_item_t *item;
+
+    OMPI_FREE_LIST_GET_MT(list, item);
+    *frag = (mca_btl_vader_frag_t *) item;
+    if (OPAL_LIKELY(NULL != item)) {
+        (*frag)->endpoint = endpoint;
+    }
+
+    return OMPI_SUCCESS;
+}
+
 static inline void mca_btl_vader_frag_return (mca_btl_vader_frag_t *frag)
 {
-    frag->hdr->flags = 0;
-    frag->segments[0].seg_addr.pval = (char *)(frag->hdr + 1);
-    frag->base.des_src     = frag->segments;
+    if (frag->hdr) {
+        frag->hdr->flags = 0;
+        frag->segments[0].base.seg_addr.pval = (char *)(frag->hdr + 1);
+    }
+
+    frag->base.des_src = &frag->segments->base;
     frag->base.des_src_cnt = 1;
-    frag->base.des_dst     = frag->segments;
+    frag->base.des_dst = &frag->segments->base;
     frag->base.des_dst_cnt = 1;
     frag->fbox = NULL;
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+    if (frag->cookie) {
+        /* NTH: explicity ignore the return code. Don't care about this cookie anymore anyway. */
+        (void) ioctl(mca_btl_vader.knem_fd, KNEM_CMD_DESTROY_REGION, &frag->cookie);
+        frag->cookie = 0;
+    }
+#endif
 
     OMPI_FREE_LIST_RETURN_MT(frag->my_list, (ompi_free_list_item_t *)frag);
 }
@@ -97,13 +149,14 @@ OBJ_CLASS_DECLARATION(mca_btl_vader_frag_t);
 #define MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint)                  \
     mca_btl_vader_frag_alloc (&(frag), &mca_btl_vader_component.vader_frags_eager, endpoint)
 
-#if !OMPI_BTL_VADER_HAVE_XPMEM
 #define MCA_BTL_VADER_FRAG_ALLOC_MAX(frag, endpoint)                    \
     mca_btl_vader_frag_alloc (&(frag), &mca_btl_vader_component.vader_frags_max_send, endpoint)
-#endif
 
 #define MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint)                   \
     mca_btl_vader_frag_alloc (&(frag), &mca_btl_vader_component.vader_frags_user, endpoint)
+
+#define MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint)                   \
+    mca_btl_vader_frag_alloc_rdma (&(frag), &mca_btl_vader_component.vader_frags_rdma, endpoint)
 
 #define MCA_BTL_VADER_FRAG_RETURN(frag) mca_btl_vader_frag_return(frag)
 
@@ -111,8 +164,7 @@ OBJ_CLASS_DECLARATION(mca_btl_vader_frag_t);
 static inline void mca_btl_vader_frag_complete (mca_btl_vader_frag_t *frag) {
     if (OPAL_UNLIKELY(MCA_BTL_DES_SEND_ALWAYS_CALLBACK & frag->base.des_flags)) {
         /* completion callback */
-        frag->base.des_cbfunc(&mca_btl_vader.super, frag->endpoint,
-                              &frag->base, OMPI_SUCCESS);
+        frag->base.des_cbfunc (&mca_btl_vader.super, frag->endpoint, &frag->base, OMPI_SUCCESS);
     }
 
     if (OPAL_LIKELY(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) {

--- a/ompi/mca/btl/vader/btl_vader_get.c
+++ b/ompi/mca/btl/vader/btl_vader_get.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2010-2013 Los Alamos National Security, LLC.  
- *                         All rights reserved. 
+ * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,9 +33,9 @@
  * @param descriptor (IN)  Description of the data to be transferred
  */
 #if OMPI_BTL_VADER_HAVE_XPMEM
-int mca_btl_vader_get (struct mca_btl_base_module_t *btl,
-                       struct mca_btl_base_endpoint_t *endpoint,
-                       struct mca_btl_base_descriptor_t *des)
+int mca_btl_vader_get_xpmem (struct mca_btl_base_module_t *btl,
+                             struct mca_btl_base_endpoint_t *endpoint,
+                             struct mca_btl_base_descriptor_t *des)
 {
     mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
     mca_btl_base_segment_t *src = des->des_src;
@@ -53,14 +53,20 @@ int mca_btl_vader_get (struct mca_btl_base_module_t *btl,
 
     vader_return_registration (reg, endpoint);
 
+    /* always call the callback function */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
+    frag->endpoint = endpoint;
     mca_btl_vader_frag_complete (frag);
 
     return OMPI_SUCCESS;
 }
-#elif OMPI_BTL_VADER_HAVE_CMA
-int mca_btl_vader_get (struct mca_btl_base_module_t *btl,
-                       struct mca_btl_base_endpoint_t *endpoint,
-                       struct mca_btl_base_descriptor_t *des)
+#endif
+
+#if OMPI_BTL_VADER_HAVE_CMA
+int mca_btl_vader_get_cma (struct mca_btl_base_module_t *btl,
+                           struct mca_btl_base_endpoint_t *endpoint,
+                           struct mca_btl_base_descriptor_t *des)
 {
     mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
     mca_btl_base_segment_t *src = des->des_src;
@@ -70,12 +76,68 @@ int mca_btl_vader_get (struct mca_btl_base_module_t *btl,
     struct iovec dst_iov = {.iov_base = dst->seg_addr.pval, .iov_len = size};
     ssize_t ret;
 
-    ret = process_vm_readv (endpoint->seg_ds.seg_cpid, &dst_iov, 1, &src_iov, 1, 0);
-    if (ret != size) {
-        fprintf (stderr, "Read %d, expected %u, errno = %d\n", ret, size, errno);
+    ret = process_vm_readv (endpoint->segment_data.other.seg_ds->seg_cpid, &dst_iov, 1, &src_iov, 1, 0);
+    if (ret != (ssize_t)size) {
+        opal_output(0, "Read %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno);
         return OMPI_ERROR;
     }
 
+    /* always call the callback function */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
+    frag->endpoint = endpoint;
+    mca_btl_vader_frag_complete (frag);
+
+    return OMPI_SUCCESS;
+}
+#endif
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+int mca_btl_vader_get_knem (struct mca_btl_base_module_t *btl,
+                            struct mca_btl_base_endpoint_t *endpoint,
+                            struct mca_btl_base_descriptor_t *des)
+{
+    mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
+    mca_btl_vader_segment_t *src = (mca_btl_vader_segment_t *) des->des_src;
+    mca_btl_vader_segment_t *dst = (mca_btl_vader_segment_t *) des->des_dst;
+    const size_t size = min(dst->base.seg_len, src->base.seg_len);
+    struct knem_cmd_param_iovec recv_iovec;
+    struct knem_cmd_inline_copy icopy;
+
+    /* Fill in the ioctl data fields.  There's no async completion, so
+       we don't need to worry about getting a slot, etc. */
+    recv_iovec.base = (uintptr_t) dst->base.seg_addr.lval;
+    recv_iovec.len = size;
+    icopy.local_iovec_array = (uintptr_t) &recv_iovec;
+    icopy.local_iovec_nr    = 1;
+    icopy.remote_cookie     = src->cookie;
+    icopy.remote_offset     = 0;
+    icopy.write             = 0;
+    icopy.flags             = 0;
+
+    /* Use the DMA flag if knem supports it *and* the segment length
+     * is greater than the cutoff. Not that if DMA is not supported
+     * or the user specified 0 for knem_dma_min the knem_dma_min was
+     * set to UINT_MAX in mca_btl_vader_knem_init. */
+    if (mca_btl_vader_component.knem_dma_min <= dst->base.seg_len) {
+        icopy.flags = KNEM_FLAG_DMA;
+    }
+    /* synchronous flags only, no need to specify icopy.async_status_index */
+
+    /* When the ioctl returns, the transfer is done and we can invoke
+       the btl callback and return the frag */
+    if (OPAL_UNLIKELY(0 != ioctl (mca_btl_vader.knem_fd, KNEM_CMD_INLINE_COPY, &icopy))) {
+        return OMPI_ERROR;
+    }
+
+    if (KNEM_STATUS_FAILED == icopy.current_status) {
+        return OMPI_ERROR;
+    }
+
+    /* always call the callback function */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
+    frag->endpoint = endpoint;
     mca_btl_vader_frag_complete (frag);
 
     return OMPI_SUCCESS;

--- a/ompi/mca/btl/vader/btl_vader_knem.c
+++ b/ompi/mca/btl/vader/btl_vader_knem.c
@@ -1,0 +1,101 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "btl_vader.h"
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "opal/util/show_help.h"
+
+int mca_btl_vader_knem_init (void)
+{
+    struct knem_cmd_info knem_info;
+    int rc;
+
+    /* Open the knem device.  Try to print a helpful message if we
+       fail to open it. */
+    mca_btl_vader.knem_fd = open("/dev/knem", O_RDWR);
+    if (mca_btl_vader.knem_fd < 0) {
+	if (EACCES == errno) {
+	    struct stat sbuf;
+	    if (0 != stat("/dev/knem", &sbuf)) {
+		sbuf.st_mode = 0;
+	    }
+	    opal_show_help("help-btl-vader.txt", "knem permission denied",
+			   true, ompi_process_info.nodename, sbuf.st_mode);
+	} else {
+	    opal_show_help("help-btl-vader.txt", "knem fail open",
+			   true, ompi_process_info.nodename, errno,
+			   strerror(errno));
+	}
+
+	return OMPI_ERR_NOT_AVAILABLE;
+    }
+
+    do {
+	/* Check that the ABI if kernel module running is the same
+	 * as what we were compiled against. */
+	rc = ioctl(mca_btl_vader.knem_fd, KNEM_CMD_GET_INFO, &knem_info);
+	if (rc < 0) {
+	    opal_show_help("help-btl-vader.txt", "knem get ABI fail",
+			   true, ompi_process_info.nodename, errno,
+			   strerror(errno));
+	    break;
+	}
+
+	if (KNEM_ABI_VERSION != knem_info.abi) {
+	    opal_show_help("help-btl-vader.txt", "knem ABI mismatch",
+			   true, ompi_process_info.nodename, KNEM_ABI_VERSION,
+			   knem_info.abi);
+	    break;
+	}
+
+	if (!(mca_btl_vader_component.knem_dma_min && (knem_info.features & KNEM_FEATURE_DMA))) {
+	    /* disable DMA */
+	    mca_btl_vader_component.knem_dma_min = UINT_MAX;
+	}
+
+	/* TODO: add async support */
+
+	/* knem set up successfully */
+	mca_btl_vader.super.btl_get = mca_btl_vader_get_knem;
+	mca_btl_vader.super.btl_put = mca_btl_vader_put_knem;
+
+	return OMPI_SUCCESS;
+    } while (0);
+
+    mca_btl_vader_knem_fini ();
+
+    return OMPI_ERR_NOT_AVAILABLE;;
+}
+
+int mca_btl_vader_knem_fini (void)
+{
+    if (-1 != mca_btl_vader.knem_fd) {
+	close (mca_btl_vader.knem_fd);
+	mca_btl_vader.knem_fd = -1;
+    }
+
+    return OMPI_SUCCESS;
+}
+
+int mca_btl_vader_knem_progress (void)
+{
+    /* NTH: does nothing until async support is added */
+    return OMPI_SUCCESS;
+}
+
+#endif

--- a/ompi/mca/btl/vader/btl_vader_knem.h
+++ b/ompi/mca/btl/vader/btl_vader_knem.h
@@ -1,0 +1,26 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(BTL_VADER_KNEM_H)
+#define BTL_VADER_KNEM_H
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+
+#include <knem_io.h>
+#include <sys/mman.h>
+
+int mca_btl_vader_knem_init (void);
+int mca_btl_vader_knem_fini (void);
+int mca_btl_vader_knem_progress (void);
+
+#endif /* OMPI_BTL_VADER_HAVE_KNEM */
+
+#endif /* defined(BTL_VADER_KNEM_H) */

--- a/ompi/mca/btl/vader/btl_vader_module.c
+++ b/ompi/mca/btl/vader/btl_vader_module.c
@@ -14,6 +14,9 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +30,7 @@
 #include "btl_vader_endpoint.h"
 #include "btl_vader_fifo.h"
 #include "btl_vader_fbox.h"
+#include "btl_vader_xpmem.h"
 
 #include <string.h>
 
@@ -81,13 +85,6 @@ mca_btl_vader_t mca_btl_vader = {
         .btl_prepare_dst = vader_prepare_dst,
         .btl_send = mca_btl_vader_send,
         .btl_sendi = mca_btl_vader_sendi,
-
-        /* only support RDMA if we have CMA or XPMEM */
-#if OMPI_BTL_VADER_HAVE_XPMEM || OMPI_BTL_VADER_HAVE_CMA
-        .btl_put = mca_btl_vader_put,
-        .btl_get = mca_btl_vader_get,
-#endif
-
         .btl_dump = mca_btl_base_dump,
         .btl_register_error = vader_register_error_cb,
         .btl_ft_event = vader_ft_event
@@ -102,11 +99,31 @@ static int vader_btl_first_time_init(mca_btl_vader_t *vader_btl, int n)
     /* generate the endpoints */
     component->endpoints = (struct mca_btl_base_endpoint_t *) calloc (n + 1, sizeof (struct mca_btl_base_endpoint_t));
     component->endpoints[n].peer_smp_rank = -1;
+    component->fbox_in_endpoints = calloc (n + 1, sizeof (void *));
 
-    component->segment_offset = (n - 1) * MCA_BTL_VADER_FBOX_PEER_SIZE + MCA_BTL_VADER_FIFO_SIZE;
+    if (NULL == component->endpoints || NULL == component->fbox_in_endpoints) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    component->segment_offset = MCA_BTL_VADER_FIFO_SIZE;
 
     /* initialize fragment descriptor free lists */
-    /* initialize free list for put/get/single copy/inline fragments */
+    /* initialize free list for single copy (get, put) */
+    if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
+        rc = ompi_free_list_init_ex_new (&component->vader_frags_rdma,
+                                         sizeof(mca_btl_vader_frag_t), 8,
+                                         OBJ_CLASS(mca_btl_vader_frag_t),
+                                         0, opal_cache_line_size,
+                                         component->vader_free_list_num,
+                                         component->vader_free_list_max,
+                                         component->vader_free_list_inc,
+                                         NULL, mca_btl_vader_frag_init, (void *) 0);
+        if (OMPI_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    /* initialize free list for small send and inline fragments */
     rc = ompi_free_list_init_ex_new(&component->vader_frags_user, 
                                     sizeof(mca_btl_vader_frag_t),
                                     opal_cache_line_size, OBJ_CLASS(mca_btl_vader_frag_t),
@@ -115,8 +132,7 @@ static int vader_btl_first_time_init(mca_btl_vader_t *vader_btl, int n)
                                     component->vader_free_list_max,
                                     component->vader_free_list_inc,
                                     NULL, mca_btl_vader_frag_init,
-                                    (void *) (sizeof(mca_btl_vader_hdr_t) +
-                                              mca_btl_vader_component.max_inline_send));
+                                    (void *)(intptr_t) mca_btl_vader_component.max_inline_send);
     if (OMPI_SUCCESS != rc) {
         return rc;
     }
@@ -130,28 +146,26 @@ static int vader_btl_first_time_init(mca_btl_vader_t *vader_btl, int n)
                                     component->vader_free_list_max,
                                     component->vader_free_list_inc,
                                     NULL, mca_btl_vader_frag_init,
-                                    (void *) (sizeof (mca_btl_vader_hdr_t) +
-                                              mca_btl_vader.super.btl_eager_limit));
+                                    (void *)(intptr_t) mca_btl_vader.super.btl_eager_limit);
     if (OMPI_SUCCESS != rc) {
         return rc;
     }
 
-#if !OMPI_BTL_VADER_HAVE_XPMEM
-    /* initialize free list for buffered send fragments */
-    rc = ompi_free_list_init_ex_new(&component->vader_frags_max_send,
-                                    sizeof (mca_btl_vader_frag_t),
-                                    opal_cache_line_size, OBJ_CLASS(mca_btl_vader_frag_t),
-                                    0, opal_cache_line_size,
-                                    component->vader_free_list_num,
-                                    component->vader_free_list_max,
-                                    component->vader_free_list_inc,
-                                    NULL, mca_btl_vader_frag_init,
-                                    (void *) (sizeof (mca_btl_vader_hdr_t) +
-                                              mca_btl_vader.super.btl_max_send_size));
-    if (OMPI_SUCCESS != rc) {
-        return rc;
+    if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
+        /* initialize free list for buffered send fragments */
+        rc = ompi_free_list_init_ex_new(&component->vader_frags_max_send,
+                                        sizeof (mca_btl_vader_frag_t),
+                                        opal_cache_line_size, OBJ_CLASS(mca_btl_vader_frag_t),
+                                        0, opal_cache_line_size,
+                                        component->vader_free_list_num,
+                                        component->vader_free_list_max,
+                                        component->vader_free_list_inc,
+                                        NULL, mca_btl_vader_frag_init,
+                                        (void *)(intptr_t) mca_btl_vader.super.btl_max_send_size);
+        if (OMPI_SUCCESS != rc) {
+            return rc;
+        }
     }
-#endif
 
     /* set flag indicating btl has been inited */
     vader_btl->btl_inited = true;
@@ -161,12 +175,12 @@ static int vader_btl_first_time_init(mca_btl_vader_t *vader_btl, int n)
 
 
 static int init_vader_endpoint (struct mca_btl_base_endpoint_t *ep, struct ompi_proc_t *proc, int remote_rank) {
-    const int fbox_in_offset = MCA_BTL_VADER_LOCAL_RANK - (MCA_BTL_VADER_LOCAL_RANK > remote_rank);
-    const int fbox_out_offset = remote_rank - (MCA_BTL_VADER_LOCAL_RANK < remote_rank);
     mca_btl_vader_component_t *component = &mca_btl_vader_component;
-    struct vader_modex_t *modex;
+    union vader_modex_t *modex;
     size_t msg_size;
     int rc;
+
+    OBJ_CONSTRUCT(ep, mca_btl_vader_endpoint_t);
 
     ep->peer_smp_rank = remote_rank;
 
@@ -178,36 +192,35 @@ static int init_vader_endpoint (struct mca_btl_base_endpoint_t *ep, struct ompi_
 
         /* attatch to the remote segment */
 #if OMPI_BTL_VADER_HAVE_XPMEM
-        /* always use xpmem if it is available */
-        ep->apid = xpmem_get (modex->seg_id, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
-        ep->rcache = mca_rcache_base_module_create("vma");
-        (void) vader_get_registation (ep, modex->segment_base, mca_btl_vader_component.segment_size,
-                                      MCA_MPOOL_FLAGS_PERSIST, (void **) &ep->segment_base);
-#else
-        int offset = offsetof (opal_shmem_ds_t, seg_name);
+        if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+            /* always use xpmem if it is available */
+            ep->segment_data.xpmem.apid = xpmem_get (modex->xpmem.seg_id, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
+            ep->segment_data.xpmem.rcache = mca_rcache_base_module_create("vma");
+            (void) vader_get_registation (ep, modex->xpmem.segment_base, mca_btl_vader_component.segment_size,
+                                          MCA_MPOOL_FLAGS_PERSIST, (void **) &ep->segment_base);
+        } else {
+#endif
+            /* store a copy of the segment information for detach */
+            ep->segment_data.other.seg_ds = malloc (sizeof (opal_shmem_ds_t));
+            if (NULL == ep->segment_data.other.seg_ds) {
+                return OMPI_ERR_OUT_OF_RESOURCE;
+            }
 
-        memcpy (&ep->seg_ds, modex->buffer, offset);
-        memcpy (&ep->seg_ds.seg_base_addr, modex->buffer + offset, sizeof (ep->seg_ds.seg_base_addr));
-        offset += sizeof (ep->seg_ds.seg_base_addr);
-        strncpy (ep->seg_ds.seg_name, modex->buffer + offset, OPAL_PATH_MAX);
+            ep->segment_data.other.seg_ds->seg_base_addr = modex->shmem.segment_base;
+            msg_size -= sizeof (modex->shmem.segment_base);
 
-        ep->segment_base = opal_shmem_segment_attach (&ep->seg_ds);
-        if (NULL == ep->segment_base) {
-            return rc;
+            memcpy (ep->segment_data.other.seg_ds, modex->shmem.buffer, msg_size);
+
+            ep->segment_base = opal_shmem_segment_attach (ep->segment_data.other.seg_ds);
+            if (NULL == ep->segment_base) {
+                return OMPI_ERROR;
+            }
+#if OMPI_BTL_VADER_HAVE_XPMEM
         }
 #endif
+        OBJ_CONSTRUCT(&ep->lock, opal_mutex_t);
 
         free (modex);
-
-        ep->next_fbox_out = 0;
-        ep->next_fbox_in  = 0;
-        ep->next_sequence = 0;
-        ep->expected_sequence = 0;
-
-        ep->fbox_in  = (struct mca_btl_vader_fbox_t * restrict) (ep->segment_base + MCA_BTL_VADER_FIFO_SIZE +
-                                                                 fbox_in_offset * MCA_BTL_VADER_FBOX_PEER_SIZE);
-        ep->fbox_out = (struct mca_btl_vader_fbox_t * restrict) (component->my_segment + MCA_BTL_VADER_FIFO_SIZE +
-                                                                 fbox_out_offset * MCA_BTL_VADER_FBOX_PEER_SIZE);
     } else {
         /* set up the segment base so we can calculate a virtual to real for local pointers */
         ep->segment_base = component->my_segment;
@@ -220,36 +233,10 @@ static int init_vader_endpoint (struct mca_btl_base_endpoint_t *ep, struct ompi_
 
 static int fini_vader_endpoint (struct mca_btl_base_endpoint_t *ep)
 {
-
-    if (NULL != ep->fbox_out) {
-#if OMPI_BTL_VADER_HAVE_XPMEM
-        if (ep->rcache) {
-            /* clean out the registration cache */
-            const int nregs = 100;
-            mca_mpool_base_registration_t *regs[nregs];
-            int reg_cnt;
-
-            do {
-                reg_cnt = ep->rcache->rcache_find_all(ep->rcache, 0, (size_t)-1,
-                                                      regs, nregs);
-
-                for (int i = 0 ; i < reg_cnt ; ++i) {
-                    /* otherwise dereg will fail on assert */
-                    regs[i]->ref_count = 0;
-                    OBJ_RELEASE(regs[i]);
-                }
-            } while (reg_cnt == nregs);
-
-            ep->rcache = NULL;
-        }
-        xpmem_release (ep->apid);
-#else
-        opal_shmem_segment_detach (&ep->seg_ds);
-#endif
+    /* check if the endpoint is initialized. avoids a double-destruct */
+    if (ep->fifo) {
+        OBJ_DESTRUCT(ep);
     }
-
-    ep->fbox_in = ep->fbox_out = NULL;
-    ep->segment_base = NULL;
 
     return OMPI_SUCCESS;
 }
@@ -275,8 +262,8 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
 {
     mca_btl_vader_component_t *component = &mca_btl_vader_component;
     mca_btl_vader_t *vader_btl = (mca_btl_vader_t *) btl;
-    ompi_proc_t *my_proc;
-    int rc;
+    const ompi_proc_t *my_proc;
+    int rc = OMPI_SUCCESS;
 
     /* initializion */
 
@@ -314,17 +301,20 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
         if (my_proc != procs[proc]) {
             /* add this proc to shared memory accessibility list */
             rc = opal_bitmap_set_bit (reachability, proc);
-            if(OMPI_SUCCESS != rc) {
+            if(OPAL_SUCCESS != rc) {
                 return rc;
             }
         }
 
         /* setup endpoint */
         peers[proc] = component->endpoints + local_rank;
-        init_vader_endpoint (peers[proc], procs[proc], local_rank++);
+        rc = init_vader_endpoint (peers[proc], procs[proc], local_rank++);
+        if (OMPI_SUCCESS != rc) {
+            break;
+        }
     }
 
-    return OMPI_SUCCESS;
+    return rc;
 }
 
 /**
@@ -379,12 +369,17 @@ static int vader_finalize(struct mca_btl_base_module_t *btl)
     }
 
     free (component->endpoints);
+    component->endpoints = NULL;
+
     vader_btl->btl_inited = false;
 
-#if !OMPI_BTL_VADER_HAVE_XPMEM
-    opal_shmem_unlink (&mca_btl_vader_component.seg_ds);
-    opal_shmem_segment_detach (&mca_btl_vader_component.seg_ds);
-#endif
+    free (component->fbox_in_endpoints);
+    component->fbox_in_endpoints = NULL;
+
+    if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
+        opal_shmem_unlink (&mca_btl_vader_component.seg_ds);
+        opal_shmem_segment_detach (&mca_btl_vader_component.seg_ds);
+    }
 
     return OMPI_SUCCESS;
 }
@@ -420,15 +415,13 @@ mca_btl_base_descriptor_t *mca_btl_vader_alloc(struct mca_btl_base_module_t *btl
         (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
     } else if (size <= mca_btl_vader.super.btl_eager_limit) {
         (void) MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint);
-    }
-#if !OMPI_BTL_VADER_HAVE_XPMEM
-    else if (size <= mca_btl_vader.super.btl_max_send_size) {
+    } else if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism &&
+               size <= mca_btl_vader.super.btl_max_send_size) {
         (void) MCA_BTL_VADER_FRAG_ALLOC_MAX(frag, endpoint);
     }
-#endif
 
     if (OPAL_LIKELY(frag != NULL)) {
-        frag->segments[0].seg_len  = size;
+        frag->segments[0].base.seg_len  = size;
 
         frag->base.des_flags   = flags;
         frag->base.order       = order;
@@ -460,15 +453,38 @@ struct mca_btl_base_descriptor_t *vader_prepare_dst(struct mca_btl_base_module_t
     mca_btl_vader_frag_t *frag;
     void *data_ptr;
 
-    (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
+    (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
     if (OPAL_UNLIKELY(NULL == frag)) {
         return NULL;
     }
-    
+
     opal_convertor_get_current_pointer (convertor, &data_ptr);
 
-    frag->segments[0].seg_addr.lval = (uint64_t)(uintptr_t) data_ptr;
-    frag->segments[0].seg_len       = *size;
+    frag->segments[0].base.seg_addr.lval = (uint64_t)(uintptr_t) data_ptr;
+    frag->segments[0].base.seg_len       = *size;
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+    if (MCA_BTL_VADER_KNEM == mca_btl_vader_component.single_copy_mechanism) {
+        struct knem_cmd_create_region knem_cr;
+        struct knem_cmd_param_iovec knem_iov;
+
+        knem_iov.base = (uintptr_t) data_ptr;
+        knem_iov.len = *size;
+
+        knem_cr.iovec_array = (uintptr_t) &knem_iov;
+        knem_cr.iovec_nr = 1;
+        knem_cr.protection = PROT_WRITE;
+        /* Vader will explicitly destroy this cookie */
+        knem_cr.flags = 0;
+        if (OPAL_UNLIKELY(ioctl(mca_btl_vader.knem_fd, KNEM_CMD_CREATE_REGION, &knem_cr) < 0)) {
+            MCA_BTL_VADER_FRAG_RETURN(frag);
+            return NULL;
+        }
+
+        frag->segments[0].cookie = knem_cr.cookie;
+        frag->cookie = knem_cr.cookie;
+    }
+#endif /* OMPI_BTL_SM_HAVE_KNEM */
     
     frag->base.order       = order;
     frag->base.des_flags   = flags;
@@ -489,8 +505,8 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
                                                             uint32_t flags)
 {
     const size_t total_size = reserve + *size;
-    mca_btl_vader_fbox_t *fbox;
     mca_btl_vader_frag_t *frag;
+    unsigned char *fbox;
     void *data_ptr;
     int rc;
 
@@ -503,12 +519,11 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
             struct iovec iov;
 
             /* non-contiguous data requires the convertor */
-#if !OMPI_BTL_VADER_HAVE_XPMEM
-            if (total_size > mca_btl_vader.super.btl_eager_limit) {
+            if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism &&
+                total_size > mca_btl_vader.super.btl_eager_limit) {
                 (void) MCA_BTL_VADER_FRAG_ALLOC_MAX(frag, endpoint);
             } else
-#endif
-            (void) MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint);
+                (void) MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint);
 
             if (OPAL_UNLIKELY(NULL == frag)) {
                 return NULL;
@@ -516,7 +531,7 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
 
             iov.iov_len = *size;
             iov.iov_base =
-                (IOVBASE_TYPE *)(((uintptr_t)(frag->segments[0].seg_addr.pval)) +
+                (IOVBASE_TYPE *)(((uintptr_t)(frag->segments[0].base.seg_addr.pval)) +
                                  reserve);
 
             rc = opal_convertor_pack (convertor, &iov, &iov_count, size);
@@ -525,24 +540,25 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
                 return NULL;
             }
 
-            frag->segments[0].seg_len = *size + reserve;
+            frag->segments[0].base.seg_len = *size + reserve;
         } else {
-#if !OMPI_BTL_VADER_HAVE_XPMEM
-            if (OPAL_LIKELY(total_size <= mca_btl_vader.super.btl_eager_limit)) {
-                (void) MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint);
-            } else {
-                (void) MCA_BTL_VADER_FRAG_ALLOC_MAX(frag, endpoint);
-            }
-#else
-            (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
-#endif
+            if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
+                if (OPAL_LIKELY(total_size <= mca_btl_vader.super.btl_eager_limit)) {
+                    (void) MCA_BTL_VADER_FRAG_ALLOC_EAGER(frag, endpoint);
+                } else {
+                    (void) MCA_BTL_VADER_FRAG_ALLOC_MAX(frag, endpoint);
+                }
+            } else
+                (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
+
             if (OPAL_UNLIKELY(NULL == frag)) {
                 return NULL;
             }
 
 #if OMPI_BTL_VADER_HAVE_XPMEM
             /* use xpmem to send this segment if it is above the max inline send size */
-            if (OPAL_UNLIKELY(total_size > (size_t) mca_btl_vader_component.max_inline_send)) {
+            if (OPAL_UNLIKELY(MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism &&
+                total_size > (size_t) mca_btl_vader_component.max_inline_send)) {
                 /* single copy send */
                 frag->hdr->flags = MCA_BTL_VADER_FLAG_SINGLE_COPY;
 
@@ -550,9 +566,9 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
                 frag->hdr->sc_iov.iov_base = data_ptr;
                 frag->hdr->sc_iov.iov_len  = *size;
 
-                frag->segments[0].seg_len = reserve;
-                frag->segments[1].seg_len = *size;
-                frag->segments[1].seg_addr.pval = data_ptr;
+                frag->segments[0].base.seg_len = reserve;
+                frag->segments[1].base.seg_len = *size;
+                frag->segments[1].base.seg_addr.pval = data_ptr;
                 frag->base.des_src_cnt = 2;
             } else {
 #endif
@@ -563,29 +579,50 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
                      * fragment does not belong to the caller */
                     fbox = mca_btl_vader_reserve_fbox (endpoint, total_size);
                     if (OPAL_LIKELY(fbox)) {
-                        frag->segments[0].seg_addr.pval = fbox->data;
+                        frag->segments[0].base.seg_addr.pval = fbox;
                     }
 
                     frag->fbox = fbox;
                 }
 
                 /* NTH: the covertor adds some latency so we bypass it here */
-                vader_memmove ((void *)((uintptr_t)frag->segments[0].seg_addr.pval + reserve),
-                               data_ptr, *size);
-                frag->segments[0].seg_len = total_size;
+                memcpy ((void *)((uintptr_t)frag->segments[0].base.seg_addr.pval + reserve), data_ptr, *size);
+                frag->segments[0].base.seg_len = total_size;
 #if OMPI_BTL_VADER_HAVE_XPMEM
             }
 #endif
         }
     } else {
         /* put/get fragment */
-        (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
+        (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
         if (OPAL_UNLIKELY(NULL == frag)) {
             return NULL;
         }
 
-        frag->segments[0].seg_addr.lval = (uint64_t)(uintptr_t) data_ptr;
-        frag->segments[0].seg_len       = total_size;
+        frag->segments[0].base.seg_addr.lval = (uint64_t)(uintptr_t) data_ptr;
+        frag->segments[0].base.seg_len       = total_size;
+#if OMPI_BTL_VADER_HAVE_KNEM
+        if (MCA_BTL_VADER_KNEM == mca_btl_vader_component.single_copy_mechanism) {
+            struct knem_cmd_create_region knem_cr;
+            struct knem_cmd_param_iovec knem_iov;
+
+            knem_iov.base = (uintptr_t) data_ptr;
+            knem_iov.len = total_size;
+
+            knem_cr.iovec_array = (uintptr_t) &knem_iov;
+            knem_cr.iovec_nr = 1;
+            knem_cr.protection = PROT_READ;
+            /* Vader will explicitly destroy this cookie */
+            knem_cr.flags = 0;
+            if (OPAL_UNLIKELY(ioctl(mca_btl_vader.knem_fd, KNEM_CMD_CREATE_REGION, &knem_cr) < 0)) {
+                MCA_BTL_VADER_FRAG_RETURN(frag);
+                return NULL;
+            }
+
+            frag->segments[0].cookie = knem_cr.cookie;
+            frag->cookie = knem_cr.cookie;
+        }
+#endif /* OMPI_BTL_SM_HAVE_KNEM */
     }
 
     frag->base.order       = order;
@@ -603,3 +640,56 @@ static int vader_ft_event (int state)
 {
     return OMPI_SUCCESS;
 }
+
+static void mca_btl_vader_endpoint_constructor (mca_btl_vader_endpoint_t *ep)
+{
+    OBJ_CONSTRUCT(&ep->pending_frags, opal_list_t);
+    ep->fifo = NULL;
+}
+
+static void mca_btl_vader_endpoint_destructor (mca_btl_vader_endpoint_t *ep)
+{
+    OBJ_DESTRUCT(&ep->pending_frags);
+
+#if OMPI_BTL_VADER_HAVE_XPMEM
+    if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
+        if (ep->segment_data.xpmem.rcache) {
+            /* clean out the registration cache */
+            const int nregs = 100;
+            mca_mpool_base_registration_t *regs[nregs];
+            int reg_cnt;
+
+            do {
+                reg_cnt = ep->segment_data.xpmem.rcache->rcache_find_all(ep->segment_data.xpmem.rcache, 0, (size_t)-1,
+                                                                          regs, nregs);
+
+                for (int i = 0 ; i < reg_cnt ; ++i) {
+                    /* otherwise dereg will fail on assert */
+                    regs[i]->ref_count = 0;
+                    OBJ_RELEASE(regs[i]);
+                }
+            } while (reg_cnt == nregs);
+
+            ep->segment_data.xpmem.rcache = NULL;
+        }
+
+        if (ep->segment_base) {
+            xpmem_release (ep->segment_data.xpmem.apid);
+            ep->segment_data.xpmem.apid = 0;
+        }
+    } else
+#endif
+    if (ep->segment_data.other.seg_ds) {
+        /* disconnect from the peer's segment. in 1.8 the opal_shmem_ds_t in the endpoint
+         * is safe to use directly. */
+        opal_shmem_segment_detach (ep->segment_data.other.seg_ds);
+        free (ep->segment_data.other.seg_ds);
+        ep->segment_data.other.seg_ds = NULL;
+    }
+
+    ep->fbox_in.buffer = ep->fbox_out.buffer = NULL;
+    ep->segment_base = NULL;
+    ep->fifo = NULL;
+}
+
+OBJ_CLASS_INSTANCE(mca_btl_vader_endpoint_t, opal_list_item_t, mca_btl_vader_endpoint_constructor, mca_btl_vader_endpoint_destructor);

--- a/ompi/mca/btl/vader/btl_vader_put.c
+++ b/ompi/mca/btl/vader/btl_vader_put.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2010-2013 Los Alamos National Security, LLC.  
- *                         All rights reserved. 
+ * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,9 +33,9 @@
  * @param descriptor (IN)  Description of the data to be transferred
  */
 #if OMPI_BTL_VADER_HAVE_XPMEM
-int mca_btl_vader_put (struct mca_btl_base_module_t *btl,
-                       struct mca_btl_base_endpoint_t *endpoint,
-                       struct mca_btl_base_descriptor_t *des)
+int mca_btl_vader_put_xpmem (struct mca_btl_base_module_t *btl,
+                             struct mca_btl_base_endpoint_t *endpoint,
+                             struct mca_btl_base_descriptor_t *des)
 {
     mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
     mca_btl_base_segment_t *src = des->des_src;
@@ -56,14 +56,17 @@ int mca_btl_vader_put (struct mca_btl_base_module_t *btl,
     /* always call the callback function */
     frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
 
+    frag->endpoint = endpoint;
     mca_btl_vader_frag_complete (frag);
 
     return OMPI_SUCCESS;
 }
-#elif OMPI_BTL_VADER_HAVE_CMA
-int mca_btl_vader_put (struct mca_btl_base_module_t *btl,
-                       struct mca_btl_base_endpoint_t *endpoint,
-                       struct mca_btl_base_descriptor_t *des)
+#endif
+
+#if OMPI_BTL_VADER_HAVE_CMA
+int mca_btl_vader_put_cma (struct mca_btl_base_module_t *btl,
+                           struct mca_btl_base_endpoint_t *endpoint,
+                           struct mca_btl_base_descriptor_t *des)
 {
     mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
     mca_btl_base_segment_t *src = des->des_src;
@@ -73,12 +76,68 @@ int mca_btl_vader_put (struct mca_btl_base_module_t *btl,
     struct iovec dst_iov = {.iov_base = dst->seg_addr.pval, .iov_len = size};
     ssize_t ret;
 
-    ret = process_vm_writev (endpoint->seg_ds.seg_cpid, &src_iov, 1, &dst_iov, 1, 0);
-    if (ret != size) {
-        fprintf (stderr, "Wrote %d, expected %u\n", ret, size);
+    ret = process_vm_writev (endpoint->segment_data.other.seg_ds->seg_cpid, &src_iov, 1, &dst_iov, 1, 0);
+    if (ret != (ssize_t)size) {
+        opal_output(0, "Wrote %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno);
         return OMPI_ERROR;
     }
 
+    /* always call the callback function */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
+    frag->endpoint = endpoint;
+    mca_btl_vader_frag_complete (frag);
+
+    return OMPI_SUCCESS;
+}
+#endif
+
+#if OMPI_BTL_VADER_HAVE_KNEM
+int mca_btl_vader_put_knem (struct mca_btl_base_module_t *btl,
+                            struct mca_btl_base_endpoint_t *endpoint,
+                            struct mca_btl_base_descriptor_t *des)
+{
+    mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) des;
+    mca_btl_vader_segment_t *src = (mca_btl_vader_segment_t *) des->des_src;
+    mca_btl_vader_segment_t *dst = (mca_btl_vader_segment_t *) des->des_dst;
+    const size_t size = min(dst->base.seg_len, src->base.seg_len);
+    struct knem_cmd_param_iovec send_iovec;
+    struct knem_cmd_inline_copy icopy;
+
+    /* Fill in the ioctl data fields.  There's no async completion, so
+       we don't need to worry about getting a slot, etc. */
+    send_iovec.base = (uintptr_t) dst->base.seg_addr.lval;
+    send_iovec.len = size;
+    icopy.local_iovec_array = (uintptr_t) &send_iovec;
+    icopy.local_iovec_nr    = 1;
+    icopy.remote_cookie     = dst->cookie;
+    icopy.remote_offset     = 0;
+    icopy.write             = 1;
+    icopy.flags             = 0;
+
+    /* Use the DMA flag if knem supports it *and* the segment length
+     * is greater than the cutoff. Not that if DMA is not supported
+     * or the user specified 0 for knem_dma_min the knem_dma_min was
+     * set to UINT_MAX in mca_btl_vader_knem_init. */
+    if (mca_btl_vader_component.knem_dma_min <= dst->base.seg_len) {
+        icopy.flags = KNEM_FLAG_DMA;
+    }
+    /* synchronous flags only, no need to specify icopy.async_status_index */
+
+    /* When the ioctl returns, the transfer is done and we can invoke
+       the btl callback and return the frag */
+    if (OPAL_UNLIKELY(0 != ioctl (mca_btl_vader.knem_fd, KNEM_CMD_INLINE_COPY, &icopy))) {
+        return OMPI_ERROR;
+    }
+
+    if (KNEM_STATUS_FAILED == icopy.current_status) {
+        return OMPI_ERROR;
+    }
+
+    /* always call the callback function */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
+    frag->endpoint = endpoint;
     mca_btl_vader_frag_complete (frag);
 
     return OMPI_SUCCESS;

--- a/ompi/mca/btl/vader/btl_vader_sendi.c
+++ b/ompi/mca/btl/vader/btl_vader_sendi.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2013 Los Alamos National Security, LLC.  
- *                         All rights reserved. 
+ * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,6 +47,12 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
     void *data_ptr = NULL;
     size_t length;
 
+    /* don't attempt sendi if there are pending fragments on the endpoint */
+    if (OPAL_UNLIKELY(opal_list_get_size (&endpoint->pending_frags))) {
+        *descriptor = NULL;
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
     if (payload_size) {
         opal_convertor_get_current_pointer (convertor, &data_ptr);
     }
@@ -55,7 +61,6 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
         mca_btl_vader_fbox_sendi (endpoint, tag, header, header_size, data_ptr, payload_size)) {
         return OMPI_SUCCESS;
     }
-
 
     length = header_size + payload_size;
 
@@ -73,7 +78,7 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
     frag->hdr->tag = tag;
 
     /* write the match header (with MPI comm/tag/etc. info) */
-    memcpy (frag->segments[0].seg_addr.pval, header, header_size);
+    memcpy (frag->segments[0].base.seg_addr.pval, header, header_size);
 
     /* write the message data if there is any */
     /* we can't use single-copy semantics here since as caller will consider the send
@@ -83,7 +88,7 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
         struct iovec iov;
 
         /* pack the data into the supplied buffer */
-        iov.iov_base = (IOVBASE_TYPE *)((uintptr_t)frag->segments[0].seg_addr.pval + header_size);
+        iov.iov_base = (IOVBASE_TYPE *)((uintptr_t)frag->segments[0].base.seg_addr.pval + header_size);
         iov.iov_len  = length = payload_size;
 
         (void) opal_convertor_pack (convertor, &iov, &iov_count, &length);
@@ -92,7 +97,10 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
     }
 
     /* write the fragment pointer to peer's the FIFO. the progress function will return the fragment */
-    vader_fifo_write_ep (frag->hdr, endpoint);
+    if (!vader_fifo_write_ep (frag->hdr, endpoint)) {
+        *descriptor = &frag->base;
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/btl/vader/btl_vader_xpmem.h
+++ b/ompi/mca/btl/vader/btl_vader_xpmem.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
  *                         reserved. 
  * $COPYRIGHT$
  *
@@ -12,11 +12,23 @@
 #if !defined(MCA_BTL_VADER_XPMEM_H)
 #define MCA_BTL_VADER_XPMEM_H
 
-#include "btl_vader.h"
-
 #if OMPI_BTL_VADER_HAVE_XPMEM
+
+#if defined(HAVE_XPMEM_H)
+  #include <xpmem.h>
+
+  typedef struct xpmem_addr xpmem_addr_t;
+#elif defined(HAVE_SN_XPMEM_H)
+  #include <sn/xpmem.h>
+
+  typedef int64_t xpmem_segid_t;
+#endif
+
 /* look up the remote pointer in the peer rcache and attach if
  * necessary */
+
+/* largest address we can attach to using xpmem */
+#define VADER_MAX_ADDRESS ((uintptr_t)0x7ffffffff000ul)
 
 mca_mpool_base_registration_t *vader_get_registation (struct mca_btl_base_endpoint_t *endpoint, void *rem_ptr,
  						      size_t size, int flags, void **local_ptr);

--- a/ompi/mca/btl/vader/configure.m4
+++ b/ompi/mca/btl/vader/configure.m4
@@ -6,7 +6,6 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2014      Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,7 +23,7 @@ AC_DEFUN([OMPI_CHECK_XPMEM], [
     AC_ARG_WITH([xpmem],
                 [AC_HELP_STRING([--with-xpmem(=DIR)],
                 [Build with XPMEM kernel module support, searching for headers in DIR])])
-    OMPI_CHECK_WITHDIR([xpmem], [$with_xpmem], [include/xpmem.h])
+    OMPI_CHECK_WITHDIR([xpmem], [$with_xpmem], [include/xpmem.h include/sn/xpmem.h])
 
     AC_ARG_WITH([xpmem-libdir],
                 [AC_HELP_STRING([--with-xpmem-libdir=DIR],
@@ -42,7 +41,7 @@ AC_DEFUN([OMPI_CHECK_XPMEM], [
 	    ompi_check_xpmem_libdir="$with_xpmem_libdir"
 	fi
 
-	OMPI_CHECK_PACKAGE([$1],[xpmem.h],[xpmem],[xpmem_make],[],
+	OMPI_CHECK_PACKAGE([$1],[xpmem.h sn/xpmem.h],[xpmem],[xpmem_make],[],
 	    [$ompi_check_xpmem_dir],[$ompi_check_xpmem_libdir], [ompi_check_xpmem_happy="yes"], [])
 
 	if test "$ompi_check_xpmem_happy" = "no" -a -n "$with_xpmem" -a "$with_xpmem" != "yes" ; then
@@ -55,30 +54,27 @@ AC_DEFUN([OMPI_CHECK_XPMEM], [
     OPAL_VAR_SCOPE_POP
 ])dnl
 
-# MCA_btl_sm_CONFIG([action-if-can-compile],
-#                   [action-if-cant-compile])
+# MCA_btl_vader_CONFIG([action-if-can-compile],
+#                      [action-if-cant-compile])
 # ------------------------------------------------
 AC_DEFUN([MCA_ompi_btl_vader_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/btl/vader/Makefile])
 
-    OPAL_VAR_SCOPE_PUSH([btl_vader_xpmem_happy btl_vader_cma_happy])
+    OPAL_VAR_SCOPE_PUSH([btl_vader_xpmem_happy btl_vader_cma_happy btl_vader_knem_happy])
 
-    btl_vader_cma_happy=0
-    btl_vader_xpmem_happy=0
-
-    # default to using XPMEM if it is available
-    OMPI_CHECK_XPMEM([btl_vader], [btl_vader_xpmem_happy=1], [])
+    # Check for single-copy APIs
+    OMPI_CHECK_XPMEM([btl_vader], [btl_vader_xpmem_happy=1], [btl_vader_xpmem_happy=0])
+    OMPI_CHECK_KNEM([btl_vader], [btl_vader_knem_happy=1],[btl_vader_knem_happy=0])
+    OMPI_CHECK_CMA([btl_vader], [AC_CHECK_HEADER([sys/prctl.h]) btl_vader_cma_happy=1], [btl_vader_cma_happy=0])
 
     AC_DEFINE_UNQUOTED([OMPI_BTL_VADER_HAVE_XPMEM], [$btl_vader_xpmem_happy],
         [If XPMEM support can be enabled within vader])
 
-    if test $btl_vader_xpmem_happy = 0 ; then
-        # check for CMA if requested. it won't be used if xpmem was available
-	OMPI_CHECK_CMA([btl_vader], [btl_vader_cma_happy=1], [])
-    fi
-
     AC_DEFINE_UNQUOTED([OMPI_BTL_VADER_HAVE_CMA], [$btl_vader_cma_happy],
         [If CMA support can be enabled within vader])
+
+    AC_DEFINE_UNQUOTED([OMPI_BTL_VADER_HAVE_KNEM], [$btl_vader_knem_happy],
+	[If KNEM support can be enabled within vader])
 
     OPAL_VAR_SCOPE_POP
 

--- a/ompi/mca/btl/vader/help-btl-vader.txt
+++ b/ompi/mca/btl/vader/help-btl-vader.txt
@@ -6,6 +6,8 @@
 # Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2014 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -15,52 +17,63 @@
 # This is the US/English help file for Open MPI's shared memory support.
 #
 [sys call fail]
-A system call failed during sm BTL initialization that should
-not have.  It is likely that your MPI job will now either abort or
-experience performance degradation.
+A system call failed during vader shared memory BTL initialization
+that should not have.  It is likely that your MPI job will now either
+abort or experience performance degradation.
 
   System call: %s
   Error:       %s (errno %d)
 #
 [no locality]
-WARNING: Missing locality information required for sm initialization.
-Continuing without shared memory support.
+WARNING: Missing locality information required for vader shared memory
+BTL initialization. Continuing without shared memory support.
 #
 [knem permission denied]
-Open MPI failed to open the /dev/knem device due to a permissions
-problem.  Please check with your system administrator to get the
-permissions fixed, or set the btl_sm_use_knem MCA parameter to 0 to
-run without /dev/knem support.
+WARING: Open MPI failed to open the /dev/knem device due to a
+permissions problem.  Please check with your system administrator to
+get the permissions fixed, or set the btl_vader_single_copy_mechanism
+MCA variable to none to silence this warning and run without knem
+support.
 
   Local host:            %s
   /dev/knem permissions: 0%o
 #
 [knem fail open]
-Open MPI failed to open the /dev/knem device due to a local error.
-Please check with your system administrator to get the problem fixed,
-or set the btl_sm_use_knem MCA parameter to 0 to run without /dev/knem
-support.
+WARNING: Open MPI failed to open the /dev/knem device due to a local
+error. Please check with your system administrator to get the problem
+fixed, or set the btl_vader_single_copy_mechanism MCA variable to none
+to silence this warning and run without knem support.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host: %s
   Errno:      %d (%s)
 #
 [knem get ABI fail]
-Open MPI failed to retrieve the ABI version from the /dev/knem device
-due to a local error.  This usually indicates an error in your
-/dev/knem installation; please check with your system administrator,
-or set the btl_sm_use_knem MCA parameter to 0 to run without /dev/knem
-support.
+WARNING: Open MPI failed to retrieve the ABI version from the
+/dev/knem device due to a local error.  This usually indicates an
+error in your knem installation; please check with your system
+administrator, or set the btl_vader_single_copy_mechanism MCA variable
+to none to silence this warning and run without knem support.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host: %s
   Errno:      %d (%s)
 #
 [knem ABI mismatch]
-Open MPI was compiled with support for one version of the knem kernel
-module, but it discovered a different version running in /dev/knem.
-Open MPI needs to be installed with support for the same version of
-knem as is in the running Linux kernel.  Please check with your system
-administrator, or set the btl_sm_use_knem MCA parameter to 0 to run
-without /dev/knem support.
+WARNING: Open MPI was compiled with support for one version of the
+knem kernel module, but it discovered a different version running in
+/dev/knem. Open MPI needs to be installed with support for the same
+version of knem as is in the running Linux kernel. Please check with
+your system administrator, or set the btl_vader_single_copy_mechanism
+MCA variable to none to silence this warning and run without knem
+support.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host:              %s
   Open MPI's knem version: 0x%x
@@ -68,25 +81,33 @@ without /dev/knem support.
 #
 [knem mmap fail]
 Open MPI failed to map support from the knem Linux kernel module; this
-shouldn't happen.  Please check with your system administrator, or set
-the btl_sm_use_knem MCA parameter to 0 to run without /dev/knem support.
+shouldn't happen. Please check with your system administrator, or set
+the btl_vader_single_copy_mechanism MCA variable to none to silence
+this warning and run without knem support.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host:  %s
   System call: mmap()
   Errno:       %d (%s)
 #
 [knem init error]
-Open MPI encountered an error during the knem initialization.  Please
-check with your system administrator, or set the btl_sm_use_knem MCA
-parameter to 0 to run without /dev/knem support.
+Open MPI encountered an error during the knem initialization. Please
+check with your system administrator, or set the
+btl_vader_single_copy_mechanism MCA variable to none to silence this
+warning and run without knem support.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host:  %s
   System call: %s
   Errno:       %d (%s)
 #
 [knem requested but not available]
-WARNING: Linux kernel Knem support was requested via the
-mca_btl_sm_use_knem MCA parameter, but Knem support was either not
+WARNING: Linux kernel knem support was requested via the
+btl_vader_single_copy_mechanism MCA parameter, but Knem support was either not
 compiled into this Open MPI installation, or Knem support was unable
 to be activated in this process.
 
@@ -97,11 +118,11 @@ is available. This may result in lower performance.
 #
 [cma-permission-denied]
 WARNING: Linux kernel CMA support was requested via the
-mca_btl_vader_single_copy_mechanism MCA variable, but CMA support is
+btl_vader_single_copy_mechanism MCA variable, but CMA support is
 not available due to restrictive ptrace settings.
 
-The vader BTL will fall back on another single-copy mechanism if one
-is available. This may result in lower performance.
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host: %s
 #
@@ -109,8 +130,8 @@ is available. This may result in lower performance.
 WARNING: Could not generate an xpmem segment id for this process'
 address space.
 
-The vader BTL will fall back on another single-copy mechanism if one
-is available. This may result in lower performance.
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
 
   Local host: %s
   Error code: %d (%s)

--- a/ompi/mca/btl/vader/help-btl-vader.txt
+++ b/ompi/mca/btl/vader/help-btl-vader.txt
@@ -3,21 +3,28 @@
 # Copyright (c) 2004-2009 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2014 Los Alamos National Security, LLC.
+#                         All rights reserved.
 # $COPYRIGHT$
-# 
+#
 # Additional copyrights may follow
-# 
+#
 # $HEADER$
 #
 # This is the US/English help file for Open MPI's shared memory support.
 #
-[knem requested but not supported]
-WARNING: Linux kernel knem support was requested for the shared memory
-(sm) BTL, but it is not supported.  Deactivating the shared memory
-BTL.
+[sys call fail]
+A system call failed during sm BTL initialization that should
+not have.  It is likely that your MPI job will now either abort or
+experience performance degradation.
 
-  Local host: %s
+  System call: %s
+  Error:       %s (errno %d)
+#
+[no locality]
+WARNING: Missing locality information required for sm initialization.
+Continuing without shared memory support.
 #
 [knem permission denied]
 Open MPI failed to open the /dev/knem device due to a permissions
@@ -76,3 +83,34 @@ parameter to 0 to run without /dev/knem support.
   Local host:  %s
   System call: %s
   Errno:       %d (%s)
+#
+[knem requested but not available]
+WARNING: Linux kernel Knem support was requested via the
+mca_btl_sm_use_knem MCA parameter, but Knem support was either not
+compiled into this Open MPI installation, or Knem support was unable
+to be activated in this process.
+
+The vader BTL will fall back on another single-copy mechanism if one
+is available. This may result in lower performance.
+
+  Local host: %s
+#
+[cma-permission-denied]
+WARNING: Linux kernel CMA support was requested via the
+mca_btl_vader_single_copy_mechanism MCA variable, but CMA support is
+not available due to restrictive ptrace settings.
+
+The vader BTL will fall back on another single-copy mechanism if one
+is available. This may result in lower performance.
+
+  Local host: %s
+#
+[xpmem-make-failed]
+WARNING: Could not generate an xpmem segment id for this process'
+address space.
+
+The vader BTL will fall back on another single-copy mechanism if one
+is available. This may result in lower performance.
+
+  Local host: %s
+  Error code: %d (%s)


### PR DESCRIPTION
This commit brings the following commits from master:

open-mpi/ompi@12bfd13
open-mpi/ompi@79881ca
open-mpi/ompi@a31cf3b
open-mpi/ompi@13642f5
open-mpi/ompi@f56169c
open-mpi/ompi@1a3734a
open-mpi/ompi@13643f5
open-mpi/ompi@d60f0cb
open-mpi/ompi@75e8387

The most relevant changes:
- Add support for KNEM. Allow selection of the single-copy mechanism
  at runtime. The default behavior has not changed. Vader will continue
  to use the best available mechanism. If the default mechanism is
  not available vader will fall back on another mechanism.
- Improved CMA support. Code now determines if CMA can be used and
  (if possible) sets the appropriate ptrace permissions so it can
  be used.
- Improved memory scaling by allocating fast box memory only once a
  send threshold has been met. This addresses an issue discovered by
  Riken.
- Better fast-box design that further improves the small message
  performance.

Pieces of other relevant commits are also included in this commit.

Tested with XPMEM, CMA, and KNEM with Linux kernel 3.13.
