### PR TITLE
OSHMEM: spml ikrit: add call to mxm_mq_destroy()

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -258,6 +258,8 @@ static int mca_spml_ikrit_component_open(void)
                     (cur_ver >> MXM_MINOR_BIT) & 0xff);
     }
 
+    mca_spml_ikrit.mxm_mq = NULL;
+    mca_spml_ikrit.mxm_context = NULL;
     mca_spml_ikrit.ud_only = 0;
 #if MXM_API < MXM_VERSION(2,1)
     mca_spml_ikrit.hw_rdma_channel = 0;
@@ -317,6 +319,9 @@ static int mca_spml_ikrit_component_open(void)
 
 static int mca_spml_ikrit_component_close(void)
 {
+    if (mca_spml_ikrit.mxm_mq) {
+        mxm_mq_destroy(mca_spml_ikrit.mxm_mq);
+    }
     if (mca_spml_ikrit.mxm_context) {
         mxm_cleanup(mca_spml_ikrit.mxm_context);
 #if MXM_API < MXM_VERSION(2,0)
@@ -330,6 +335,7 @@ static int mca_spml_ikrit_component_close(void)
         }
 #endif
     }
+    mca_spml_ikrit.mxm_mq = NULL;
     mca_spml_ikrit.mxm_context = NULL;
     return OSHMEM_SUCCESS;
 }


### PR DESCRIPTION
@miked-mellanox 
Make valgrind happy by calling mxm_mq_destroy() on module
close.
cherry picked from commit open-mpi/ompi@8de50d84206e597bf5b190c08aac4f824638faf1
