### PR TITLE
osc/rdma: bring over one-sided fixes from master

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -423,8 +423,8 @@ static inline void mark_incoming_completion (ompi_osc_rdma_module_t *module, int
 {
     if (MPI_PROC_NULL == source) {
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                             "mark_incoming_completion marking active incoming complete. count = %d",
-                             (int) module->active_incoming_frag_count + 1));
+                             "mark_incoming_completion marking active incoming complete. count = %d. signal = %d",
+                             (int) module->active_incoming_frag_count + 1, module->active_incoming_frag_signal_count));
         OPAL_THREAD_ADD32(&module->active_incoming_frag_count, 1);
         if (module->active_incoming_frag_count >= module->active_incoming_frag_signal_count) {
             opal_condition_broadcast(&module->cond);

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -130,29 +130,29 @@ struct ompi_osc_rdma_module_t {
 
     /** Nmber of communication fragments started for this epoch, by
         peer.  Not in peer data to make fence more manageable. */
-    int32_t *epoch_outgoing_frag_count;
+    uint32_t *epoch_outgoing_frag_count;
 
     /** List of full communication buffers queued to be sent.  Should
         be maintained in order (at least in per-target order). */
     opal_list_t queued_frags;
 
     /** cyclic counter for a unique tage for long messages. */
-    int tag_counter;
+    unsigned int tag_counter;
 
     /* Number of outgoing fragments that have completed since the
        begining of time */
-    int32_t outgoing_frag_count;
+    uint32_t outgoing_frag_count;
     /* Next outgoing fragment count at which we want a signal on cond */
-    int32_t outgoing_frag_signal_count;
+    uint32_t outgoing_frag_signal_count;
 
     /* Number of incoming fragments that have completed since the
        begining of time */
-    int32_t active_incoming_frag_count;
+    uint32_t active_incoming_frag_count;
     /* Next incoming buffer count at which we want a signal on cond */
-    int32_t active_incoming_frag_signal_count;
+    uint32_t active_incoming_frag_signal_count;
 
-    int32_t *passive_incoming_frag_count;
-    int32_t *passive_incoming_frag_signal_count;
+    uint32_t *passive_incoming_frag_count;
+    uint32_t *passive_incoming_frag_signal_count;
 
     /* Number of flush ack requests send since beginning of time */
     uint64_t flush_ack_requested_count;
@@ -425,7 +425,7 @@ static inline void mark_incoming_completion (ompi_osc_rdma_module_t *module, int
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "mark_incoming_completion marking active incoming complete. count = %d. signal = %d",
                              (int) module->active_incoming_frag_count + 1, module->active_incoming_frag_signal_count));
-        OPAL_THREAD_ADD32(&module->active_incoming_frag_count, 1);
+        OPAL_THREAD_ADD32((int32_t *) &module->active_incoming_frag_count, 1);
         if (module->active_incoming_frag_count >= module->active_incoming_frag_signal_count) {
             opal_condition_broadcast(&module->cond);
         }
@@ -433,7 +433,7 @@ static inline void mark_incoming_completion (ompi_osc_rdma_module_t *module, int
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "mark_incoming_completion marking passive incoming complete. source = %d, count = %d",
                              source, (int) module->passive_incoming_frag_count[source] + 1));
-        OPAL_THREAD_ADD32(module->passive_incoming_frag_count + source, 1);
+        OPAL_THREAD_ADD32((int32_t *) module->passive_incoming_frag_count + source, 1);
         if (module->passive_incoming_frag_count[source] >= module->passive_incoming_frag_signal_count[source]) {
             opal_condition_broadcast(&module->cond);
         }
@@ -455,7 +455,7 @@ static inline void mark_incoming_completion (ompi_osc_rdma_module_t *module, int
  */
 static inline void mark_outgoing_completion (ompi_osc_rdma_module_t *module)
 {
-    OPAL_THREAD_ADD32(&module->outgoing_frag_count, 1);
+    OPAL_THREAD_ADD32((int32_t *) &module->outgoing_frag_count, 1);
     if (module->outgoing_frag_count >= module->outgoing_frag_signal_count) {
         opal_condition_broadcast(&module->cond);
     }
@@ -475,12 +475,12 @@ static inline void mark_outgoing_completion (ompi_osc_rdma_module_t *module)
  */
 static inline void ompi_osc_signal_outgoing (ompi_osc_rdma_module_t *module, int target, int count)
 {
-    OPAL_THREAD_ADD32(&module->outgoing_frag_signal_count, count);
+    OPAL_THREAD_ADD32((int32_t *) &module->outgoing_frag_signal_count, count);
     if (MPI_PROC_NULL != target) {
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "ompi_osc_signal_outgoing_passive: target = %d, count = %d, total = %d", target,
                              count, module->epoch_outgoing_frag_count[target] + count));
-        OPAL_THREAD_ADD32(module->epoch_outgoing_frag_count + target, count);
+        OPAL_THREAD_ADD32((int32_t *) module->epoch_outgoing_frag_count + target, count);
     }
 }
 

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -461,7 +461,7 @@ ompi_osc_rdma_wait(ompi_win_t *win)
 
     OPAL_THREAD_LOCK(&module->lock);
     while (0 != module->num_complete_msgs ||
-             module->active_incoming_frag_count < module->active_incoming_frag_signal_count) {
+             module->active_incoming_frag_count != module->active_incoming_frag_signal_count) {
         OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                              "num_complete_msgs = %d, active_incoming_frag_count = %d, active_incoming_frag_signal_count = %d",
                              module->num_complete_msgs, module->active_incoming_frag_count, module->active_incoming_frag_signal_count));
@@ -501,7 +501,7 @@ ompi_osc_rdma_test(ompi_win_t *win,
     OPAL_THREAD_LOCK(&(module->lock));
 
     if (0 != module->num_complete_msgs || 
-           module->active_incoming_frag_count < module->active_incoming_frag_signal_count) {
+           module->active_incoming_frag_count != module->active_incoming_frag_signal_count) {
         *flag = 0;
         ret = OMPI_SUCCESS;
         goto cleanup;


### PR DESCRIPTION
This commit brings over two commits:

open-mpi/ompi@eed7b45db59b356f6257f3b019e77643f14f84ce

osc/rdma: fix issue identified by Berk Hess

osc/rdma uses counters to determine if all messages have been received
before exiting synchronization calls. The problem is that the active
target counter is always increasing (never zeroed). If over 2^31-1
messages are sent this causes the counter to overflow (in itself this
isn't an error). This causes test/wait to return before the communication
is complete. There is an additional error in the use of the fragment
flush function. If PSCW synchronization is in use this function CAN NOT
be called unless a post message has arrived.

Relevant mailing list thread: http://www.open-mpi.org/community/lists/devel/2014/10/16016.php

This commit fixes both issues. Tested against MTT and issue reproducer.

open-mpi/ompi@23dd3af946dbfec55f3261c2a1a8e3ea30ed695c

osc/rdma: use unsigned types for all counters

Some of the counters used by the "rdma" one-sided component are intended
to overflow. Since overflow behavior is undefined for signed integers in
C it is safer to use unsigned integers here.
