### PR TITLE
help-opal-shmem-mmap.txt: trivial typo fix

### DIFF
--- a/opal/mca/shmem/mmap/help-opal-shmem-mmap.txt
+++ b/opal/mca/shmem/mmap/help-opal-shmem-mmap.txt
@@ -1,7 +1,7 @@
 # -*- text -*-
 #
-# Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2010      Los Alamos National Security, LLC.
+# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2012 Los Alamos National Security, LLC.
 #                         All rights reserved.
 #
 # $COPYRIGHT$
@@ -38,7 +38,7 @@ where Open MPI is disallowed from creating temporary files by setting
 the MCA parameter "orte_no_session_dir".
 
   Local host: %s
-  Fileame:    %s
+  Filename:   %s
 
 You can set the MCA paramter shmem_mmap_enable_nfs_warning to 0 to
 disable this message.


### PR DESCRIPTION
Cherry picked from commit open-mpi/ompi@5207429734d131f80397c7bdab12f52de05881a2
