### PR TITLE
Fix static linking for LSF and TM

### DIFF
--- a/config/orte_check_lsf.m4
+++ b/config/orte_check_lsf.m4
@@ -117,6 +117,10 @@ AC_DEFUN([ORTE_CHECK_LSF],[
     LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
     LIBS="$orte_check_lsf_$1_save_LIBS"
 
+    # add the LSF libraries to static builds as they are required
+    $1_WRAPPER_EXTRA_LDFLAGS=$1_LDFLAGS
+    $1_WRAPPER_EXTRA_LIBS=$1_LIBS
+
     # Reset for the next time we're called
     orte_check_lsf_dir=
     orte_check_lsf_libdir=

--- a/config/orte_check_lsf.m4
+++ b/config/orte_check_lsf.m4
@@ -118,8 +118,8 @@ AC_DEFUN([ORTE_CHECK_LSF],[
     LIBS="$orte_check_lsf_$1_save_LIBS"
 
     # add the LSF libraries to static builds as they are required
-    $1_WRAPPER_EXTRA_LDFLAGS=$1_LDFLAGS
-    $1_WRAPPER_EXTRA_LIBS=$1_LIBS
+    $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
+    $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
 
     # Reset for the next time we're called
     orte_check_lsf_dir=

--- a/config/orte_check_tm.m4
+++ b/config/orte_check_tm.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -138,6 +138,10 @@ AC_DEFUN([ORTE_CHECK_TM],[
     CPPFLAGS="$orte_check_package_$1_save_CPPFLAGS"
     LDFLAGS="$orte_check_package_$1_save_LDFLAGS"
     LIBS="$orte_check_package_$1_save_LIBS"
+
+    # add the TM libraries to static builds as they are required
+    $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
+    $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
 
     # Did we find the right stuff?
     AS_IF([test "$orte_check_tm_happy" = "yes" -a "$orte_check_tm_found" = "yes"],


### PR DESCRIPTION
After iterating a while, this is the minimum-distance change to fix the issue.  Commits are pulled directly from master:
- open-mpi/ompi@0338bc80b7b15fb789e320e567d1e997209718f8
- open-mpi/ompi@f4aa94dddfcad9234b7a385a783a25aa11bd94c0
- open-mpi/ompi@4e8ea6f716e31abb4f3e0e356c2fe0df0935d5c2

@rhc54 reviewed.
