### PR TITLE
OSHMEM: spml ikrit valgrind fix

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -1113,10 +1113,10 @@ static inline int mca_spml_ikrit_put_internal(void* dst_addr,
         put_req->mxm_req.base.flags = MXM_REQ_FLAG_SEND_LAZY|MXM_REQ_FLAG_SEND_SYNC;
     }
 #else
+    put_req->mxm_req.flags = 0;
     if (mca_spml_ikrit.free_list_max - mca_spml_ikrit.n_active_puts <= SPML_IKRIT_PUT_LOW_WATER ||
             (int)opal_list_get_size(&mca_spml_ikrit.active_peers) > mca_spml_ikrit.unsync_conn_max ||
             (mca_spml_ikrit.mxm_peers[dst]->n_active_puts + 1) % SPML_IKRIT_PACKETS_PER_SYNC == 0) {
-        put_req->mxm_req.flags = 0;
         need_progress = 1;
         put_req->mxm_req.opcode = MXM_REQ_OP_PUT_SYNC;
     } else  {


### PR DESCRIPTION
@miked-mellanox 
always initialize request flags
(cherry picked from commit fbb9dc5b1e53bdbbd8db726e9b63b10aa02f4fa3)
