### PR TITLE
opal_check_ident.m4: make the test match what we do in the code base

### DIFF
--- a/config/opal_check_ident.m4
+++ b/config/opal_check_ident.m4
@@ -1,6 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2007 Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -68,7 +69,8 @@ AC_DEFUN([_OMPI_CHECK_IDENT], [
 
     ompi_ident="string_not_coincidentally_inserted_by_the_compiler"
     cat > conftest.$3 <<EOF
-$4 "$ompi_ident" $5
+#define IDENT_MSG "$ompi_ident"
+$4 IDENT_MSG $5
 int main(int argc, char** argv);
 int main(int argc, char** argv) { return 0; }
 EOF


### PR DESCRIPTION
Per open-mpi/ompi#257, the configure test used to check:

``` c
#pragma ident "foo"
```

But out in the code base, we actually do this:

``` c
#define IDENT_MSG "foo"
// ...
#pragma ident IDENT_MSG
```

This commit updates the configure test to `#define` a string and then use that with the various ident strategies.
