### PR TITLE
If we can't output an entire block, then we need to adjust the number of bytes

### DIFF
--- a/orte/mca/iof/base/iof_base_output.c
+++ b/orte/mca/iof/base/iof_base_output.c
@@ -316,6 +316,8 @@ void orte_iof_base_write_handler(int fd, short event, void *cbdata)
         } else if (num_written < output->numbytes) {
             /* incomplete write - adjust data to avoid duplicate output */
             memmove(output->data, &output->data[num_written], output->numbytes - num_written);
+            /* adjust the number of bytes remaining to be written */
+            output->numbytes -= num_written;
             /* push this item back on the front of the list */
             opal_list_prepend(&wev->outputs, item);
             /* if the list is getting too large, abort */


### PR DESCRIPTION
...remaining to be output or else we will output duplicate bytes when next we are able to write.

Cherry-pick of ompi-master:
open-mpi/ompi@8c837d3cb34e0d871dde0e13b734f96ce1e52dc3

@jsquyres please review this trivial fix
