### PR TITLE
Fixed a bug that fails to parse hostname starting with numbers.

### DIFF
--- a/orte/util/hostfile/hostfile_lex.l
+++ b/orte/util/hostfile/hostfile_lex.l
@@ -173,7 +173,7 @@ cores_per_socket   { orte_util_hostfile_value.sval = yytext;
                       orte_util_hostfile_value.sval = yytext;
                       return ORTE_HOSTFILE_IPV6; }
 
-(\^?[A-Za-z0-9][A-Za-z0-9_\-]*"@")?[A-Za-z][A-Za-z0-9_\-\.]*  {
+(\^?[A-Za-z0-9][A-Za-z0-9_\-]*"@")?[A-Za-z0-9][A-Za-z0-9_\-\.]*  {
                      orte_util_hostfile_value.sval = yytext; 
                      return ORTE_HOSTFILE_HOSTNAME; }
 


### PR DESCRIPTION
According to RFC 1123, hostnames that begin with numbers are valid.

(cherry picked from commit open-mpi/ompi@07ff51f43f48d896d6b580279b527f793f387946)
