### PR TITLE
Man page fixes

### DIFF
--- a/ompi/mpi/man/man3/MPI.3in
+++ b/ompi/mpi/man/man3/MPI.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2008 Sun Microsystems, Inc. 
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 MPI \- General information #PACKAGE_NAME# #PACKAGE_VERSION#. 

--- a/ompi/mpi/man/man3/MPI_Abort.3in
+++ b/ompi/mpi/man/man3/MPI_Abort.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Abort 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Abort\fP \- Terminates MPI execution environment.
@@ -27,12 +28,6 @@ MPI_ABORT(\fICOMM\fP, \fIERRORCODE\fP, \fIIERROR\fP)
 void Comm::Abort(int \fIerrorcode\fP)
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.Abort(int \fIerrorcode\fP)
-
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
@@ -56,12 +51,12 @@ action with the error code. However, a UNIX or POSIX
 environment should handle this as a return errorcode from the main program
 or an abort (errorcode).
 .sp
-The long-term goal of the Open MPI implementation is to terminate all processes in all tasks that contain a process in \fIcomm\fP, and the error code is not returned to the invoking environment. At the moment, this isn't fully implemented and MPI_Abort will terminate the entire job. The Java implementation currently does not allow specification of a communicator and aborts the entire job - this will be updated to support the long-term implementation at a later date.
+The long-term goal of the Open MPI implementation is to terminate all processes in all tasks that contain a process in \fIcomm\fP, and the error code is not returned to the invoking environment. At the moment, this isn't fully implemented and MPI_Abort will terminate the entire job.
 .sp
 Note: All associated processes are sent a SIGTERM.
 
 .SH ERRORS
-Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ and Java functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object - similar behavior is followed by Java.
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
 .sp
 Before the error value is returned, the current MPI error handler is
 called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler

--- a/ompi/mpi/man/man3/MPI_Abort.3in
+++ b/ompi/mpi/man/man3/MPI_Abort.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Accumulate.3in
+++ b/ompi/mpi/man/man3/MPI_Accumulate.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Accumulate 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Accumulate\fP, \fBMPI_Raccumulate\fP \- Combines the contents of the origin buffer with that of a target buffer.

--- a/ompi/mpi/man/man3/MPI_Add_error_class.3in
+++ b/ompi/mpi/man/man3/MPI_Add_error_class.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Add_error_class 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Add_error_code.3in
+++ b/ompi/mpi/man/man3/MPI_Add_error_code.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Add_error_code 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Add_error_string.3in
+++ b/ompi/mpi/man/man3/MPI_Add_error_string.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Add_error_string 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Address.3in
+++ b/ompi/mpi/man/man3/MPI_Address.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Address 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Address\fP \- Gets the address of a location in memory -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Allgather.3in
+++ b/ompi/mpi/man/man3/MPI_Allgather.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Allgather 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Allgather, MPI_Iallgather\fP \- Gathers data from all processes and distributes it to all processes
@@ -45,21 +46,11 @@ void MPI::Comm::Allgather(const void* \fIsendbuf\fP, int \fIsendcount\fP, const
 	const MPI::Datatype& \fIrecvtype\fP) const = 0
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Allgather(Object \fIsendbuf\fP, int \fIsendoffset\fP, int \fIsendcount\fP, MPI.Datatype \fIsendtype\fP,
-                              Object \fIrecvbuf\fP, int \fIrecvoffset\fP, int \fIrecvcount\fP, Datatype \fIrecvtype\fP)
-
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
 sendbuf    
 Starting address of send buffer (choice).
-.TP 1i
-sendoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1i
 sendcount    
 Number of elements in send buffer (integer).
@@ -69,9 +60,6 @@ Datatype of send buffer elements (handle).
 .TP 1i
 recvbuf    
 Starting address of recv buffer (choice).
-.TP 1i
-recvoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1i
 recvcount    
 Number of elements received from any process (integer).

--- a/ompi/mpi/man/man3/MPI_Allgatherv.3in
+++ b/ompi/mpi/man/man3/MPI_Allgatherv.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc. 
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Allgatherv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Allgatherv, MPI_Iallgatherv\fP \- Gathers data from all processes and delivers it to all. Each process may contribute a different amount of data.
@@ -47,31 +48,17 @@ void MPI::Comm::Allgatherv(const void* \fIsendbuf\fP, int \fIsendcount\fP,
 	const MPI::Datatype& \fIrecvtype\fP) const = 0
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Allgatherv(Object \fIsendbuf\fP, int \fIsendoffset\fP, int \fIsendcount\fP, MPI.Datatype \fIsendtype\fP,
-                               Object \fIrecvbuf\fP, int \fIrecvoffset\fP, int \fI*recvcount\fP, int \fI*displs\fP,
-                               Datatype \fIrecvtype\fP)
-
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
 sendbuf    
 Starting address of send buffer (choice).
 .TP 1i
-sendoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
-.TP 1i
 sendcount    
 Number of elements in send buffer (integer).
 .TP 1i
 sendtype    
 Datatype of send buffer elements (handle).
-.TP 1i
-recvoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1i
 recvcount    
 Integer array (of length group size) containing the number of elements that are received from each process.

--- a/ompi/mpi/man/man3/MPI_Alloc_mem.3in
+++ b/ompi/mpi/man/man3/MPI_Alloc_mem.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Alloc_mem 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Alloc_mem \fP \- Allocates a specified memory segment. 
@@ -84,9 +85,7 @@ For example,
 
            CALL MPI_FREE_MEM(A, IERR)
 .fi
-.SH JAVA NOTES
 .ft R
-There is no Java syntax for using MPI_Alloc_mem.
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.

--- a/ompi/mpi/man/man3/MPI_Alloc_mem.3in
+++ b/ompi/mpi/man/man3/MPI_Alloc_mem.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Allreduce.3in
+++ b/ompi/mpi/man/man3/MPI_Allreduce.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Allreduce 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Allreduce, MPI_Iallreduce\fP \- Combines values from all processes and distributes the result back to all processes.
@@ -40,28 +41,14 @@ void MPI::Comm::Allreduce(const void* \fIsendbuf\fP, void* \fIrecvbuf\fP,
 	MPI::Op& \fIop\fP) const=0
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Allreduce(Object \fIsendbuf\fP, int \fIsendoffset\fP,
-                              Object \fIrecvbuf\fP, int \fIrecvoffset\fP,
-                              int \fIcount\fP, MPI.Datatype \fIsendtype\fP,
-                              MPI.Op \fIop\fP)
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
 sendbuf
 Starting address of send buffer (choice).
 .TP 1i
-sendoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
-.TP 1i
 count
 Number of elements in send buffer (integer).
-.TP 1i
-recvoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1i
 datatype
 Datatype of elements of send buffer (handle).

--- a/ompi/mpi/man/man3/MPI_Alltoall.3in
+++ b/ompi/mpi/man/man3/MPI_Alltoall.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Alltoall 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME
@@ -49,29 +50,17 @@ void MPI::Comm::Alltoall(const void* \fIsendbuf\fP, int \fIsendcount\fP,
 	int \fIrecvcount\fP, const MPI::Datatype& \fIrecvtype\fP)
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Alltoall(Object \fIsendbuf\fP, int \fIsendoffset\fP, int \fIsendcount\fP, MPI.Datatype \fIsendtype\fP,
-                             Object \fIrecvbuf\fP, int \fIrecvoffset\fP, int \fIrecvcount\fP, MPI.Datatype \fIrecvtype\fP)
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1.2i
 sendbuf
 Starting address of send buffer (choice).
 .TP 1.2i
-sendoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
-.TP 1.2i
 sendcount
 Number of elements to send to each process (integer).
 .TP 1.2i
 sendtype
 Datatype of send buffer elements (handle).
-.TP 1.2i
-recvoffset    
-Number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1.2i
 recvcount
 Number of elements to receive from each process (integer).

--- a/ompi/mpi/man/man3/MPI_Alltoallv.3in
+++ b/ompi/mpi/man/man3/MPI_Alltoallv.3in
@@ -1,6 +1,6 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -57,22 +57,11 @@ void MPI::Comm::Alltoallv(const void* \fIsendbuf\fP,
 	const MPI::Datatype& \fIrecvtype\fP)
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Alltoallv(Object \fIsendbuf\fP, int \fIsendoffset\fP, int \fIsendcount\fP[],
-                              int \fIsdispls\fP[], MPI.Datatype \fIsendtype\fP,
-                              Object \fIrecvbuf\fP, int \fIrecvoffset\fP, int \fIrecvcount\fP[],
-                              int \fIrdispls\fP[], MPI.Datatype \fIrecvtype\fP)
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1.2i
 sendbuf
 Starting address of send buffer.
-.TP 1.2i
-sendoffset    
-Initial number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1.2i
 sendcounts
 Integer array, where entry i specifies the number of elements to send
@@ -85,9 +74,6 @@ rank i.
 .TP 1.2i
 sendtype
 Datatype of send buffer elements.
-.TP 1.2i
-recvoffset    
-Initial number of elements to skip at beginning of buffer (integer, Java-only).
 .TP 1.2i
 recvcounts
 Integer array, where entry j specifies the number of elements to

--- a/ompi/mpi/man/man3/MPI_Alltoallw.3in
+++ b/ompi/mpi/man/man3/MPI_Alltoallw.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Alltoallw 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Attr_delete.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_delete.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Attr_delete.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_delete.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Attr_delete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Attr_delete\fP \- Deletes attribute value associated with a key -- use of this routine is deprecated.
@@ -19,12 +20,6 @@ INCLUDE 'mpif.h'
 MPI_ATTR_DELETE(\fICOMM\fP,\fI KEYVAL\fP, \fIIERROR\fP)			
 	INTEGER	\fICOMM\fP,\fI KEYVAL\fP,\fI IERROR\fP
 
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-int MPI.COMM_WORLD.Attr_delete(MPI.\fIkeyval\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Attr_get.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_get.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Attr_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Attr_get\fP \- Retrieves attribute value by key -- use of this routine is deprecated.
@@ -21,12 +22,6 @@ MPI_ATTR_GET(\fICOMM\fP,\fI KEYVAL\fP, \fIATTRIBUTE_VAL\fP,\fI FLAG\fP,\fI IERRO
 	INTEGER	\fICOMM\fP,\fI KEYVAL\fP, \fIATTRIBUTE_VAL\fP,\fI IERROR\fP
 	LOGICAL	\fIFLAG\fP
 
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-int MPI.COMM_WORLD.Attr_get(MPI.\fIkeyval\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Attr_get.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_get.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Attr_put.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_put.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Attr_put 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Attr_put\fP \- Stores attribute value associated with a key -- use of this routine is deprecated.
@@ -19,12 +20,6 @@ INCLUDE 'mpif.h'
 MPI_ATTR_PUT(\fICOMM\fP,\fI KEYVAL\fP, \fIATTRIBUTE_VAL\fP,\fI IERROR\fP)
 	INTEGER	\fICOMM\fP,\fI KEYVAL\fP,\fI ATTRIBUTE_VAL\fP,\fI IERROR
 
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-int MPI.COMM_WORLD.Attr_put(MPI.\fIkeyval\fP, int \fIattribute_val\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Attr_put.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_put.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Barrier.3in
+++ b/ompi/mpi/man/man3/MPI_Barrier.3in
@@ -1,6 +1,7 @@
 .\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Barrier 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Barrier, MPI_Ibcarrier\fP \- Synchronization between MPI processes in a group
@@ -29,14 +30,6 @@ MPI_IBARRIER(\fICOMM\fP,\fI IERROR\fP)
 .nf
 import mpi.*;
 void MPI.COMM_WORLD.Barrier()
-
-.fi
-.SH Java Syntax
-.nf
-#include <mpi.h>
-void MPI::Comm::Barrier() const = 0
-
-void MPI::Comm::Ibarrier() const = 0
 
 .fi
 .SH INPUT PARAMETER

--- a/ompi/mpi/man/man3/MPI_Barrier.3in
+++ b/ompi/mpi/man/man3/MPI_Barrier.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Bcast.3in
+++ b/ompi/mpi/man/man3/MPI_Bcast.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Bcast.3in
+++ b/ompi/mpi/man/man3/MPI_Bcast.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Bcast 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Bcast, MPI_Ibcast\fP \- Broadcasts a message from the process with rank \fIroot\fP to all other processes of the group.
@@ -36,21 +37,11 @@ void MPI::Comm::Bcast(void* \fIbuffer\fP, int \fIcount\fP,
 	const MPI::Datatype& \fIdatatype\fP, int \fIroot\fP) const = 0
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Bcast(Object \fIbuffer\fP, int \fIoffset\fP, int \fIcount\fP,
-			  MPI.Datatype \fIdatatype\fP, int \fIroot\fP)
-
-.fi
 .SH INPUT/OUTPUT PARAMETERS
 .ft R
 .TP 1i
 buffer
 Starting address of buffer (choice).
-.TP 1i
-offset
-Offset of starting point in buffer (Java-only)
 .TP 1i
 count
 Number of entries in buffer (integer).

--- a/ompi/mpi/man/man3/MPI_Bsend.3in
+++ b/ompi/mpi/man/man3/MPI_Bsend.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Bsend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Bsend\fP \- Basic send with user-specified buffering.
@@ -31,21 +32,11 @@ void Comm::Bsend(const void* \fIbuf\fP, int \fIcount\fP, const
 	Datatype& \fIdatatype\fP, int \fIdest\fP, int \fItag\fP) const
 
 .fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.COMM_WORLD.Bsend(Object \fIbuf\fP, int \fIoffset\fP, int \fIcount\fP,
-	                  MPI.Datatype \fIdatatype\fP, int \fIdest\fP, int \fItag\fP)
-
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
 buf
 Initial address of send buffer (choice).
-.TP 1i
-offset
-Offset of starting point in buffer (Java-only).
 .TP 1i
 count
 Number of entries in send buffer (nonnegative integer).

--- a/ompi/mpi/man/man3/MPI_Bsend_init.3in
+++ b/ompi/mpi/man/man3/MPI_Bsend_init.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Bsend_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Bsend_init\fP \- Builds a handle for a buffered send.
@@ -33,21 +34,11 @@ Prequest MPI.COMM_WORLD.Bsend_init(const void* \fIbuf\fP, int \fIcount\fP, const
 	Datatype& \fIdatatype\fP, int \fIdest\fP, int \fItag\fP) const 
 
 .fi
-.SH Java Syntax
-.nf
-#include <mpi.h>
-Prequest Comm::Bsend_init(Object \fIbuf\fP, int \fIoffset\fP, int \fIcount\fP,
-	                  MPI.Datatype \fIdatatype\fP, int \fIdest\fP, int \fItag\fP)
-
-.fi
 .SH INPUT PARAMETERS
 .ft R
 .TP 1i
 buf
 Initial address of send buffer (choice).
-.TP 1i
-offset
-Offset of starting point in buffer (Java-only).
 .TP 1i
 count
 Number of elements sent (integer).

--- a/ompi/mpi/man/man3/MPI_Buffer_attach.3in
+++ b/ompi/mpi/man/man3/MPI_Buffer_attach.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines

--- a/ompi/mpi/man/man3/MPI_Buffer_attach.3in
+++ b/ompi/mpi/man/man3/MPI_Buffer_attach.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Buffer_attach 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Buffer_attach\fP \- Attaches a user-defined buffer for sending.
@@ -25,12 +26,6 @@ MPI_BUFFER_ATTACH(\fIBUF\fP,\fI SIZE\fP, \fIIERROR\fP)
 .nf
 #include <mpi.h>
 void Attach_buffer(void* \fIbuffer\fP, int \fIsize\fP)
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.Buffer_attach(byte[] \fIbuffer\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Buffer_detach.3in
+++ b/ompi/mpi/man/man3/MPI_Buffer_detach.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Buffer_detach 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Buffer_detach\fP \- Removes an existing buffer (for use in MPI_Bsend, etc.)
@@ -25,12 +26,6 @@ MPI_BUFFER_DETACH(\fIBUF\fP,\fI SIZE\fP, \fIIERROR\fP)
 .nf
 #include <mpi.h>
 int Detach_buffer(void*& \fIbuffer\fP)
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-byte[] MPI.Buffer_detach()
 
 .fi
 .SH OUTPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Buffer_detach.3in
+++ b/ompi/mpi/man/man3/MPI_Buffer_detach.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Cancel.3in
+++ b/ompi/mpi/man/man3/MPI_Cancel.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Cancel.3in
+++ b/ompi/mpi/man/man3/MPI_Cancel.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cancel 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cancel\fP \- Cancels a communication request.
@@ -24,12 +25,6 @@ MPI_CANCEL(\fIREQUEST\fP, \fIIERROR\fP)
 .nf
 #include <mpi.h>
 void Request::Cancel() const
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void MPI.Request.Cancel()
 
 .fi
 .SH INPUT PARAMETER

--- a/ompi/mpi/man/man3/MPI_Cart_coords.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_coords.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_coords 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_coords\fP \- Determines process coords in Cartesian topology given rank in group.
@@ -26,12 +27,6 @@ MPI_CART_COORDS(\fICOMM\fP,\fI RANK\fP,\fI MAXDIMS\fP,\fI COORDS\fP, \fIIERROR\f
 #include <mpi.h>
 void Cartcomm::Get_coords(int \fIrank\fP, int \fImaxdims\fP, 
 	int \fIcoords\fP[]) const
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-int[] Cartcomm.Coords(int \fIrank\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Cart_coords.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_coords.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Cart_create.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_create.3in
@@ -1,8 +1,9 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_create\fP \- Makes a new communicator to which Cartesian topology information has been attached.
@@ -30,12 +31,6 @@ MPI_CART_CREATE(\fICOMM_OLD\fP,\fI NDIMS\fP,\fI DIMS\fP,\fI PERIODS\fP,\fI REORD
 #include <mpi.h>
 Cartcomm Intracomm.Create_cart(int[] \fIndims\fP, int[] \fIdims\fP[], 
 	const bool \fIperiods\fP[], bool \fIreorder\fP) const
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-Cartcomm Intracomm.Create_cart(int \fIdims\fP[], const bool \fIperiods\fP[], bool \fIreorder\fP)
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_Cart_get.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_get.3in
@@ -1,6 +1,7 @@
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_get\fP \-  Retrieves Cartesian topology information associated with a communicator.
@@ -26,13 +27,6 @@ MPI_CART_GET(\fICOMM\fP, \fIMAXDIMS\fP, \fIDIMS\fP, \fIPERIODS\fP, \fICOORDS\fP,
 .nf
 #include <mpi.h>
 void Cartcomm::Get_topo(int \fImaxdims\fP, int \fIdims\fP[], 
-	bool \fIperiods\fP[], int \fIcoords\fP[]) const 
-
-.fi
-.SH Java Syntax
-.nf
-import mpi.*;
-void Cartcomm.Get_topo(int \fImaxdims\fP, int \fIdims\fP[], 
 	bool \fIperiods\fP[], int \fIcoords\fP[]) const 
 
 .fi

--- a/ompi/mpi/man/man3/MPI_Cart_get.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_get.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Cart_map.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_map.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_map 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_map \fP \-  Maps process to Cartesian topology information.

--- a/ompi/mpi/man/man3/MPI_Cart_rank.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_rank.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_rank 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_rank \fP \-  Determines process rank in communicator given Cartesian location.

--- a/ompi/mpi/man/man3/MPI_Cart_shift.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_shift.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Cart_shift 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_shift \fP \-  Returns the shifted source and destination ranks, given a shift direction and amount.

--- a/ompi/mpi/man/man3/MPI_Cart_sub.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_sub.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cart_sub 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cart_sub \fP \- Partitions a communicator into subgroups, which form lower-dimensional Cartesian subgrids.

--- a/ompi/mpi/man/man3/MPI_Cartdim_get.3in
+++ b/ompi/mpi/man/man3/MPI_Cartdim_get.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Cartdim_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Cartdim_get \fP \-  Retrieves Cartesian topology information associated with a communicator.

--- a/ompi/mpi/man/man3/MPI_Close_port.3in
+++ b/ompi/mpi/man/man3/MPI_Close_port.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Close_port 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Close_port \fP \- Releases the specified network address. 

--- a/ompi/mpi/man/man3/MPI_Comm_accept.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_accept.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007, Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_accept 3OpenMPI "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_accept \fP \- Establishes communication with a client. 

--- a/ompi/mpi/man/man3/MPI_Comm_call_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_call_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_call_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 

--- a/ompi/mpi/man/man3/MPI_Comm_compare.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_compare.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_compare 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_compare \fP \-  Compares two communicators.

--- a/ompi/mpi/man/man3/MPI_Comm_connect.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_connect.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_connect 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_connect \fP \- Establishes communication with a server. 

--- a/ompi/mpi/man/man3/MPI_Comm_create.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_create.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_create\fP \- Creates a new communicator.

--- a/ompi/mpi/man/man3/MPI_Comm_create_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_create_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_create_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_create_errhandler \fP \- Creates an error handler that can be attached to communicators. 

--- a/ompi/mpi/man/man3/MPI_Comm_create_group.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_create_group.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_create_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_create_group\fP \- Creates a new communicator.

--- a/ompi/mpi/man/man3/MPI_Comm_create_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_create_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_create_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_create_keyval\fP \- Generates a new attribute key. 

--- a/ompi/mpi/man/man3/MPI_Comm_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_delete_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_delete_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_delete_attr\fP \- Deletes attribute value associated with a key. 

--- a/ompi/mpi/man/man3/MPI_Comm_disconnect.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_disconnect.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_disconnect 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_disconnect\fP \- Deallocates communicator object and sets handle to MPI_COMM_NULL. 

--- a/ompi/mpi/man/man3/MPI_Comm_dup.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_dup.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_dup 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_dup \fP \-  Duplicates an existing communicator with all its cached information.

--- a/ompi/mpi/man/man3/MPI_Comm_dup_with_info.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_dup_with_info.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_dup_with_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_dup_with_info \fP \-  Duplicates an existing communicator using provided info.

--- a/ompi/mpi/man/man3/MPI_Comm_f2c.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_f2c.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_f2c 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_f2c, MPI_Comm_c2f, MPI_File_f2c, MPI_File_c2f, MPI_Info_f2c, MPI_Info_c2f, MPI_Op_f2c, MPI_Op_c2f, MPI_Request_f2c, MPI_Request_c2f, MPI_Type_f2c, MPI_Type_c2f, MPI_Win_f2c, MPI_Win_c2f \fP \- Translates a C handle into a Fortran handle, or vice versa.

--- a/ompi/mpi/man/man3/MPI_Comm_free.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_free \fP \- Mark a communicator object for deallocation.

--- a/ompi/mpi/man/man3/MPI_Comm_free_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_free_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_free_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_free_keyval\fP \- Frees attribute key for communicator cache attribute.

--- a/ompi/mpi/man/man3/MPI_Comm_get_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_get_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_get_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_get_attr\fP \- Retrieves attribute value by key.

--- a/ompi/mpi/man/man3/MPI_Comm_get_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_get_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_get_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_get_errhandler \fP \- Retrieves error handler associated with a communicator. 

--- a/ompi/mpi/man/man3/MPI_Comm_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_get_info.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_get_info\fP \- Retrieves active communicator info hints

--- a/ompi/mpi/man/man3/MPI_Comm_get_name.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_get_name.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_get_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_get_name\fP \- Returns the name that was most recently associated with a communicator. 

--- a/ompi/mpi/man/man3/MPI_Comm_get_parent.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_get_parent.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_get_parent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_get_parent\fP \- Returns the parent intercommunicator of current spawned process. 

--- a/ompi/mpi/man/man3/MPI_Comm_group.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_group.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_group \fP \- Returns the group associated with a communicator.  

--- a/ompi/mpi/man/man3/MPI_Comm_idup.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_idup.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_idup 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_idup \fP \-  Start the nonblocking duplication of an existing communicator with all its cached information.

--- a/ompi/mpi/man/man3/MPI_Comm_join.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_join.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_join 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Comm_rank.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_rank.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_rank 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_rank\fP \- Determines the rank of the calling process in the communicator.

--- a/ompi/mpi/man/man3/MPI_Comm_remote_group.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_remote_group.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_remote_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_remote_group \fP \- Accesses the remote group associated with an intercommunicator.

--- a/ompi/mpi/man/man3/MPI_Comm_remote_size.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_remote_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_remote_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_remote_size \fP \- Determines the size of the remote group associated with an intercommunicator.

--- a/ompi/mpi/man/man3/MPI_Comm_set_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_set_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_set_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_set_attr\fP \- Stores attribute value associated with a key.

--- a/ompi/mpi/man/man3/MPI_Comm_set_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_set_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_set_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_set_errhandler \fP \- Attaches a new error handler to a communicator. 

--- a/ompi/mpi/man/man3/MPI_Comm_set_info.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_set_info.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_set_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_set_info\fP \- Set communicator info hints

--- a/ompi/mpi/man/man3/MPI_Comm_set_name.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_set_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Comm_set_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_set_name\fP \- Associates a name with a communicator.

--- a/ompi/mpi/man/man3/MPI_Comm_size.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_size \fP \- Returns the size of the group associated with a communicator.  

--- a/ompi/mpi/man/man3/MPI_Comm_spawn.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_spawn.3in
@@ -3,6 +3,7 @@
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_spawn 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_spawn\fP \- Spawns a number of identical binaries. 

--- a/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
@@ -3,6 +3,7 @@
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_spawn_multiple 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_spawn_multiple\fP \- Spawns multiple binaries, or the same binary with multiple sets of arguments. 

--- a/ompi/mpi/man/man3/MPI_Comm_split.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_split.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_split 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_split \fP \- Creates new communicators based on colors and keys.

--- a/ompi/mpi/man/man3/MPI_Comm_split_type.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_split_type.3in
@@ -1,8 +1,9 @@
-.\" -*- nroff-mode -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_split_type 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_split_type \fP \- Creates new communicators based on colors and keys.

--- a/ompi/mpi/man/man3/MPI_Comm_test_inter.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_test_inter.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Comm_test_inter 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Comm_test_inter \fP \- Tests to see if a comm is an intercommunicator.

--- a/ompi/mpi/man/man3/MPI_Compare_and_swap.3in
+++ b/ompi/mpi/man/man3/MPI_Compare_and_swap.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Compare_and_swap 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Compare_and_swap\fP \- Perform RMA compare-and-swap

--- a/ompi/mpi/man/man3/MPI_Dims_create.3in
+++ b/ompi/mpi/man/man3/MPI_Dims_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Dims_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Dims_create \fP \- Creates a division of processors in a Cartesian grid.

--- a/ompi/mpi/man/man3/MPI_Dist_graph_create.3in
+++ b/ompi/mpi/man/man3/MPI_Dist_graph_create.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Dist_graph_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Dist_graph_create \fP \- Makes a new communicator to which topology information has been attached.

--- a/ompi/mpi/man/man3/MPI_Dist_graph_create_adjacent.3in
+++ b/ompi/mpi/man/man3/MPI_Dist_graph_create_adjacent.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Dist_graph_create_adjacent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Dist_graph_create_adjacent \fP \- Makes a new communicator to which topology information has been attached.

--- a/ompi/mpi/man/man3/MPI_Dist_graph_neighbors.3in
+++ b/ompi/mpi/man/man3/MPI_Dist_graph_neighbors.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Dist_graph_neighbors 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Dist_graph_neighbors \fP \- Returns the neighbors of the calling process in a distributed graph topology.

--- a/ompi/mpi/man/man3/MPI_Dist_graph_neighbors_count.3in
+++ b/ompi/mpi/man/man3/MPI_Dist_graph_neighbors_count.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Dist_graph_neighbors_count 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Dist_graph_neighbors_count \fP \- Returns the number of in and out edges for the calling processes in a distributed graph topology and a flag indicating whether the distributed graph is weighted.

--- a/ompi/mpi/man/man3/MPI_Errhandler_create.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Errhandler_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Errhandler_create \fP \- Creates an MPI-style error handler -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Errhandler_free.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Errhandler_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Errhandler_free \fP \- Frees an MPI-style error handler.

--- a/ompi/mpi/man/man3/MPI_Errhandler_get.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_get.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Errhandler_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Errhandler_get \fP \- Gets the error handler for a communicator -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Errhandler_set.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_set.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Errhandler_set 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Errhandler_set \fP \- Sets the error handler for a communicator -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Error_class.3in
+++ b/ompi/mpi/man/man3/MPI_Error_class.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Error_class 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Error_class \fP \- Converts an error code into an error class.

--- a/ompi/mpi/man/man3/MPI_Error_string.3in
+++ b/ompi/mpi/man/man3/MPI_Error_string.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Error_string 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Error_string \fP \- Returns a string for a given error code.

--- a/ompi/mpi/man/man3/MPI_Exscan.3in
+++ b/ompi/mpi/man/man3/MPI_Exscan.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Exscan 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Fetch_and_op.3in
+++ b/ompi/mpi/man/man3/MPI_Fetch_and_op.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Fetch_and_op 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Fetch_and_op\fP \- Combines the contents of the origin buffer with that of a target buffer and returns the target buffer value.

--- a/ompi/mpi/man/man3/MPI_File_call_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_File_call_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_call_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_File_close.3in
+++ b/ompi/mpi/man/man3/MPI_File_close.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_close 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_close\fP \- Closes a file (collective).

--- a/ompi/mpi/man/man3/MPI_File_create_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_File_create_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_create_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_create_errhandler \fP \- Creates an MPI-style error handler that can be attached to a file. 

--- a/ompi/mpi/man/man3/MPI_File_delete.3in
+++ b/ompi/mpi/man/man3/MPI_File_delete.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_delete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_delete\fP \- Deletes a file.

--- a/ompi/mpi/man/man3/MPI_File_f2c.3in
+++ b/ompi/mpi/man/man3/MPI_File_f2c.3in
@@ -1,1 +1,2 @@
+.\" -*- nroff -*-
 .so man3/MPI_Comm_f2c.3

--- a/ompi/mpi/man/man3/MPI_File_get_amode.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_amode.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_amode 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_amode\fP \- Returns access mode associated with an open file.

--- a/ompi/mpi/man/man3/MPI_File_get_atomicity.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_atomicity.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_atomicity 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_atomicity\fP \- Returns current consistency semantics for data-access operations.

--- a/ompi/mpi/man/man3/MPI_File_get_byte_offset.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_byte_offset.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_byte_offset 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_byte_offset\fP \- Converts a view-relative offset into an absolute byte position.

--- a/ompi/mpi/man/man3/MPI_File_get_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_errhandler \fP \- Gets the error handler for a file. 

--- a/ompi/mpi/man/man3/MPI_File_get_group.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_group.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_group\fP \- Returns a duplicate of the process group of a file.

--- a/ompi/mpi/man/man3/MPI_File_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_info.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_info\fP \- Returns a new info object containing values for current hints associated with a file. 

--- a/ompi/mpi/man/man3/MPI_File_get_position.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_position.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_position 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_position\fP \- Returns the current position of the individual file pointer.

--- a/ompi/mpi/man/man3/MPI_File_get_position_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_position_shared.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_position_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_position_shared\fP \- Returns the current position of the shared file pointer.

--- a/ompi/mpi/man/man3/MPI_File_get_size.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_size\fP \- Returns the current size of the file.

--- a/ompi/mpi/man/man3/MPI_File_get_type_extent.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_type_extent.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_type_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_type_extent\fP \- Returns the extent of the data type in a file. 

--- a/ompi/mpi/man/man3/MPI_File_get_view.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_view.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_get_view 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_get_view\fP \- Returns the process's view of data in the file.

--- a/ompi/mpi/man/man3/MPI_File_iread.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iread 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iread\fP \- Reads a file starting at the location specified by the individual file pointer (nonblocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_iread_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_at.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iread_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iread_at\fP \- Reads a file at an explicitly specified offset (nonblocking, noncollective). 

--- a/ompi/mpi/man/man3/MPI_File_iread_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_shared.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iread_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iread_shared\fP \- Reads a file using the shared file pointer (nonblocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_iwrite.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iwrite 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iwrite\fP \- Writes a file starting at the location specified by the individual file pointer (nonblocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_iwrite_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_at.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iwrite_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iwrite_at\fP \- Writes a file at an explicitly specified offset (nonblocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_iwrite_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_shared.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_iwrite_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_iwrite_shared\fP \- Writes a file using the shared file pointer (nonblocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_open.3in
+++ b/ompi/mpi/man/man3/MPI_File_open.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_open 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_open\fP \- Opens a file (collective).

--- a/ompi/mpi/man/man3/MPI_File_preallocate.3in
+++ b/ompi/mpi/man/man3/MPI_File_preallocate.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_preallocate 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_preallocate\fP \- Preallocates a specified amount of storage space  at the beginning of a file (collective). 

--- a/ompi/mpi/man/man3/MPI_File_read.3in
+++ b/ompi/mpi/man/man3/MPI_File_read.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read\fP \- Reads a file starting at the location specified by the individual file pointer (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_read_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_all\fP \- Reads a file starting at the locations specified by individual file pointers (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_read_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all_begin.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_all_begin\fP \- Reads a file starting at the locations specified by individual file pointers; beginning part of a split collective routine (nonblocking). 

--- a/ompi/mpi/man/man3/MPI_File_read_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all_end.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_all_end\fP \- Reads a file starting at the locations specified by individual file pointers; ending part of a split collective routine (blocking). 

--- a/ompi/mpi/man/man3/MPI_File_read_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_at\fP \- Reads a file at an explicitly specified offset (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_read_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_at_all\fP \- Reads a file at explicitly specified offsets (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_read_at_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all_begin.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_at_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_at_all_begin\fP \- Reads a file at explicitly specified offsets; beginning part of a split collective routine (nonblocking).

--- a/ompi/mpi/man/man3/MPI_File_read_at_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all_end.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_at_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_at_all_end\fP \- Reads a file at explicitly specified offsets; ending part of a split collective routine (blocking).

--- a/ompi/mpi/man/man3/MPI_File_read_ordered.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_ordered 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_ordered\fP \- Reads a file at a location specified by a shared file pointer (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_read_ordered_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered_begin.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_ordered_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_ordered_begin\fP \- Reads a file at a location specified by a shared file pointer; beginning part of a split collective routine (nonblocking).

--- a/ompi/mpi/man/man3/MPI_File_read_ordered_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered_end.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_ordered_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_ordered_end\fP \- Reads a file at a location specified by a shared file pointer; ending part of a split collective routine (blocking).

--- a/ompi/mpi/man/man3/MPI_File_read_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_shared.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_read_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_read_shared\fP \- Reads a file using the shared file pointer (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_seek.3in
+++ b/ompi/mpi/man/man3/MPI_File_seek.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_seek 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_seek\fP \- Updates individual file pointers (noncollective).

--- a/ompi/mpi/man/man3/MPI_File_seek_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_seek_shared.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_seek_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_seek_shared\fP \- Updates the global shared file pointer (collective).

--- a/ompi/mpi/man/man3/MPI_File_set_atomicity.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_atomicity.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_set_atomicity 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_set_atomicity\fP \- Sets consistency semantics for data-access operations (collective).

--- a/ompi/mpi/man/man3/MPI_File_set_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_set_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_set_errhandler \fP \- Sets the error handler for a file. 

--- a/ompi/mpi/man/man3/MPI_File_set_info.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_info.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_set_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_set_info\fP \- Sets new values for hints (collective). 

--- a/ompi/mpi/man/man3/MPI_File_set_size.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_set_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_set_size\fP \- Resizes a file (collective).

--- a/ompi/mpi/man/man3/MPI_File_set_view.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_view.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_set_view 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_set_view\fP \- Changes process's view of data in file (collective).

--- a/ompi/mpi/man/man3/MPI_File_sync.3in
+++ b/ompi/mpi/man/man3/MPI_File_sync.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_sync 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_sync\fP \- Makes semantics consistent for data-access operations (collective). 

--- a/ompi/mpi/man/man3/MPI_File_write.3in
+++ b/ompi/mpi/man/man3/MPI_File_write.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write\fP \- Writes a file starting at the location specified by the individual file pointer (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_write_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_all\fP \- Writes a file starting at the locations specified by individual file pointers (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_write_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all_begin.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_all_begin\fP \- Writes a file starting at the locations specified by individual file pointers; beginning part of a split collective routine (nonblocking). 

--- a/ompi/mpi/man/man3/MPI_File_write_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all_end.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_all_end\fP \- Writes a file starting at the locations specified by individual file pointers; ending part of a split collective routine (blocking). 

--- a/ompi/mpi/man/man3/MPI_File_write_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_at\fP \- Writes a file at an explicitly specified offset (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_File_write_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_at_all\fP \- Writes a file at explicitly specified offsets (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_write_at_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all_begin.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_at_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_at_all_begin\fP \- Writes a file at explicitly specified offsets; beginning part of a split collective routine (nonblocking).

--- a/ompi/mpi/man/man3/MPI_File_write_at_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all_end.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_at_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_at_all_end\fP \- Writes a file at explicitly specified offsets; ending part of a split collective routine (blocking).

--- a/ompi/mpi/man/man3/MPI_File_write_ordered.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_ordered 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_ordered\fP \- Writes a file at a location specified by a shared file pointer (blocking, collective).

--- a/ompi/mpi/man/man3/MPI_File_write_ordered_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered_begin.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_ordered_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_ordered_begin\fP \- Writes a file at a location specified by a shared file pointer; beginning part of a split collective routine (nonblocking).

--- a/ompi/mpi/man/man3/MPI_File_write_ordered_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered_end.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_ordered_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_ordered_end\fP \- Writes a file at a location specified by a shared file pointer; ending part of a split collective routine (blocking).

--- a/ompi/mpi/man/man3/MPI_File_write_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_shared.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_File_write_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_File_write_shared\fP \- Writes a file using the shared file pointer (blocking, noncollective).

--- a/ompi/mpi/man/man3/MPI_Finalize.3in
+++ b/ompi/mpi/man/man3/MPI_Finalize.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Finalize 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Finalize \fP \- Terminates MPI execution environment.

--- a/ompi/mpi/man/man3/MPI_Finalized.3in
+++ b/ompi/mpi/man/man3/MPI_Finalized.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Finalized 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Finalized \fP \- Checks whether MPI_Finalize has completed. 

--- a/ompi/mpi/man/man3/MPI_Free_mem.3in
+++ b/ompi/mpi/man/man3/MPI_Free_mem.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Free_mem 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Free_mem \fP \- Frees memory that has been allocated using MPI_Alloc_mem.

--- a/ompi/mpi/man/man3/MPI_Gather.3in
+++ b/ompi/mpi/man/man3/MPI_Gather.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Gather 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Gather, MPI_Igather\fP \- Gathers values from a group of processes.

--- a/ompi/mpi/man/man3/MPI_Gatherv.3in
+++ b/ompi/mpi/man/man3/MPI_Gatherv.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Gatherv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Gatherv, MPI_Igatherv\fP \- Gathers varying amounts of data from all processes to the root process

--- a/ompi/mpi/man/man3/MPI_Get.3in
+++ b/ompi/mpi/man/man3/MPI_Get.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright 2014 Los Alamos National Security, LLC. All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get\fP, \fBMPI_Rget\fP \- Copies data from the target memory to the origin.

--- a/ompi/mpi/man/man3/MPI_Get_accumulate.3in
+++ b/ompi/mpi/man/man3/MPI_Get_accumulate.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Get_accumulate 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get_accumulate\fP, \fBMPI_Rget_accumulate\fP \- Combines the contents of the origin buffer with that of a target buffer and returns the target buffer value.

--- a/ompi/mpi/man/man3/MPI_Get_address.3in
+++ b/ompi/mpi/man/man3/MPI_Get_address.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Get_address 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get_address\fP \- Gets the address of a location in memory. 

--- a/ompi/mpi/man/man3/MPI_Get_count.3in
+++ b/ompi/mpi/man/man3/MPI_Get_count.3in
@@ -2,6 +2,7 @@
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Get_count 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get_count \fP \- Gets the number of top-level elements received.

--- a/ompi/mpi/man/man3/MPI_Get_elements.3in
+++ b/ompi/mpi/man/man3/MPI_Get_elements.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Get_elements 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get_elements, MPI_Get_elements_x\fP \- Returns the number of basic elements in a data type.

--- a/ompi/mpi/man/man3/MPI_Get_library_version.3in
+++ b/ompi/mpi/man/man3/MPI_Get_library_version.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Get_processor_name.3in
+++ b/ompi/mpi/man/man3/MPI_Get_processor_name.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc. All rights reserved. Use is subject to license terms.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Get_processor_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Get_processor_name \fP \- Gets the name of the processor.

--- a/ompi/mpi/man/man3/MPI_Get_version.3in
+++ b/ompi/mpi/man/man3/MPI_Get_version.3in
@@ -1,3 +1,4 @@
+.\" -*- nroff -*-
 .\" Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation

--- a/ompi/mpi/man/man3/MPI_Graph_create.3in
+++ b/ompi/mpi/man/man3/MPI_Graph_create.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graph_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graph_create \fP \- Makes a new communicator to which topology information has been attached.

--- a/ompi/mpi/man/man3/MPI_Graph_get.3in
+++ b/ompi/mpi/man/man3/MPI_Graph_get.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graph_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graph_get \fP \- Retrieves graph topology information associated with a communicator.

--- a/ompi/mpi/man/man3/MPI_Graph_map.3in
+++ b/ompi/mpi/man/man3/MPI_Graph_map.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graph_map 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graph_map \fP \- Maps process to graph topology information.

--- a/ompi/mpi/man/man3/MPI_Graph_neighbors.3in
+++ b/ompi/mpi/man/man3/MPI_Graph_neighbors.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graph_neighbors 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graph_neighbors \fP \- Returns the neighbors of a node associated with a graph topology.

--- a/ompi/mpi/man/man3/MPI_Graph_neighbors_count.3in
+++ b/ompi/mpi/man/man3/MPI_Graph_neighbors_count.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graph_neighbors_count 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graph_neighbors_count \fP \- Returns the number of neighbors of a node associated with a graph topology.

--- a/ompi/mpi/man/man3/MPI_Graphdims_get.3in
+++ b/ompi/mpi/man/man3/MPI_Graphdims_get.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Graphdims_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Graphdims_get \fP \- Retrieves graph topology information associated with a communicator.

--- a/ompi/mpi/man/man3/MPI_Grequest_complete.3in
+++ b/ompi/mpi/man/man3/MPI_Grequest_complete.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Grequest_complete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Grequest_complete \fP \- Reports that a generalized request is complete. 

--- a/ompi/mpi/man/man3/MPI_Grequest_start.3in
+++ b/ompi/mpi/man/man3/MPI_Grequest_start.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Grequest_start 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Grequest_start \fP \- Starts a generalized request and returns a handle to it in \fIrequest\fP. 

--- a/ompi/mpi/man/man3/MPI_Group_compare.3in
+++ b/ompi/mpi/man/man3/MPI_Group_compare.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_compare 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_compare \fP \- Compares two groups.

--- a/ompi/mpi/man/man3/MPI_Group_difference.3in
+++ b/ompi/mpi/man/man3/MPI_Group_difference.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_difference 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_difference \fP \- Makes a group from the difference of two groups.

--- a/ompi/mpi/man/man3/MPI_Group_excl.3in
+++ b/ompi/mpi/man/man3/MPI_Group_excl.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_excl 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_excl\fP \- Produces a group by reordering an existing group and taking only unlisted members.

--- a/ompi/mpi/man/man3/MPI_Group_free.3in
+++ b/ompi/mpi/man/man3/MPI_Group_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_free \fP \- Frees a group.

--- a/ompi/mpi/man/man3/MPI_Group_incl.3in
+++ b/ompi/mpi/man/man3/MPI_Group_incl.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_incl 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_incl \fP \- Produces a group by reordering an existing group and taking only listed members.

--- a/ompi/mpi/man/man3/MPI_Group_intersection.3in
+++ b/ompi/mpi/man/man3/MPI_Group_intersection.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_intersection 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_intersection \fP \- Produces a group at the intersection of two existing groups.

--- a/ompi/mpi/man/man3/MPI_Group_range_excl.3in
+++ b/ompi/mpi/man/man3/MPI_Group_range_excl.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_range_excl 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_range_excl\fP \- Produces a group by excluding ranges of processes from an existing group.

--- a/ompi/mpi/man/man3/MPI_Group_range_incl.3in
+++ b/ompi/mpi/man/man3/MPI_Group_range_incl.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_range_incl 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_range_incl\fP \- Creates a new group from ranges of ranks in an existing group.

--- a/ompi/mpi/man/man3/MPI_Group_rank.3in
+++ b/ompi/mpi/man/man3/MPI_Group_rank.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_rank 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_rank\fP \- Returns the rank of the calling process in the given group.

--- a/ompi/mpi/man/man3/MPI_Group_size.3in
+++ b/ompi/mpi/man/man3/MPI_Group_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_size\fP \- Returns the size of a group.

--- a/ompi/mpi/man/man3/MPI_Group_translate_ranks.3in
+++ b/ompi/mpi/man/man3/MPI_Group_translate_ranks.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_translate_ranks 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_translate_ranks\fP \- Translates the ranks of processes in one group to those in another group.

--- a/ompi/mpi/man/man3/MPI_Group_union.3in
+++ b/ompi/mpi/man/man3/MPI_Group_union.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Group_union 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Group_union \fP \- Produces a group by combining two groups.

--- a/ompi/mpi/man/man3/MPI_Ibsend.3in
+++ b/ompi/mpi/man/man3/MPI_Ibsend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Ibsend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Ibsend\fP \- Starts a nonblocking buffered send.

--- a/ompi/mpi/man/man3/MPI_Improbe.3in
+++ b/ompi/mpi/man/man3/MPI_Improbe.3in
@@ -1,6 +1,9 @@
+.\" -*- nroff -*-
+.\" Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 .\" Copyright 2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Improbe 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Improbe\fP \- Non-blocking matched probe for a message.

--- a/ompi/mpi/man/man3/MPI_Imrecv.3in
+++ b/ompi/mpi/man/man3/MPI_Imrecv.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Imrecv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Imrecv\fP \- Non-blocking receive for a matched message

--- a/ompi/mpi/man/man3/MPI_Info_create.3in
+++ b/ompi/mpi/man/man3/MPI_Info_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_create\fP \- Creates a new info object.

--- a/ompi/mpi/man/man3/MPI_Info_delete.3in
+++ b/ompi/mpi/man/man3/MPI_Info_delete.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_delete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_delete\fP \- Deletes a key/value pair from \fIinfo\fP. 

--- a/ompi/mpi/man/man3/MPI_Info_dup.3in
+++ b/ompi/mpi/man/man3/MPI_Info_dup.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_dup 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_dup\fP \- Duplicates an info object. 

--- a/ompi/mpi/man/man3/MPI_Info_env.3in
+++ b/ompi/mpi/man/man3/MPI_Info_env.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2012 Los Alamos National Security, LLC.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_INFO_ENV 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_INFO_ENV\fP \- Static MPI_Info object containing info about the application

--- a/ompi/mpi/man/man3/MPI_Info_free.3in
+++ b/ompi/mpi/man/man3/MPI_Info_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_free\fP \- Frees an info object. 

--- a/ompi/mpi/man/man3/MPI_Info_get.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_get\fP \- Retrieves the value associated with a key in an info object. 

--- a/ompi/mpi/man/man3/MPI_Info_get_nkeys.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get_nkeys.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_get_nkeys 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_get_nkeys\fP \- Gets the number of keys currently defined in an info object. 

--- a/ompi/mpi/man/man3/MPI_Info_get_nthkey.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get_nthkey.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_get_nthkey 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_get_nthkey\fP \- Returns the \fIn\fPth defined key in \fIinfo\fP.

--- a/ompi/mpi/man/man3/MPI_Info_get_valuelen.3in
+++ b/ompi/mpi/man/man3/MPI_Info_get_valuelen.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_get_valuelen 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_get_valuelen\fP \- Retrieves the length of the key value associated with an info object. 

--- a/ompi/mpi/man/man3/MPI_Info_set.3in
+++ b/ompi/mpi/man/man3/MPI_Info_set.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Info_set 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Info_set\fP \- Adds a key/value pair to \fIinfo\fP.

--- a/ompi/mpi/man/man3/MPI_Init.3in
+++ b/ompi/mpi/man/man3/MPI_Init.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Init_thread.3in
+++ b/ompi/mpi/man/man3/MPI_Init_thread.3in
@@ -1,7 +1,8 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Init_thread 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Initialized.3in
+++ b/ompi/mpi/man/man3/MPI_Initialized.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Initialized 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Initialized\fP \- Indicates whether MPI_Init has been called.

--- a/ompi/mpi/man/man3/MPI_Intercomm_create.3in
+++ b/ompi/mpi/man/man3/MPI_Intercomm_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Intercomm_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Intercomm_create\fP \- Creates an intercommunicator from two intracommunicators.

--- a/ompi/mpi/man/man3/MPI_Intercomm_merge.3in
+++ b/ompi/mpi/man/man3/MPI_Intercomm_merge.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Intercomm_merge 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Intercomm_merge\fP \- Creates an intracommunicator from an intercommunicator.

--- a/ompi/mpi/man/man3/MPI_Iprobe.3in
+++ b/ompi/mpi/man/man3/MPI_Iprobe.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Iprobe 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Iprobe\fP \- Nonblocking test for a message.

--- a/ompi/mpi/man/man3/MPI_Irecv.3in
+++ b/ompi/mpi/man/man3/MPI_Irecv.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Irecv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Irecv\fP \- Starts a standard-mode, nonblocking receive.

--- a/ompi/mpi/man/man3/MPI_Irsend.3in
+++ b/ompi/mpi/man/man3/MPI_Irsend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Irsend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Irsend\fP \- Starts a ready-mode nonblocking send.

--- a/ompi/mpi/man/man3/MPI_Is_thread_main.3in
+++ b/ompi/mpi/man/man3/MPI_Is_thread_main.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Is_thread_main 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Isend.3in
+++ b/ompi/mpi/man/man3/MPI_Isend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Isend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Isend\fP \- Starts a standard-mode, nonblocking send.

--- a/ompi/mpi/man/man3/MPI_Issend.3in
+++ b/ompi/mpi/man/man3/MPI_Issend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Issend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Issend\fP \- Starts a nonblocking synchronous send.

--- a/ompi/mpi/man/man3/MPI_Keyval_create.3in
+++ b/ompi/mpi/man/man3/MPI_Keyval_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Keyval_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Keyval_create\fP \- Generates a new attribute key -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Keyval_free.3in
+++ b/ompi/mpi/man/man3/MPI_Keyval_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Keyval_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Keyval_free\fP \- Frees attribute key for communicator cache attribute -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Lookup_name.3in
+++ b/ompi/mpi/man/man3/MPI_Lookup_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Lookup_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Mprobe.3in
+++ b/ompi/mpi/man/man3/MPI_Mprobe.3in
@@ -1,6 +1,9 @@
+.\" -*- nroff -*-
+.\" Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 .\" Copyright 2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Mprobe 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Mprobe\fP \- Blocking matched probe for a message.

--- a/ompi/mpi/man/man3/MPI_Mrecv.3in
+++ b/ompi/mpi/man/man3/MPI_Mrecv.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2012 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Mrecv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Mrecv\fP \- Blocking receive for a matched message

--- a/ompi/mpi/man/man3/MPI_Neighbor_allgather.3in
+++ b/ompi/mpi/man/man3/MPI_Neighbor_allgather.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Neighbor_allgather 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Neighbor_allgather, MPI_Ineighbor_allgather\fP \- Gathers and distributes data from and to all neighbors

--- a/ompi/mpi/man/man3/MPI_Neighbor_allgatherv.3in
+++ b/ompi/mpi/man/man3/MPI_Neighbor_allgatherv.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Neighbor_allgatherv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Neighbor_allgatherv, MPI_Ineighbor_allgatherv\fP \- Gathers and distributes data from and to all neighbors. Each process may contribute a different amount of data.

--- a/ompi/mpi/man/man3/MPI_Neighbor_alltoall.3in
+++ b/ompi/mpi/man/man3/MPI_Neighbor_alltoall.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Neighbor_alltoall 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Neighbor_alltoallv.3in
+++ b/ompi/mpi/man/man3/MPI_Neighbor_alltoallv.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Neighbor_alltoallv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Neighbor_alltoallw.3in
+++ b/ompi/mpi/man/man3/MPI_Neighbor_alltoallw.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Neighbor_alltoallw 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Op_create.3in
+++ b/ompi/mpi/man/man3/MPI_Op_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Op_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Op_create\fP \- Creates a user-defined combination function handle.

--- a/ompi/mpi/man/man3/MPI_Op_free.3in
+++ b/ompi/mpi/man/man3/MPI_Op_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Op_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Op_free\fP \- Frees a user-defined combination function handle.

--- a/ompi/mpi/man/man3/MPI_Open_port.3in
+++ b/ompi/mpi/man/man3/MPI_Open_port.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Open_port 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Open_port\fP \- Establishes a network address for a server to accept connections from clients.

--- a/ompi/mpi/man/man3/MPI_Pack.3in
+++ b/ompi/mpi/man/man3/MPI_Pack.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Pack 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Pack\fP \- Packs data of a given datatype into contiguous memory.

--- a/ompi/mpi/man/man3/MPI_Pack_external.3in
+++ b/ompi/mpi/man/man3/MPI_Pack_external.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Pack_external 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Pack_external_size.3in
+++ b/ompi/mpi/man/man3/MPI_Pack_external_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Pack_external_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Pack_size.3in
+++ b/ompi/mpi/man/man3/MPI_Pack_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Pack_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Pack_size\fP \- Returns the upper bound on the amount of space needed to pack a message.

--- a/ompi/mpi/man/man3/MPI_Pcontrol.3in
+++ b/ompi/mpi/man/man3/MPI_Pcontrol.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Pcontrol 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Pcontrol\fP \- Controls profiling.

--- a/ompi/mpi/man/man3/MPI_Probe.3in
+++ b/ompi/mpi/man/man3/MPI_Probe.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Probe 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Probe\fP \- Blocking test for a message.

--- a/ompi/mpi/man/man3/MPI_Publish_name.3in
+++ b/ompi/mpi/man/man3/MPI_Publish_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Publish_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Put.3in
+++ b/ompi/mpi/man/man3/MPI_Put.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Put 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Put\fP, \fBMPI_Rput\fP \- Copies data from the origin memory to the target.

--- a/ompi/mpi/man/man3/MPI_Query_thread.3in
+++ b/ompi/mpi/man/man3/MPI_Query_thread.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Query_thread 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Recv.3in
+++ b/ompi/mpi/man/man3/MPI_Recv.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Recv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Recv\fP \- Performs a standard-mode blocking receive.

--- a/ompi/mpi/man/man3/MPI_Recv_init.3in
+++ b/ompi/mpi/man/man3/MPI_Recv_init.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Recv_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Recv_init\fP \- Builds a handle for a receive.

--- a/ompi/mpi/man/man3/MPI_Reduce.3in
+++ b/ompi/mpi/man/man3/MPI_Reduce.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Reduce 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Reduce, MPI_Ireduce\fP \- Reduces values on all processes within a group.

--- a/ompi/mpi/man/man3/MPI_Reduce_local.3in
+++ b/ompi/mpi/man/man3/MPI_Reduce_local.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Reduce_local 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Reduce_local\fP \- Perform a local reduction

--- a/ompi/mpi/man/man3/MPI_Reduce_scatter.3in
+++ b/ompi/mpi/man/man3/MPI_Reduce_scatter.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Reduce_scatter 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Reduce_scatter, MPI_Ireduce_scatter\fP \- Combines values and scatters the results.

--- a/ompi/mpi/man/man3/MPI_Reduce_scatter_block.3in
+++ b/ompi/mpi/man/man3/MPI_Reduce_scatter_block.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Reduce_scatter_block 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Reduce_scatter_block, MPI_Ireduce_scatter_block\fP \- Combines values and scatters the results in blocks.

--- a/ompi/mpi/man/man3/MPI_Register_datarep.3in
+++ b/ompi/mpi/man/man3/MPI_Register_datarep.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Register_datarep 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Register_datarep\fP \- Defines data representation. 

--- a/ompi/mpi/man/man3/MPI_Request_free.3in
+++ b/ompi/mpi/man/man3/MPI_Request_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Request_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Request_free\fP \- Frees a communication request object.

--- a/ompi/mpi/man/man3/MPI_Request_get_status.3in
+++ b/ompi/mpi/man/man3/MPI_Request_get_status.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Request_get_status 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Request_get_status\fP \- Access information associated with a request without freeing the request. 

--- a/ompi/mpi/man/man3/MPI_Rsend.3in
+++ b/ompi/mpi/man/man3/MPI_Rsend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Rsend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Rsend\fP \- Ready send.

--- a/ompi/mpi/man/man3/MPI_Rsend_init.3in
+++ b/ompi/mpi/man/man3/MPI_Rsend_init.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Rsend_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Rsend_init\fP \- Builds a handle for a ready send.

--- a/ompi/mpi/man/man3/MPI_Scan.3in
+++ b/ompi/mpi/man/man3/MPI_Scan.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Scan 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Scatter.3in
+++ b/ompi/mpi/man/man3/MPI_Scatter.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Scatter 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Scatter, MPI_Iscatter\fP \- Sends data from one task to all tasks in a group.

--- a/ompi/mpi/man/man3/MPI_Scatterv.3in
+++ b/ompi/mpi/man/man3/MPI_Scatterv.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Scatterv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Scatterv, MPI_Iscatterv\fP \- Scatters a buffer in parts to all tasks in a group.

--- a/ompi/mpi/man/man3/MPI_Send.3in
+++ b/ompi/mpi/man/man3/MPI_Send.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Send 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Send\fP \- Performs a standard-mode blocking send.

--- a/ompi/mpi/man/man3/MPI_Send_init.3in
+++ b/ompi/mpi/man/man3/MPI_Send_init.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Send_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Send_init\fP \- Builds a handle for a standard send.

--- a/ompi/mpi/man/man3/MPI_Sendrecv.3in
+++ b/ompi/mpi/man/man3/MPI_Sendrecv.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Sendrecv 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Sendrecv\fP \- Sends and receives a message.

--- a/ompi/mpi/man/man3/MPI_Sendrecv_replace.3in
+++ b/ompi/mpi/man/man3/MPI_Sendrecv_replace.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Sendrecv_replace 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Sendrecv_replace\fP \- Sends and receives a message using a single buffer.

--- a/ompi/mpi/man/man3/MPI_Sizeof.3in
+++ b/ompi/mpi/man/man3/MPI_Sizeof.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Sizeof 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Ssend.3in
+++ b/ompi/mpi/man/man3/MPI_Ssend.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Ssend 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Ssend\fP \- Standard synchronous send.

--- a/ompi/mpi/man/man3/MPI_Ssend_init.3in
+++ b/ompi/mpi/man/man3/MPI_Ssend_init.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Ssend_init 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Ssend_init\fP \- Builds a handle for a synchronous send.

--- a/ompi/mpi/man/man3/MPI_Start.3in
+++ b/ompi/mpi/man/man3/MPI_Start.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Start 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Start\fP \- Initiates a communication using a persistent request handle.

--- a/ompi/mpi/man/man3/MPI_Startall.3in
+++ b/ompi/mpi/man/man3/MPI_Startall.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Startall 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Startall\fP \- Starts a collection of requests.

--- a/ompi/mpi/man/man3/MPI_Status_f2c.3in
+++ b/ompi/mpi/man/man3/MPI_Status_f2c.3in
@@ -2,6 +2,7 @@
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Status_f2c 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Status_f2c, MPI_Status_c2f \fP \- Translates a C status into a Fortran status, or vice versa.

--- a/ompi/mpi/man/man3/MPI_Status_set_cancelled.3in
+++ b/ompi/mpi/man/man3/MPI_Status_set_cancelled.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Status_set_cancelled 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Status_set_cancelled\fP \- Sets \fIstatus\fP to indicate a request has been canceled. 

--- a/ompi/mpi/man/man3/MPI_Status_set_elements.3in
+++ b/ompi/mpi/man/man3/MPI_Status_set_elements.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Status_set_elements 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Status_set_elements\fP, \fBMPI_Status_set_elements_x\fP \- Modifies opaque part of \fIstatus\fP to allow MPI_Get_elements to return \fIcount\fP.

--- a/ompi/mpi/man/man3/MPI_T_category_changed.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_changed.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_changed 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_category_get_categories.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_get_categories.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_get_categories 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_category_get_cvars.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_get_cvars.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_get_cvars 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_category_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_get_info.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_category_get_num.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_get_num.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_get_num 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_category_get_pvars.3in
+++ b/ompi/mpi/man/man3/MPI_T_category_get_pvars.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_category_get_pvars 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_cvar_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_T_cvar_get_info.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_cvar_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_cvar_get_num.3in
+++ b/ompi/mpi/man/man3/MPI_T_cvar_get_num.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_cvar_get_num 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_cvar_handle_alloc.3in
+++ b/ompi/mpi/man/man3/MPI_T_cvar_handle_alloc.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_cvar_handle_alloc 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_cvar_read.3in
+++ b/ompi/mpi/man/man3/MPI_T_cvar_read.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_cvar_read 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_cvar_write.3in
+++ b/ompi/mpi/man/man3/MPI_T_cvar_write.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_cvar_write 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_enum_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_T_enum_get_info.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_enum_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_enum_get_item.3in
+++ b/ompi/mpi/man/man3/MPI_T_enum_get_item.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_enum_get_item 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_finalize.3in
+++ b/ompi/mpi/man/man3/MPI_T_finalize.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_T_finalize 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_T_finalize \fP \- Finalize the MPI tool information interface

--- a/ompi/mpi/man/man3/MPI_T_init_thread.3in
+++ b/ompi/mpi/man/man3/MPI_T_init_thread.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_init_thread 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_get_info.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_get_num.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_get_num.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_get_num 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_handle_alloc.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_handle_alloc.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_handle_alloc 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_read.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_read.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_read 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_readreset.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_readreset.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_readreset 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_reset.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_reset.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_reset 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_session_create.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_session_create.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_session_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_start.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_start.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_start 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_T_pvar_write.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_write.3in
@@ -1,8 +1,9 @@
-. -*- nroff -*-
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_T_pvar_write 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Test.3in
+++ b/ompi/mpi/man/man3/MPI_Test.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright 2007-2008 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Test 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Test\fP \- Tests for the completion of a specific send or receive.

--- a/ompi/mpi/man/man3/MPI_Test_cancelled.3in
+++ b/ompi/mpi/man/man3/MPI_Test_cancelled.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Test_cancelled 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Test_cancelled\fP \- Tests whether a request was canceled.

--- a/ompi/mpi/man/man3/MPI_Testall.3in
+++ b/ompi/mpi/man/man3/MPI_Testall.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Testall 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Testall\fP \- Tests for the completion of all previously initiated communications in a list.

--- a/ompi/mpi/man/man3/MPI_Testany.3in
+++ b/ompi/mpi/man/man3/MPI_Testany.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Testany 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Testany\fP \- Tests for completion of any one previously initiated communication in a list. 

--- a/ompi/mpi/man/man3/MPI_Testsome.3in
+++ b/ompi/mpi/man/man3/MPI_Testsome.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Testsome 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Testsome\fP \- Tests for completion of one or more previously initiated communications in a list. 

--- a/ompi/mpi/man/man3/MPI_Topo_test.3in
+++ b/ompi/mpi/man/man3/MPI_Topo_test.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Topo_test 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Topo_test\fP \- Determines the type of topology (if any) associated with a communicator.

--- a/ompi/mpi/man/man3/MPI_Type_commit.3in
+++ b/ompi/mpi/man/man3/MPI_Type_commit.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_commit 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_commit\fP \- Commits a data type.

--- a/ompi/mpi/man/man3/MPI_Type_contiguous.3in
+++ b/ompi/mpi/man/man3/MPI_Type_contiguous.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_contiguous 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_contiguous\fP \- Creates a contiguous datatype.

--- a/ompi/mpi/man/man3/MPI_Type_create_darray.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_darray.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_darray 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_darray\fP \- Creates a distributed array datatype;

--- a/ompi/mpi/man/man3/MPI_Type_create_f90_complex.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_f90_complex.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_f90_complex 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Type_create_f90_integer.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_f90_integer.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_f90_integer 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Type_create_f90_real.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_f90_real.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_f90_real 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Type_create_hvector.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_hvector.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_hvector 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_hvector\fP \- Creates a vector (strided) data type with offset in bytes. 

--- a/ompi/mpi/man/man3/MPI_Type_create_indexed_block.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_indexed_block.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_indexed_block 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_indexed_block, MPI_Type_create_hindexed_block\fP \- Creates an indexed data type with the same block length for all blocks.

--- a/ompi/mpi/man/man3/MPI_Type_create_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_keyval\fP \- Generates a new attribute key for caching on data types. 

--- a/ompi/mpi/man/man3/MPI_Type_create_resized.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_resized.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_create_resized 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_resized\fP \- Returns a new data type with new extent and upper and lower bounds. 

--- a/ompi/mpi/man/man3/MPI_Type_create_struct.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_struct.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_struct 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_struct\fP \- Creates a structured data type. 

--- a/ompi/mpi/man/man3/MPI_Type_create_subarray.3in
+++ b/ompi/mpi/man/man3/MPI_Type_create_subarray.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_create_subarray 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_create_subarray\fP \- Creates a data type describing an \fIn\fP-dimensional subarray of an \fIn\fP-dimensional array. 

--- a/ompi/mpi/man/man3/MPI_Type_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Type_delete_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_delete_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_delete_attr\fP \- Deletes a datatype-caching attribute value associated with a key. 

--- a/ompi/mpi/man/man3/MPI_Type_dup.3in
+++ b/ompi/mpi/man/man3/MPI_Type_dup.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_dup 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_dup\fP \- Duplicates a data type with associated key values.

--- a/ompi/mpi/man/man3/MPI_Type_extent.3in
+++ b/ompi/mpi/man/man3/MPI_Type_extent.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_extent\fP \- Returns the extent of a data type, the difference between the upper and lower bounds of the data type -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Type_free.3in
+++ b/ompi/mpi/man/man3/MPI_Type_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_free\fP \- Frees a data type.

--- a/ompi/mpi/man/man3/MPI_Type_free_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Type_free_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_free_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_free_keyval\fP \- Frees a previously created type key value. 

--- a/ompi/mpi/man/man3/MPI_Type_get_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_get_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_attr\fP \- Returns the attribute associated with a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_get_contents.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_contents.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_get_contents 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_contents\fP \- Returns information about arguments used in creation of a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_get_envelope 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_envelope\fP \- Returns information about input arguments associated with a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_get_extent.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_extent.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_get_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_extent\fP, \fBMPI_Type_get_extent_x\fP \- Returns the lower bound and extent of a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_get_name.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_name.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_get_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_name\fP \- Gets the name of a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_get_true_extent.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_true_extent.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_get_true_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_get_true_extent\fP, \fBMPI_Type_get_true_extent_x\fP \- Returns the true lower bound and extent of a data type's corresponding typemap, ignoring MPI_UB and MPI_LB markers. 

--- a/ompi/mpi/man/man3/MPI_Type_hvector.3in
+++ b/ompi/mpi/man/man3/MPI_Type_hvector.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_hvector 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_hvector\fP \- Creates a vector (strided) datatype with offset in bytes -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Type_lb.3in
+++ b/ompi/mpi/man/man3/MPI_Type_lb.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_lb 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_lb\fP \- Returns the lower bound of a data type -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Type_match_size.3in
+++ b/ompi/mpi/man/man3/MPI_Type_match_size.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_match_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 

--- a/ompi/mpi/man/man3/MPI_Type_set_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Type_set_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_set_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_set_attr\fP \- Sets a key value/attribute pair to a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_set_name.3in
+++ b/ompi/mpi/man/man3/MPI_Type_set_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
+.\" $COPYRIGHT$
 .TH MPI_Type_set_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_set_name\fP \- Sets the name of a data type. 

--- a/ompi/mpi/man/man3/MPI_Type_size.3in
+++ b/ompi/mpi/man/man3/MPI_Type_size.3in
@@ -1,7 +1,9 @@
+.\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_size\fP, \fBMPI_Type_size_x\fP \- Returns the number of bytes occupied by entries in a data type.

--- a/ompi/mpi/man/man3/MPI_Type_struct.3in
+++ b/ompi/mpi/man/man3/MPI_Type_struct.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_struct 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_struct\fP \- Creates a \fIstruct\fP data type -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Type_ub.3in
+++ b/ompi/mpi/man/man3/MPI_Type_ub.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_ub 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_ub\fP \- Returns the upper bound of a datatype -- use of this routine is deprecated.

--- a/ompi/mpi/man/man3/MPI_Type_vector.3in
+++ b/ompi/mpi/man/man3/MPI_Type_vector.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Type_vector 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Type_vector\fP \- Creates a vector (strided) datatype.

--- a/ompi/mpi/man/man3/MPI_Unpack.3in
+++ b/ompi/mpi/man/man3/MPI_Unpack.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Unpack 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Unpack\fP \- Unpacks a datatype into contiguous memory.

--- a/ompi/mpi/man/man3/MPI_Unpack_external.3in
+++ b/ompi/mpi/man/man3/MPI_Unpack_external.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Unpack_external 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Unpublish_name.3in
+++ b/ompi/mpi/man/man3/MPI_Unpublish_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Unpublish_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Wait.3in
+++ b/ompi/mpi/man/man3/MPI_Wait.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Wait 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Wait\fP \- Waits for an MPI send or receive to complete.

--- a/ompi/mpi/man/man3/MPI_Waitall.3in
+++ b/ompi/mpi/man/man3/MPI_Waitall.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Waitall 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Waitall\fP \- Waits for all given communications to complete.

--- a/ompi/mpi/man/man3/MPI_Waitany.3in
+++ b/ompi/mpi/man/man3/MPI_Waitany.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Waitany 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Waitany\fP \- Waits for any specified send or receive to complete.

--- a/ompi/mpi/man/man3/MPI_Waitsome.3in
+++ b/ompi/mpi/man/man3/MPI_Waitsome.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH MPI_Waitsome 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Waitsome\fP \- Waits for some given communications to complete.

--- a/ompi/mpi/man/man3/MPI_Win_call_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Win_call_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_call_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 
 .SH NAME

--- a/ompi/mpi/man/man3/MPI_Win_complete.3in
+++ b/ompi/mpi/man/man3/MPI_Win_complete.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_complete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_complete\fP \- Completes an RMA access epoch on \fIwin\fP started by a call to MPI_Win_start

--- a/ompi/mpi/man/man3/MPI_Win_create.3in
+++ b/ompi/mpi/man/man3/MPI_Win_create.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_create\fP \- One-sided MPI call that returns a window object for RMA operations.

--- a/ompi/mpi/man/man3/MPI_Win_create_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Win_create_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_create_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_create_errhandler\fP \- Creates an error handler for a window.

--- a/ompi/mpi/man/man3/MPI_Win_create_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Win_create_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_create_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_create_keyval\fP \- Creates a keyval for a window.

--- a/ompi/mpi/man/man3/MPI_Win_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Win_delete_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_delete_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_delete_attr\fP \- Deletes an attribute from a window.

--- a/ompi/mpi/man/man3/MPI_Win_fence.3in
+++ b/ompi/mpi/man/man3/MPI_Win_fence.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_fence 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_fence\fP \- Synchronizes RMA calls on a window.

--- a/ompi/mpi/man/man3/MPI_Win_flush.3in
+++ b/ompi/mpi/man/man3/MPI_Win_flush.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_flush 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_flush\fP, \fBMPI_Win_flush_all\fP \- Complete all outstanding RMA operations at both the origin and the target

--- a/ompi/mpi/man/man3/MPI_Win_flush_local.3in
+++ b/ompi/mpi/man/man3/MPI_Win_flush_local.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_flush_local 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_flush_local\fP, \fBMPI_Win_flush_local_all\fP \- Complete all outstanding RMA operations at both the origin

--- a/ompi/mpi/man/man3/MPI_Win_free.3in
+++ b/ompi/mpi/man/man3/MPI_Win_free.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_free 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_free\fP \- Frees the window object and returns a null handle.

--- a/ompi/mpi/man/man3/MPI_Win_free_keyval.3in
+++ b/ompi/mpi/man/man3/MPI_Win_free_keyval.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_free_keyval 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_free_keyval\fP \- Frees a window keyval.

--- a/ompi/mpi/man/man3/MPI_Win_get_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Win_get_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_get_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_get_attr\fP \- Obtains the value of a window attribute.

--- a/ompi/mpi/man/man3/MPI_Win_get_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Win_get_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_get_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_get_errhandler\fP \- Retrieves the error handler currently associated with a window.

--- a/ompi/mpi/man/man3/MPI_Win_get_group.3in
+++ b/ompi/mpi/man/man3/MPI_Win_get_group.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_get_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_get_group\fP \- Returns a duplicate of the group of the communicator used to create the window. 

--- a/ompi/mpi/man/man3/MPI_Win_get_name.3in
+++ b/ompi/mpi/man/man3/MPI_Win_get_name.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_get_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_get_name\fP \- Obtains the name of a window.

--- a/ompi/mpi/man/man3/MPI_Win_lock.3in
+++ b/ompi/mpi/man/man3/MPI_Win_lock.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_lock 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_lock\fP \- Starts an RMA access epoch locking access to a particular rank.

--- a/ompi/mpi/man/man3/MPI_Win_lock_all.3in
+++ b/ompi/mpi/man/man3/MPI_Win_lock_all.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_lock_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_lock_all\fP \- Starts an RMA access epoch locking access to all processes in the window

--- a/ompi/mpi/man/man3/MPI_Win_post.3in
+++ b/ompi/mpi/man/man3/MPI_Win_post.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_post 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_post\fP \- Starts an RMA exposure epoch for the local window associated with \fIwin\fP

--- a/ompi/mpi/man/man3/MPI_Win_set_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Win_set_attr.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_set_attr 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_set_attr\fP \- Sets the value of a window attribute.

--- a/ompi/mpi/man/man3/MPI_Win_set_errhandler.3in
+++ b/ompi/mpi/man/man3/MPI_Win_set_errhandler.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_set_errhandler 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_set_errhandler\fP \- Attaches a new error handler to a window.

--- a/ompi/mpi/man/man3/MPI_Win_set_name.3in
+++ b/ompi/mpi/man/man3/MPI_Win_set_name.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_set_name 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_set_name\fP \- Sets the name of a window.

--- a/ompi/mpi/man/man3/MPI_Win_start.3in
+++ b/ompi/mpi/man/man3/MPI_Win_start.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_start 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_start\fP \- Starts an RMA access epoch for \fIwin\fP

--- a/ompi/mpi/man/man3/MPI_Win_sync.3in
+++ b/ompi/mpi/man/man3/MPI_Win_sync.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_sync 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_sync\fP, \- Synchronize the private and public copies of the window

--- a/ompi/mpi/man/man3/MPI_Win_test.3in
+++ b/ompi/mpi/man/man3/MPI_Win_test.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_test 3 "#OMPI_DATE#" ""#PACKAGE_VERSION#"" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_test\fP \- Attempts to complete an RMA exposure epoch; a nonblocking version of MPI_Win_wait

--- a/ompi/mpi/man/man3/MPI_Win_unlock.3in
+++ b/ompi/mpi/man/man3/MPI_Win_unlock.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_unlock 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_unlock\fP \- Completes an RMA access epoch started by a call to MPI_Win_lock. 

--- a/ompi/mpi/man/man3/MPI_Win_unlock_all.3in
+++ b/ompi/mpi/man/man3/MPI_Win_unlock_all.3in
@@ -3,6 +3,7 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_unlock_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_unlock_all\fP \- Completes an RMA access epoch started by a call to MPI_Win_lock_all.

--- a/ompi/mpi/man/man3/MPI_Win_wait.3in
+++ b/ompi/mpi/man/man3/MPI_Win_wait.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2007-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Win_wait 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Win_wait\fP \- Completes an RMA exposure epoch started by a call to MPI_Win_post on \fIwin\fP

--- a/ompi/mpi/man/man3/MPI_Wtick.3in
+++ b/ompi/mpi/man/man3/MPI_Wtick.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Wtick 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Wtick\fP \- Returns the resolution of MPI_Wtime.

--- a/ompi/mpi/man/man3/MPI_Wtime.3in
+++ b/ompi/mpi/man/man3/MPI_Wtime.3in
@@ -1,5 +1,7 @@
+.\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
 .TH MPI_Wtime 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBMPI_Wtime\fP \- Returns an elapsed time on the calling processor.


### PR DESCRIPTION
Two commits:
1. Remove stale Java references
2. Add $COPYRIGHT$ and -_\- nroff -_\- tokens to all pages

@rhc54 please review

There's no rush on this; I marked milestone 1.8.4, but this could certainly slip to 1.8.5.
