### PR TITLE
ob1 destructor fix #2

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -234,14 +234,12 @@ int mca_pml_ob1_send(void *buf,
                              PERUSE_SEND);
 
     MCA_PML_OB1_SEND_REQUEST_START_W_SEQ(sendreq, endpoint, seqn, rc);
-    if (rc != OMPI_SUCCESS) {
-        return rc;
+    if (OPAL_UNLIKELY(rc == OMPI_SUCCESS)) {
+        ompi_request_wait_completion(&sendreq->req_send.req_base.req_ompi);
+
+        rc = sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR;
+        MCA_PML_BASE_SEND_REQUEST_FINI(&sendreq->req_send);
     }
-
-    ompi_request_wait_completion(&sendreq->req_send.req_base.req_ompi);
-
-    rc = sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR;
-    MCA_PML_BASE_SEND_REQUEST_FINI(&sendreq->req_send);
     OBJ_DESTRUCT(sendreq);
 
     return rc;

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -234,7 +234,7 @@ int mca_pml_ob1_send(void *buf,
                              PERUSE_SEND);
 
     MCA_PML_OB1_SEND_REQUEST_START_W_SEQ(sendreq, endpoint, seqn, rc);
-    if (OPAL_UNLIKELY(rc == OMPI_SUCCESS)) {
+    if (OPAL_LIKELY(rc == OMPI_SUCCESS)) {
         ompi_request_wait_completion(&sendreq->req_send.req_base.req_ompi);
 
         rc = sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR;


### PR DESCRIPTION
Minor fix to ensure that the request destructor is always called in ob1, even in error cases.

Submitted by @bosilca / @jsquyres, reviewed by @jsquyres / @bosilca.
