### PR TITLE
oob/tcp: include a missing header file

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp_common.c
+++ b/orte/mca/oob/tcp/oob_tcp_common.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,6 +59,7 @@
 #include "opal/util/argv.h"
 #include "opal/class/opal_hash_table.h"
 #include "opal/class/opal_list.h"
+#include "opal/mca/backtrace/backtrace.h"
 
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/ess/ess.h"


### PR DESCRIPTION
warning can be seen under cygwin without the missing header file

(cherry-picked from commit open-mpi/ompi@c9d1e16a9e8f4e55bbba0e1a5b7bee84594d05c1)
