### PR TITLE
vt/wrappers: add the $(EXEEXT) extension to the installed symbolic links

### DIFF
--- a/ompi/contrib/vt/wrappers/Makefile.am
+++ b/ompi/contrib/vt/wrappers/Makefile.am
@@ -29,12 +29,12 @@ nodist_pkgdata_DATA = \
 
 install-exec-hook-always:
 	test -z "$(bindir)" || $(MKDIR_P) "$(DESTDIR)$(bindir)"
-	(cd $(DESTDIR)$(bindir); rm -f mpicc-vt$(EXEEXT); $(LN_S) opal_wrapper mpicc-vt)
-	(cd $(DESTDIR)$(bindir); rm -f mpic++-vt$(EXEEXT); $(LN_S) opal_wrapper mpic++-vt)
-	(cd $(DESTDIR)$(bindir); rm -f mpicxx-vt$(EXEEXT); $(LN_S) opal_wrapper mpicxx-vt)
-	(cd $(DESTDIR)$(bindir); rm -f mpifort-vt$(EXEEXT); $(LN_S) opal_wrapper mpifort-vt)
-	(cd $(DESTDIR)$(bindir); rm -f mpif77-vt$(EXEEXT); $(LN_S) mpifort-vt mpif77-vt)
-	(cd $(DESTDIR)$(bindir); rm -f mpif90-vt$(EXEEXT); $(LN_S) mpifort-vt mpif90-vt)
+	(cd $(DESTDIR)$(bindir); rm -f mpicc-vt$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) mpicc-vt$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpic++-vt$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) mpic++-vt$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpicxx-vt$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) mpicxx-vt$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpifort-vt$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) mpifort-vt$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpif77-vt$(EXEEXT); $(LN_S) mpifort-vt$(EXEEXT) mpif77-vt$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f mpif90-vt$(EXEEXT); $(LN_S) mpifort-vt$(EXEEXT) mpif90-vt$(EXEEXT))
 
 install-data-hook-always:
 	(cd $(DESTDIR)$(pkgdatadir); rm -f mpicxx-vt-wrapper-data.txt; $(LN_S) mpic++-vt-wrapper-data.txt mpicxx-vt-wrapper-data.txt)
@@ -54,7 +54,7 @@ uninstall-local-always:
 
 if CASE_SENSITIVE_FS
 install-exec-hook: install-exec-hook-always
-	(cd $(DESTDIR)$(bindir); rm -f mpiCC-vt$(EXEEXT); $(LN_S) opal_wrapper mpiCC-vt)
+	(cd $(DESTDIR)$(bindir); rm -f mpiCC-vt$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) mpiCC-vt$(EXEEXT))
 
 install-data-hook: install-data-hook-always
 	(cd $(DESTDIR)$(pkgdatadir); rm -f mpiCC-vt-wrapper-data.txt; $(LN_S) mpic++-vt-wrapper-data.txt mpiCC-vt-wrapper-data.txt)


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@6af465f12da4e1b223ddba9e4ab9e73e2010ace0)

@bertwesarg @jurenz could you please review this ?

under cygwin, make install cannot be ran twice (symlink cannot be overwritten) without this commit
