### PR TITLE
Check for the presence of setenv. If it is present, then use it in opal_...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -847,7 +847,7 @@ OPAL_SEARCH_LIBS_CORE([dirname], [gen])
 # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
 OPAL_SEARCH_LIBS_CORE([ceil], [m])
 
-AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf openpty isatty getpwuid fork waitpid execve pipe ptsname setsid mmap tcgetpgrp posix_memalign strsignal sysconf syslog vsyslog regcmp regexec regfree _NSGetEnviron socketpair strncpy_s usleep mkfifo dbopen dbm_open statfs statvfs setpgid])
+AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf openpty isatty getpwuid fork waitpid execve pipe ptsname setsid mmap tcgetpgrp posix_memalign strsignal sysconf syslog vsyslog regcmp regexec regfree _NSGetEnviron socketpair strncpy_s usleep mkfifo dbopen dbm_open statfs statvfs setpgid  setenv])
 
 # Sanity check: ensure that we got at least one of statfs or statvfs.
 if test $ac_cv_func_statfs = no -a $ac_cv_func_statvfs = no; then

--- a/opal/util/opal_environ.c
+++ b/opal/util/opal_environ.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved
+ * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -123,15 +123,38 @@ int opal_setenv(const char *name, const char *value, bool overwrite,
     /* If this is the "environ" array, use putenv */
     if( *env == environ ) {
         /* THIS IS POTENTIALLY A MEMORY LEAK!  But I am doing it
-           because so that we don't violate the law of least
-           astonishmet for OPAL developers (i.e., those that don't
+           so that we don't violate the law of least
+           astonishment for OPAL developers (i.e., those that don't
            check the return code of opal_setenv() and notice that we
            returned an error if you passed in the real environ) */
 #if defined (HAVE_SETENV)
         setenv(name, value, overwrite);
+        /* setenv copies the value, so we can free it here */
         free(newvalue);
 #else
+        len = strlen(name);
+        for (i = 0; (*env)[i] != NULL; ++i) {
+            if (0 == strncmp((*env)[i], name, len)) {
+                /* if we find the value in the environ, then
+                 * we need to check the overwrite flag to determine
+                 * the correct response */
+                if (overwrite) {
+                    /* since it was okay to overwrite, do so */
+                    putenv(newvalue);
+                    /* putenv does NOT copy the value, so we
+                     * cannot free it here */
+                    return OPAL_SUCCESS;
+                }
+                /* since overwrite was not allowed, we return
+                 * an error as we cannot perform the requested action */
+                free(newvalue);
+                return OPAL_EXISTS;
+            }
+        }
+        /* since the value wasn't found, we can add it */
         putenv(newvalue);
+        /* putenv does NOT copy the value, so we
+         * cannot free it here */
 #endif
         return OPAL_SUCCESS;
     }

--- a/opal/util/opal_environ.c
+++ b/opal/util/opal_environ.c
@@ -11,7 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
- *                         reserved. 
+ *                         reserved.
+ * Copyright (c) 2014      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -126,7 +127,12 @@ int opal_setenv(const char *name, const char *value, bool overwrite,
            astonishmet for OPAL developers (i.e., those that don't
            check the return code of opal_setenv() and notice that we
            returned an error if you passed in the real environ) */
+#if defined (HAVE_SETENV)
+        setenv(name, value, overwrite);
+        free(newvalue);
+#else
         putenv(newvalue);
+#endif
         return OPAL_SUCCESS;
     }
 


### PR DESCRIPTION
...setenv when setting values in the environ

Port of open-mpi/ompi@907b4606c537e2b758921a90ed2037337ca6e6cd

@jsquyres please review
