### PR TITLE
One more attempt to resolve the race conditions during abnormal termination

### DIFF
--- a/orte/mca/errmgr/default_orted/errmgr_default_orted.c
+++ b/orte/mca/errmgr/default_orted/errmgr_default_orted.c
@@ -470,6 +470,11 @@ static void proc_errors(int fd, short args, void *cbdata)
                                               orte_rml_send_callback, NULL))) {
             ORTE_ERROR_LOG(rc);
         }
+        /* if the proc still reports itself as alive, then we need
+         * to ensure the state machine sees it */
+        if (child->alive && child->waitpid_recvd) {
+            ORTE_ACTIVATE_PROC_STATE(&child->name, ORTE_PROC_STATE_WAITPID_FIRED);
+        }
         return;
     }
 

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -1999,11 +1999,6 @@ void odls_base_default_wait_local_proc(pid_t pid, int status, void* cbdata)
             /* since we are going down a different code path, we need to
              * flag that this proc has had its waitpid fired */
             proc->waitpid_recvd = true;
-            /* if IOF_COMPLETE has already been recvd, then we need
-             * to mark this proc as no longer alive */
-            if (proc->iof_complete) {
-                proc->alive = false;
-            }
             goto MOVEON;
         }
         free(abortfile);

--- a/orte/mca/state/orted/state_orted.c
+++ b/orte/mca/state/orted/state_orted.c
@@ -294,7 +294,7 @@ static void track_procs(int fd, short argc, void *cbdata)
          * successful launch for short-lived procs
          */
         pdata->iof_complete = true;
-        if (pdata->waitpid_recvd) {
+        if (pdata->alive && pdata->waitpid_recvd) {
             /* the proc has terminated */
             pdata->alive = false;
             pdata->state = ORTE_PROC_STATE_TERMINATED;
@@ -305,6 +305,12 @@ static void track_procs(int fd, short argc, void *cbdata)
             orte_session_dir_finalize(proc);
             /* track job status */
             jdata->num_terminated++;
+            OPAL_OUTPUT_VERBOSE((5, orte_state_base_framework.framework_output,
+                                 "%s IOF COMPLETE FOR PROC %s NTERM %s NLOC %s",
+                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                 ORTE_NAME_PRINT(&pdata->name),
+                                 ORTE_VPID_PRINT(jdata->num_terminated),
+                                 ORTE_VPID_PRINT(jdata->num_local_procs)));
             if (jdata->num_terminated == jdata->num_local_procs) {
                 /* pack update state command */
                 cmd = ORTE_PLM_UPDATE_PROC_STATE;
@@ -365,7 +371,7 @@ static void track_procs(int fd, short argc, void *cbdata)
          * successful launch for short-lived procs
          */
         pdata->waitpid_recvd = true;
-        if (pdata->iof_complete) {
+        if (pdata->alive && pdata->iof_complete) {
             /* the proc has terminated */
             pdata->alive = false;
             pdata->state = ORTE_PROC_STATE_TERMINATED;
@@ -376,6 +382,12 @@ static void track_procs(int fd, short argc, void *cbdata)
             orte_session_dir_finalize(proc);
             /* track job status */
             jdata->num_terminated++;
+            OPAL_OUTPUT_VERBOSE((5, orte_state_base_framework.framework_output,
+                                 "%s WAITPID FOR PROC %s NTERM %s NLOC %s",
+                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                 ORTE_NAME_PRINT(&pdata->name),
+                                 ORTE_VPID_PRINT(jdata->num_terminated),
+                                 ORTE_VPID_PRINT(jdata->num_local_procs)));
             if (jdata->num_terminated == jdata->num_local_procs) {
                 /* pack update state command */
                 cmd = ORTE_PLM_UPDATE_PROC_STATE;


### PR DESCRIPTION
Ensure that no matter which fires first (iof complete or waitpid), we always go thru the state machine to properly record the number of terminated procs.

@ggouaillardet please give this a try
