### PR TITLE
btl/sm: fix a typo in the error message

### DIFF
--- a/ompi/mca/btl/sm/btl_sm_component.c
+++ b/ompi/mca/btl/sm/btl_sm_component.c
@@ -433,7 +433,7 @@ create_and_attach(mca_btl_sm_component_t *comp_ptr,
                                                size_ctl_structure,
                                                data_seg_alignment))) {
         opal_output(0, "create_and_attach: unable to create shared memory "
-                    "BTL coordinating strucure :: size %lu \n",
+                    "BTL coordinating structure :: size %lu \n",
                     (unsigned long)size);
         return OMPI_ERROR;
     }


### PR DESCRIPTION
This is a backport of open-mpi/ompi@b4e445afb53a1e3ef018c838292df64ec3c31b3a

@rhc54 could you please review this trivial PR ?
