### PR TITLE
Shorten the timeout period when we attempt to create a connection

### DIFF
--- a/orte/mca/oob/tcp/help-oob-tcp.txt
+++ b/orte/mca/oob/tcp/help-oob-tcp.txt
@@ -64,3 +64,13 @@ value will be ignored.
   Local host: %s
   Value:      %s
   Message:    %s
+#
+[no-loopback-found]
+WARNING: No loopback interface was found. This can cause problems
+when we spawn processes as they are likely to be unable to connect
+back to their host daemon. Sadly, it may take awhile for the connect
+attempt to fail, so you may experience a significant hang time.
+
+You may wish to ctrl-c out of your job and activate loopback support
+on at least one interface before trying again.
+

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -200,11 +200,14 @@ static char *dyn_port_string;
 static char *dyn_port_string6;
 #endif
 
+static char *connection_timeout_string;
+
 static int tcp_component_register(void)
 {
     mca_base_component_t *component = &mca_oob_tcp_component.super.oob_base;
     int var_id;
-
+    char **vals=NULL;
+    
     /* register oob module parameters */
     mca_oob_tcp_component.peer_limit = -1;
     (void)mca_base_component_var_register(component, "peer_limit",
@@ -402,6 +405,23 @@ static int tcp_component_register(void)
                                           &mca_oob_tcp_component.disable_ipv6_family);
 #endif
 
+    mca_oob_tcp_component.connect_timeout.tv_sec = 0;
+    mca_oob_tcp_component.connect_timeout.tv_usec = 1000;
+    connection_timeout_string = "0:1000";
+    (void)mca_base_component_var_register(component, "connect_timeout",
+                                          "Timeout for connection attempts to peer expressed as sec:usec",
+                                          MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                          OPAL_INFO_LVL_9,
+                                          MCA_BASE_VAR_SCOPE_READONLY,
+                                          &connection_timeout_string);
+
+    vals = opal_argv_split(connection_timeout_string, ':');
+    mca_oob_tcp_component.connect_timeout.tv_sec = strtol(vals[0], NULL, 10);
+    if (NULL != vals[1]) {
+        mca_oob_tcp_component.connect_timeout.tv_usec = strtol(vals[1], NULL, 10);
+    }
+    opal_argv_free(vals);
+    
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -405,9 +405,9 @@ static int tcp_component_register(void)
                                           &mca_oob_tcp_component.disable_ipv6_family);
 #endif
 
-    mca_oob_tcp_component.connect_timeout.tv_sec = 0;
-    mca_oob_tcp_component.connect_timeout.tv_usec = 1000;
-    connection_timeout_string = "0:1000";
+    mca_oob_tcp_component.connect_timeout.tv_sec = 2;
+    mca_oob_tcp_component.connect_timeout.tv_usec = 0;
+    connection_timeout_string = "2:0";
     (void)mca_base_component_var_register(component, "connect_timeout",
                                           "Timeout for connection attempts to peer expressed as sec:usec",
                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,

--- a/orte/mca/oob/tcp/oob_tcp_component.h
+++ b/orte/mca/oob/tcp/oob_tcp_component.h
@@ -77,6 +77,8 @@ typedef struct {
     bool               listen_thread_active;
     struct timeval     listen_thread_tv;       /**< Timeout when using listen thread */
     int                stop_thread[2];         /**< pipe used to exit the listen thread */
+    struct timeval     connect_timeout;        /**< timeout when attempting to connect to peer */
+    
 } mca_oob_tcp_component_t;
 
 ORTE_MODULE_DECLSPEC extern mca_oob_tcp_component_t mca_oob_tcp_component;

--- a/orte/mca/oob/tcp/oob_tcp_connection.c
+++ b/orte/mca/oob/tcp/oob_tcp_connection.c
@@ -149,7 +149,8 @@ void mca_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
     char *host;
     mca_oob_tcp_send_t *snd;
     bool connected = false;
-
+    fd_set set;
+    
     opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
                         "%s orte_tcp_peer_try_connect: "
                         "attempting to connect to proc %s",
@@ -208,20 +209,35 @@ void mca_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         peer->active_addr = addr;  // record the one we are using
     retry_connect:
         addr->retries++;
+        FD_ZERO(&set);
+        FD_SET(peer->sd, &set);
         if (connect(peer->sd, (struct sockaddr*)&addr->addr, addrlen) < 0) {
             /* non-blocking so wait for completion */
             if (opal_socket_errno == EINPROGRESS || opal_socket_errno == EWOULDBLOCK) {
                 opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
-                                    "%s waiting for connect completion to %s - activating send event",
+                                    "%s waiting %d:%03d for connect completion to %s",
+                                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                    (int)mca_oob_tcp_component.connect_timeout.tv_sec,
+                                    (int)mca_oob_tcp_component.connect_timeout.tv_usec,
+                                    ORTE_NAME_PRINT(&peer->name));
+                /* do a select to wait */
+                if (0 > select(peer->sd + 1, &set, NULL, NULL, &mca_oob_tcp_component.connect_timeout)) {
+                    /* didn't connect, let's move to next option */
+                    addr->state = MCA_OOB_TCP_FAILED;
+                    opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
+                                        "%s connection to %s failed - moving to next option",
+                                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                        ORTE_NAME_PRINT(&peer->name));
+                    continue;
+                }
+                /* if we got a positive response, then we connected */
+                opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
+                                    "%s select for connection to %s succeeded",
                                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                     ORTE_NAME_PRINT(&peer->name));
-                /* just ensure the send_event is active */
-                if (!peer->send_ev_active) {
-                    opal_event_add(&peer->send_event, 0);
-                    peer->send_ev_active = true;
-                }
-                OBJ_RELEASE(op);
-                return;
+                addr->retries = 0;
+                connected = true;
+                break;
             }
 
             /* Some kernels (Linux 2.6) will automatically software


### PR DESCRIPTION
Add an MCA parameter to allow it to be tuned by users and admins, but default it to 0.1 seconds. Need verification by others to ensure this is adequate.

@ggouaillardet please verify this and check the default value works for you
