### PR TITLE
btl/vader: use FRAG_ALLOC_USER when single_copy_mechanism is VADER_NONE

### DIFF
--- a/ompi/mca/btl/vader/btl_vader_module.c
+++ b/ompi/mca/btl/vader/btl_vader_module.c
@@ -453,7 +453,11 @@ struct mca_btl_base_descriptor_t *vader_prepare_dst(struct mca_btl_base_module_t
     mca_btl_vader_frag_t *frag;
     void *data_ptr;
 
-    (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
+    if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
+        (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
+    } else {
+        (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
+    }
     if (OPAL_UNLIKELY(NULL == frag)) {
         return NULL;
     }
@@ -594,7 +598,11 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
         }
     } else {
         /* put/get fragment */
-        (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
+        if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
+            (void) MCA_BTL_VADER_FRAG_ALLOC_RDMA(frag, endpoint);
+        } else {
+            (void) MCA_BTL_VADER_FRAG_ALLOC_USER(frag, endpoint);
+        }
         if (OPAL_UNLIKELY(NULL == frag)) {
             return NULL;
         }


### PR DESCRIPTION
back-ported from commit open-mpi/ompi@d2d7f39a4bc8dde7e8c480f248819ec0d0e6be62
