### PR TITLE
Tighten LSF integration by adding support for affinity settings

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1217,8 +1217,8 @@ int opal_hwloc_base_slot_list_parse(const char *slot_str,
                                     opal_hwloc_resource_type_t rtype,
                                     hwloc_cpuset_t cpumask)
 {
-    char **item;
-    int rc, i, j;
+    char **item, **rngs;
+    int rc, i, j, k;
     hwloc_obj_t pu;
     hwloc_cpuset_t pucpus;
     char **range, **list;
@@ -1236,10 +1236,10 @@ int opal_hwloc_base_slot_list_parse(const char *slot_str,
     opal_output_verbose(5, opal_hwloc_base_framework.framework_output,
                         "slot assignment: slot_list == %s",
                         slot_str);
-    
+
     /* split at ';' */
     item = opal_argv_split(slot_str, ';');
-
+    
     /* start with a clean mask */
     hwloc_bitmap_zero(cpumask);
     /* loop across the items and accumulate the mask */
@@ -1258,75 +1258,95 @@ int opal_hwloc_base_slot_list_parse(const char *slot_str,
             if (NULL == strchr(item[i], ':')) {
                 /* binding just to the socket level, though
                  * it could specify multiple sockets
+                 * Skip the S and look for a ranges
                  */
-                if (OPAL_SUCCESS != (rc = socket_to_cpu_set(&item[i][1],  /* skip the 'S' */
-                                                            topo, rtype, cpumask))) {
-                    opal_argv_free(item);
-                    return rc;
+                rngs = opal_argv_split(&item[i][1], ',');
+                for (j=0; NULL != rngs[j]; j++) {
+                    if (OPAL_SUCCESS != (rc = socket_to_cpu_set(rngs[j], topo, rtype, cpumask))) {
+                        opal_argv_free(rngs);
+                        opal_argv_free(item);
+                        return rc;
+                    }
                 }
+                opal_argv_free(rngs);
             } else {
                 /* binding to a socket/whatever specification */
                 if ('S' == item[i][0] ||
                     's' == item[i][0]) {
-                    if (OPAL_SUCCESS != (rc = socket_core_to_cpu_set(&item[i][1],  /* skip the 'S' */
-                                                                     topo, rtype, cpumask))) {
-                        opal_argv_free(item);
-                        return rc;
+                    rngs = opal_argv_split(&item[i][1], ',');
+                    for (j=0; NULL != rngs[j]; j++) {
+                        if (OPAL_SUCCESS != (rc = socket_core_to_cpu_set(rngs[j], topo, rtype, cpumask))) {
+                            opal_argv_free(rngs);
+                            opal_argv_free(item);
+                            return rc;
+                        }
                     }
+                    opal_argv_free(rngs);
                 } else {
-                    if (OPAL_SUCCESS != (rc = socket_core_to_cpu_set(item[i],
-                                                                     topo, rtype, cpumask))) {
-                        opal_argv_free(item);
-                        return rc;
+                    rngs = opal_argv_split(item[i], ',');
+                    for (j=0; NULL != rngs[j]; j++) {
+                        if (OPAL_SUCCESS != (rc = socket_core_to_cpu_set(rngs[j], topo, rtype, cpumask))) {
+                            opal_argv_free(rngs);
+                            opal_argv_free(item);
+                            return rc;
+                        }
                     }
+                    opal_argv_free(rngs);
                 }
             }
         } else {
-            /* just a core specification - see if one or a range was given */
-            range = opal_argv_split(item[i], '-');
-            range_cnt = opal_argv_count(range);
-            /* see if a range was set or not */
-            switch (range_cnt) {
-            case 1:  /* only one core, or a list of cores, specified */
-                list = opal_argv_split(range[0], ',');
-                for (j=0; NULL != list[j]; j++) {
-                    core_id = atoi(list[j]);
-                    /* find the specified available cpu */
-                    if (NULL == (pu = opal_hwloc_base_get_pu(topo, core_id, rtype))) {
-                        opal_argv_free(range);
-                        opal_argv_free(item);
-                        return OPAL_ERR_SILENT;
+            rngs = opal_argv_split(item[i], ',');
+            for (k=0; NULL != rngs[k]; k++) {
+                /* just a core specification - see if one or a range was given */
+                range = opal_argv_split(rngs[k], '-');
+                range_cnt = opal_argv_count(range);
+                /* see if a range was set or not */
+                switch (range_cnt) {
+                case 1:  /* only one core, or a list of cores, specified */
+                    list = opal_argv_split(range[0], ',');
+                    for (j=0; NULL != list[j]; j++) {
+                        core_id = atoi(list[j]);
+                        /* find the specified available cpu */
+                        if (NULL == (pu = opal_hwloc_base_get_pu(topo, core_id, rtype))) {
+                            opal_argv_free(range);
+                            opal_argv_free(item);
+                            opal_argv_free(rngs);
+                            return OPAL_ERR_SILENT;
+                        }
+                        /* get the available cpus for that object */
+                        pucpus = opal_hwloc_base_get_available_cpus(topo, pu);
+                        /* set that in the mask */
+                        hwloc_bitmap_or(cpumask, cpumask, pucpus);
                     }
-                    /* get the available cpus for that object */
-                    pucpus = opal_hwloc_base_get_available_cpus(topo, pu);
-                    /* set that in the mask */
-                    hwloc_bitmap_or(cpumask, cpumask, pucpus);
-                }
-                opal_argv_free(list);
-                break;
+                    opal_argv_free(list);
+                    break;
                     
-            case 2:  /* range of core id's was given */
-                lower_range = atoi(range[0]);
-                upper_range = atoi(range[1]);
-                for (core_id=lower_range; core_id <= upper_range; core_id++) {
-                    /* find the specified logical available cpu */
-                    if (NULL == (pu = opal_hwloc_base_get_pu(topo, core_id, rtype))) {
-                        opal_argv_free(range);
-                        opal_argv_free(item);
-                        return OPAL_ERR_SILENT;
+                case 2:  /* range of core id's was given */
+                    lower_range = atoi(range[0]);
+                    upper_range = atoi(range[1]);
+                    for (core_id=lower_range; core_id <= upper_range; core_id++) {
+                        /* find the specified logical available cpu */
+                        if (NULL == (pu = opal_hwloc_base_get_pu(topo, core_id, rtype))) {
+                            opal_argv_free(range);
+                            opal_argv_free(item);
+                            opal_argv_free(rngs);
+                            return OPAL_ERR_SILENT;
+                        }
+                        /* get the available cpus for that object */
+                        pucpus = opal_hwloc_base_get_available_cpus(topo, pu);
+                        /* set that in the mask */
+                        hwloc_bitmap_or(cpumask, cpumask, pucpus);
                     }
-                    /* get the available cpus for that object */
-                    pucpus = opal_hwloc_base_get_available_cpus(topo, pu);
-                    /* set that in the mask */
-                    hwloc_bitmap_or(cpumask, cpumask, pucpus);
-                }
-                break;
+                    break;
                 
-            default:
-                opal_argv_free(range);
-                opal_argv_free(item);
-                return OPAL_ERROR;
+                default:
+                    opal_argv_free(range);
+                    opal_argv_free(item);
+                    opal_argv_free(rngs);
+                    return OPAL_ERROR;
+                }
             }
+            opal_argv_free(rngs);
         }
     }
     opal_argv_free(item);

--- a/orte/mca/plm/lsf/plm_lsf_module.c
+++ b/orte/mca/plm/lsf/plm_lsf_module.c
@@ -303,22 +303,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
         if (NULL == (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
             continue;
         }
-<<<<<<< HEAD
         app_prefix_dir = app->prefix_dir;
         /* Check for already set cur_prefix_dir -- if different,
            complain */
         if (NULL != app_prefix_dir) {
-||||||| parent of c4002a8... Further cleanups on the LSF integration - the affinity file is apparently always present, but simply empty if affinity wasn't set.
-        orte_get_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, (void**)&app_prefix_dir, OPAL_STRING);
-        /* Check for already set cur_prefix_dir -- if different,
-           complain */
-        if (NULL != app_prefix_dir) {
-=======
-        if (orte_get_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, (void**)&app_prefix_dir, OPAL_STRING) &&
-            NULL != app_prefix_dir) {
-            /* Check for already set cur_prefix_dir -- if different,
-               complain */
->>>>>>> c4002a8... Further cleanups on the LSF integration - the affinity file is apparently always present, but simply empty if affinity wasn't set.
             if (NULL != cur_prefix &&
                 0 != strcmp (cur_prefix, app_prefix_dir)) {
                 orte_show_help("help-plm-lsf.txt", "multiple-prefixes",

--- a/orte/mca/plm/lsf/plm_lsf_module.c
+++ b/orte/mca/plm/lsf/plm_lsf_module.c
@@ -299,14 +299,26 @@ static void launch_daemons(int fd, short args, void *cbdata)
        the LSF plm) */
     cur_prefix = NULL;
     for (i=0; i < jdata->apps->size; i++) {
-        char *app_prefix_dir;
+        char *app_prefix_dir=NULL;
         if (NULL == (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
             continue;
         }
+<<<<<<< HEAD
         app_prefix_dir = app->prefix_dir;
         /* Check for already set cur_prefix_dir -- if different,
            complain */
         if (NULL != app_prefix_dir) {
+||||||| parent of c4002a8... Further cleanups on the LSF integration - the affinity file is apparently always present, but simply empty if affinity wasn't set.
+        orte_get_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, (void**)&app_prefix_dir, OPAL_STRING);
+        /* Check for already set cur_prefix_dir -- if different,
+           complain */
+        if (NULL != app_prefix_dir) {
+=======
+        if (orte_get_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, (void**)&app_prefix_dir, OPAL_STRING) &&
+            NULL != app_prefix_dir) {
+            /* Check for already set cur_prefix_dir -- if different,
+               complain */
+>>>>>>> c4002a8... Further cleanups on the LSF integration - the affinity file is apparently always present, but simply empty if affinity wasn't set.
             if (NULL != cur_prefix &&
                 0 != strcmp (cur_prefix, app_prefix_dir)) {
                 orte_show_help("help-plm-lsf.txt", "multiple-prefixes",

--- a/orte/mca/ras/lsf/help-ras-lsf.txt
+++ b/orte/mca/ras/lsf/help-ras-lsf.txt
@@ -27,4 +27,10 @@ LSF or your cluster.
 While trying to determine what resources are available, LSF returned
 a list of available nodes from which we were unable to extract anything
 usable. This may indicate a problem with LSF or your cluster.
+[affinity-file-not-found]
+The affinity file provided in LSB_AFFINITY_HOSTFILE could not be found:
+
+  File:  %s
+
+We cannot continue.
 

--- a/orte/mca/ras/lsf/ras_lsf_module.c
+++ b/orte/mca/ras/lsf/ras_lsf_module.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -22,6 +23,8 @@
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #define SR1_PJOBS
 #include <lsf/lsbatch.h>
@@ -58,7 +61,13 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
     char **nodelist;
     orte_node_t *node;
     int i, num_nodes;
-
+    char *affinity_file, *hstname;
+    bool found;
+    FILE *fp;
+    orte_app_context_t *app;
+    struct stat buf;
+    orte_app_context_t *app;
+    
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {
         orte_show_help("help-ras-lsf.txt", "nodelist-failed", true);
@@ -88,6 +97,39 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
     /* release the nodelist from lsf */
     opal_argv_free(nodelist);
 
+    /* check for an affinity file */
+    if (NULL != (affinity_file = getenv("LSB_AFFINITY_HOSTFILE"))) {
+        /* check to see if the file is empty - if it is,
+         * then affinity wasn't actually set for this job */
+        if (0 != stat(affinity_file, &buf)) {
+            orte_show_help("help-ras-lsf.txt", "affinity-file-not-found", true, affinity_file);
+            return ORTE_ERR_SILENT;
+        }
+        if (0 == buf.st_size) {
+            /* no affinity, so just return */
+            return ORTE_SUCCESS;
+        }
+        /* the affinity file sequentially lists rank locations, with
+         * cpusets given as physical cpu-ids. Setup the job object
+         * so it knows to process this accordingly */
+        if (NULL == jdata->map) {
+            jdata->map = OBJ_NEW(orte_job_map_t);
+        }
+        ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_SEQ);
+        jdata->map->req_mapper = strdup("seq"); // need sequential mapper
+        /* tell the sequential mapper that all cpusets are to be treated as "physical" */
+        jdata->controls |= ORTE_JOB_CONTROL_PHYS_CPUS;
+        /* get the apps and set the hostfile attribute in each to point to
+         * the hostfile */
+        for (i=0; i < jdata->apps->size; i++) {
+            if (NULL == (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
+                continue;
+            }
+            app->hostfile = strdup(affinity_file);
+        }
+        return ORTE_SUCCESS;
+    }
+    
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/ras/lsf/ras_lsf_module.c
+++ b/orte/mca/ras/lsf/ras_lsf_module.c
@@ -31,6 +31,7 @@
 
 #include "opal/util/argv.h"
 
+#include "orte/mca/rmaps/rmaps_types.h"
 #include "orte/runtime/orte_globals.h"
 #include "orte/util/show_help.h"
 
@@ -66,7 +67,6 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
     FILE *fp;
     orte_app_context_t *app;
     struct stat buf;
-    orte_app_context_t *app;
     
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {

--- a/orte/mca/rmaps/base/help-orte-rmaps-base.txt
+++ b/orte/mca/rmaps/base/help-orte-rmaps-base.txt
@@ -97,6 +97,11 @@ Your job failed to map. Either no mapper was available, or none
 of the available mappers was able to perform the requested
 mapping operation. This can happen if you request a map type
 (e.g., loadbalance) and the corresponding mapper was not built.
+
+  Mapper result:    %s
+  #procs mapped:    %d
+  #nodes assigned:  %d
+
 #
 [unrecognized-policy]
 The specified %s policy is not recognized:
@@ -319,11 +324,13 @@ Please specify a mapping level that has more than one cpu, or
 else let us define a default mapping that will allow multiple
 cpus-per-proc.
 #
-[unrecog-modifier]
-A modifier was given to the --map-by directive that is not
-recognized:
+[seq:not-enough-resources]
+A sequential map was requested, but not enough node entries
+were given to support the requested number of processes:
 
-  Modifier:  %s
+  Num procs:  %d
+  Num nodes:  %d
 
-Please see "mpirun --help" for a description of supported
-modifiers.
+We cannot continue - please adjust either the number of processes
+or provide more node locations in the file.
+

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -302,7 +302,9 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
      * the map, then that's an error
      */
     if (!did_map || 0 == jdata->num_procs || 0 == jdata->map->num_nodes) {
-        orte_show_help("help-orte-rmaps-base.txt", "failed-map", true);
+        orte_show_help("help-orte-rmaps-base.txt", "failed-map", true,
+                       did_map ? "mapped" : "unmapped",
+                       jdata->num_procs, jdata->map->num_nodes);
         ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_MAP_FAILED);
         OBJ_RELEASE(caddy);
         return;

--- a/orte/mca/rmaps/rank_file/rmaps_rank_file_lex.l
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file_lex.l
@@ -99,7 +99,7 @@ username           { orte_rmaps_rank_file_value.sval = yytext;
     */
 %}
 
-[A-za-z0-9_\-,\;:*@]*  { orte_rmaps_rank_file_value.sval = yytext;
+[A-Za-z0-9_\-,\;:*@]*  { orte_rmaps_rank_file_value.sval = yytext;
                          return ORTE_RANKFILE_STRING; }
 
 ([A-Za-z0-9][A-Za-z0-9_\-]*"@")?([0-9]{1,3}"."){3}[0-9]{1,3} {

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -220,6 +220,8 @@ typedef uint16_t orte_job_controls_t;
 #define ORTE_JOB_CONTROL_NO_VM              0x4000
 #define ORTE_JOB_CONTROL_INDEX_ARGV         0x8000
 
+#define ORTE_JOB_CONTROL_PHYS_CPUS          0x0001
+
 /* global type definitions used by RTE - instanced in orte_globals.c */
 
 /************

--- a/orte/util/hostfile/hostfile.c
+++ b/orte/util/hostfile/hostfile.c
@@ -387,6 +387,11 @@ static int hostfile_parse_line(int token, opal_list_t* updates,
             }
             break;
 
+        case ORTE_HOSTFILE_STRING:
+        case ORTE_HOSTFILE_INT:
+            /* just ignore it */
+            break;
+            
         default:
             hostfile_parse_error(token);
             opal_list_remove_item(updates, &node->super);

--- a/orte/util/hostfile/hostfile_lex.l
+++ b/orte/util/hostfile/hostfile_lex.l
@@ -162,7 +162,7 @@ cores_per_socket   { orte_util_hostfile_value.sval = yytext;
     */
 %}
 
-[A-za-z0-9_\-,:*@]*  { orte_util_hostfile_value.sval = yytext;
+[A-Za-z0-9_\-,:*@]*  { orte_util_hostfile_value.sval = yytext;
                      return ORTE_HOSTFILE_STRING; }
 
 ([A-Za-z0-9][A-Za-z0-9_\-]*"@")?([0-9]{1,3}"."){3}[0-9]{1,3} {


### PR DESCRIPTION
 Provide tighter LSF integration by correctly handling scenarios where the user has asked LSF to assign bindings. Fix a couple of typos in lex parser definitions. Tell hostfile parser to ignore binding designations in hostfiles. Add a control flag to indicate that cpusets were provided as physical cpu ids.

open-mpi@3f9d9ae
open-mpi@960ef34
open-mpi@f92ccaf
open-mpi@c4002a8
open-mpi@c4fd6d1

IBM is validating this for us
