### PR TITLE
Make sure CUDA init called during BTL init

### DIFF
--- a/ompi/mca/btl/sm/btl_sm_component.c
+++ b/ompi/mca/btl/sm/btl_sm_component.c
@@ -732,6 +732,10 @@ mca_btl_sm_component_init(int *num_btls,
     mca_btl_sm_component.sm_mpool = NULL;
     mca_btl_sm_component.sm_mpool_base = NULL;
 
+#if OPAL_CUDA_SUPPORT
+    mca_common_cuda_stage_one_init();
+#endif /* OPAL_CUDA_SUPPORT */
+
     /* if no session directory was created, then we cannot be used */
     if (NULL == ompi_process_info.job_session_dir) {
     /* SKG - this isn't true anymore. Some backing facilities don't require a
@@ -918,10 +922,6 @@ mca_btl_sm_component_init(int *num_btls,
         return NULL;
     }
 #endif /* OMPI_BTL_SM_HAVE_CMA */
-
-#if OPAL_CUDA_SUPPORT
-    mca_common_cuda_stage_one_init();
-#endif /* OPAL_CUDA_SUPPORT */
 
     return btls;
 

--- a/ompi/mca/btl/smcuda/btl_smcuda_component.c
+++ b/ompi/mca/btl/smcuda/btl_smcuda_component.c
@@ -853,6 +853,10 @@ mca_btl_smcuda_component_init(int *num_btls,
     mca_btl_smcuda_component.sm_mpool = NULL;
     mca_btl_smcuda_component.sm_mpool_base = NULL;
 
+#if OPAL_CUDA_SUPPORT
+    mca_common_cuda_stage_one_init();
+#endif /* OPAL_CUDA_SUPPORT */
+
     /* if no session directory was created, then we cannot be used */
     if (NULL == ompi_process_info.job_session_dir) {
     /* SKG - this isn't true anymore. Some backing facilities don't require a
@@ -943,7 +947,6 @@ mca_btl_smcuda_component_init(int *num_btls,
     /* Register a smcuda control function to help setup IPC support */
     mca_btl_base_active_message_trigger[MCA_BTL_TAG_SMCUDA].cbfunc = btl_smcuda_control;
     mca_btl_base_active_message_trigger[MCA_BTL_TAG_SMCUDA].cbdata = NULL;
-    mca_common_cuda_stage_one_init();
 #endif /* OPAL_CUDA_SUPPORT */
 
     return btls;


### PR DESCRIPTION
Need to ensure that CUDA init is called during init to match corresponding finalize during closing.
open-mpi/ompi:022612c83ba541678015791fab1a51b7c8ce9fb4
open-mpi/ompi:cbb43d5ac3e5fa96a001097f2b4c680ffef74798

@jsquyres can you review?
