### PR TITLE
btl/vader: fix typo in mca_btl_vader_put_knem

### DIFF
--- a/ompi/mca/btl/vader/btl_vader_put.c
+++ b/ompi/mca/btl/vader/btl_vader_put.c
@@ -2,6 +2,8 @@
 /*
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,7 +108,7 @@ int mca_btl_vader_put_knem (struct mca_btl_base_module_t *btl,
 
     /* Fill in the ioctl data fields.  There's no async completion, so
        we don't need to worry about getting a slot, etc. */
-    send_iovec.base = (uintptr_t) dst->base.seg_addr.lval;
+    send_iovec.base = (uintptr_t) src->base.seg_addr.lval;
     send_iovec.len = size;
     icopy.local_iovec_array = (uintptr_t) &send_iovec;
     icopy.local_iovec_nr    = 1;


### PR DESCRIPTION
Backported from open-mpi/ompi@b0881757058c94836fc5938a4398da013b6effcd
