### PR TITLE
Minor configury fixes

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -33,7 +33,7 @@ ompi_show_subtitle "OPAL Configuration options"
 # Is this a developer copy?
 #
 
-if test -d .svn -o -d .hg; then
+if test -d .git -o -d .hg; then
     OMPI_DEVEL=1
 else
     OMPI_DEVEL=0

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ m4_ifdef([project_ompi],
 m4_ifdef([project_oshmem],
          [AC_CONFIG_HEADER([oshmem/include/shmem.h])])
 
-opal_show_subtitle "Initialization, setup"
+ompi_show_subtitle "Initialization, setup"
 
 OMPI_TOP_BUILDDIR="`pwd`"
 AC_SUBST(OMPI_TOP_BUILDDIR)


### PR DESCRIPTION
Trivial stuff -- but it answers why none of my v1.8 git clone builds have had -g/debugging info in a while!

@rhc54, can you review?
