### PR TITLE
Fix a hang due to a race condition when processes call MPI_Abort.

### DIFF
--- a/orte/mca/errmgr/default_orted/errmgr_default_orted.c
+++ b/orte/mca/errmgr/default_orted/errmgr_default_orted.c
@@ -457,10 +457,6 @@ static void proc_errors(int fd, short args, void *cbdata)
             ORTE_ERROR_LOG(rc);
             return;
         }
-        /* remove the child from our local array as it is no longer alive */
-        opal_pointer_array_set_item(orte_local_children, i, NULL);
-        /* Decrement the number of local procs */
-        jdata->num_local_procs--;
 
         OPAL_OUTPUT_VERBOSE((5, orte_errmgr_base_framework.framework_output,
                              "%s errmgr:default_orted reporting proc %s aborted to HNP (local procs = %d)",
@@ -468,9 +464,6 @@ static void proc_errors(int fd, short args, void *cbdata)
                              ORTE_NAME_PRINT(&child->name),
                              jdata->num_local_procs));
         
-        /* release the child object */
-        OBJ_RELEASE(child);
-
         /* send it */
         if (0 > (rc = orte_rml.send_buffer_nb(ORTE_PROC_MY_HNP, alert,
                                               ORTE_RML_TAG_PLM,

--- a/orte/mca/state/orted/state_orted.c
+++ b/orte/mca/state/orted/state_orted.c
@@ -319,7 +319,7 @@ static void track_procs(int fd, short argc, void *cbdata)
                 }
                 /* send it */
                 OPAL_OUTPUT_VERBOSE((5, orte_state_base_framework.framework_output,
-                                     "%s SENDING PROC TERMINATION UPDATE FOR JOB %s",
+                                     "%s SENDING JOB TERMINATION UPDATE FOR JOB %s",
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                      ORTE_JOBID_PRINT(jdata->jobid)));
                 if (0 > (rc = orte_rml.send_buffer_nb(ORTE_PROC_MY_HNP, alert,


### PR DESCRIPTION
If a process was being forcibly killed instead of reaching the call to "abort", then we would accidentally increment a counter in one place while decrementing a counter in another - thus putting them off when comparing the two. This ensures we only increment the one side, and leave the other alone.

No corresponding master commit as this problem doesn't exist there.

@ggouaillardet please review
