### PR TITLE
backport OPAL_WANT_MEMCHECKER macro

### DIFF
--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -464,7 +466,7 @@ static inline opal_object_t *opal_obj_new(opal_class_t * cls)
     opal_object_t *object;
     assert(cls->cls_sizeof >= sizeof(opal_object_t));
 
-#if OPAL_WANT_MEMCHECKER
+#if OMPI_WANT_MEMCHECKER
     object = (opal_object_t *) calloc(1, cls->cls_sizeof);
 #else
     object = (opal_object_t *) malloc(cls->cls_sizeof);


### PR DESCRIPTION
This fixes commit open-mpi/ompi-release@3156f98d358a5d3f34e21324a11708441153268f
which is a cherry pick from open-mpi/ompi@a422d893b8e63347deb71bbaaa14ca25ddb1f192

@jsquyres could you please review this PR ?
