### PR TITLE
Add automatic detection of hetero nodes

### DIFF
--- a/opal/mca/hwloc/base/base.h
+++ b/opal/mca/hwloc/base/base.h
@@ -274,6 +274,10 @@ OPAL_DECLSPEC hwloc_obj_t opal_hwloc_base_get_pu(hwloc_topology_t topo,
 
 #endif
 
+/* get the topology "signature" so we can check for differences - caller
+ * if responsible for freeing the returned string */
+OPAL_DECLSPEC char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo);
+
 END_C_DECLS
 
 #endif /* OPAL_HWLOC_BASE_H */

--- a/opal/mca/hwloc/base/hwloc_base_dt.c
+++ b/opal/mca/hwloc/base/hwloc_base_dt.c
@@ -193,9 +193,6 @@ int opal_hwloc_compare(const hwloc_topology_t topo1,
     int l1, l2;
     int s;
     struct hwloc_topology_support *s1, *s2;
-    char *x1=NULL, *x2=NULL;
-    int l1, l2;
-    int s;
     
     /* stop stupid compiler warnings */
     t1 = (hwloc_topology_t)topo1;

--- a/opal/mca/hwloc/base/hwloc_base_dt.c
+++ b/opal/mca/hwloc/base/hwloc_base_dt.c
@@ -193,7 +193,10 @@ int opal_hwloc_compare(const hwloc_topology_t topo1,
     int l1, l2;
     int s;
     struct hwloc_topology_support *s1, *s2;
-
+    char *x1=NULL, *x2=NULL;
+    int l1, l2;
+    int s;
+    
     /* stop stupid compiler warnings */
     t1 = (hwloc_topology_t)topo1;
     t2 = (hwloc_topology_t)topo2;
@@ -205,10 +208,13 @@ int opal_hwloc_compare(const hwloc_topology_t topo1,
         return OPAL_VALUE1_GREATER;
     } else if (d2 > d1) {
         return OPAL_VALUE2_GREATER;
-    }
+    }    
 
     /* do the comparison the "cheat" way - get an xml representation
-     * of each tree, and strcmp!
+     * of each tree, and strcmp! This will work fine for inventory
+     * comparisons, but might not meet the need for comparing topology
+     * where we really need to do a tree-wise search so we only compare
+     * the things we care about, and ignore stuff like MAC addresses
      */
     if (0 != hwloc_topology_export_xmlbuffer(t1, &x1, &l1)) {
         return OPAL_EQUAL;
@@ -226,7 +232,7 @@ int opal_hwloc_compare(const hwloc_topology_t topo1,
     } else if (s < 0) {
         return OPAL_VALUE2_GREATER;
     }
-
+    
     /* compare the available support - hwloc unfortunately does
      * not include this info in its xml support!
      */

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -2081,3 +2081,37 @@ int opal_hwloc_get_sorted_numa_list(hwloc_topology_t topo, char* device_name, op
     }
     return OPAL_ERR_NOT_FOUND;
 }
+
+char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo)
+{
+    unsigned int nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt;
+    char *sig=NULL, *arch=NULL;
+    hwloc_obj_t obj;
+    unsigned i;
+    
+    nnuma = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_NODE, 0, OPAL_HWLOC_AVAILABLE);
+    nsocket = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_SOCKET, 0, OPAL_HWLOC_AVAILABLE);
+    nl3 = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CACHE, 3, OPAL_HWLOC_AVAILABLE);
+    nl2 = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CACHE, 2, OPAL_HWLOC_AVAILABLE);
+    nl1 = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CACHE, 1, OPAL_HWLOC_AVAILABLE);
+    ncore = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE, 0, OPAL_HWLOC_AVAILABLE);
+    nhwt = opal_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PU, 0, OPAL_HWLOC_AVAILABLE);
+
+    /* get the root object so we can add the processor architecture */
+    obj = hwloc_get_root_obj(topo);
+    for (i=0; i < obj->infos_count; i++) {
+        if (0 == strcmp(obj->infos[i].name, "Architecture")) {
+            arch = obj->infos[i].value;
+            break;
+        }
+    }
+
+    if (NULL == arch) {
+        asprintf(&sig, "%uN:%uS:%uL3:%uL2:%uL1:%uC:%uH",
+                 nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt);
+    } else {
+        asprintf(&sig, "%uN:%uS:%uL3:%uL2:%uL1:%uC:%uH:%s",
+                 nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt, arch);
+    }
+    return sig;
+}

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -139,6 +139,8 @@ int orte_ess_base_orted_setup(char **hosts)
                 goto error;
             }
         }
+        /* generate the signature */
+        orte_topo_signature = opal_hwloc_base_get_topo_signature(opal_hwloc_topology);
         
         /* remove the hostname from the topology. Unfortunately, hwloc
          * decided to add the source hostname to the "topology", thus

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -201,6 +201,8 @@ static int rte_init(void)
                 goto error;
             }
         }
+        /* generate the signature */
+        orte_topo_signature = opal_hwloc_base_get_topo_signature(opal_hwloc_topology);
 
         /* remove the hostname from the topology. Unfortunately, hwloc
          * decided to add the source hostname to the "topology", thus

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -124,6 +124,7 @@ static struct {
     bool abort;
     bool mapreduce;
     bool tree_spawn;
+    char *hnp_topo_sig;
 } orted_globals;
 
 /*
@@ -215,6 +216,10 @@ opal_cmd_line_init_t orte_cmd_line_opts[] = {
     { "orte_hetero_nodes", '\0', NULL, "hetero-nodes", 0,
       NULL, OPAL_CMD_LINE_TYPE_BOOL,
       "Nodes in cluster may differ in topology, so send the topology back from each node [Default = false]" },
+    
+    { NULL, '\0', NULL, "hnp-topo-sig", 1,
+      &orted_globals.hnp_topo_sig, OPAL_CMD_LINE_TYPE_STRING,
+      "Topology signature of HNP" },
 #endif
 
     { NULL, '\0', "mapreduce", "mapreduce", 0,
@@ -778,10 +783,23 @@ int orte_daemon(int argc, char *argv[])
 #if OPAL_HAVE_HWLOC
         {
             char *coprocessors;
-            /* add the local topology */
-            if (NULL != opal_hwloc_topology &&
-                (1 == ORTE_PROC_MY_NAME->vpid || orte_hetero_nodes)) {
+            uint8_t tflag;
+                        
+            /* add the local topology, if different from the HNP's or user directed us to */
+            if (orte_hetero_nodes || 0 != strcmp(orte_topo_signature, orted_globals.hnp_topo_sig)) {
+                tflag = 1;
+                if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &tflag, 1, OPAL_UINT8))) {
+                    ORTE_ERROR_LOG(ret);
+                }
+                if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &orte_topo_signature, 1, OPAL_STRING))) {
+                    ORTE_ERROR_LOG(ret);
+                }
                 if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &opal_hwloc_topology, 1, OPAL_HWLOC_TOPO))) {
+                    ORTE_ERROR_LOG(ret);
+                }
+            } else {
+                tflag = 0;
+                if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &tflag, 1, OPAL_UINT8))) {
                     ORTE_ERROR_LOG(ret);
                 }
             }

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -71,6 +71,7 @@ char *orte_local_cpu_model = NULL;
 char *orte_basename = NULL;
 bool orte_coprocessors_detected = false;
 opal_hash_table_t *orte_coprocessors = NULL;
+char *orte_topo_signature = NULL;
 
 /* ORTE OOB port flags */
 bool orte_static_ports = false;
@@ -1059,3 +1060,23 @@ OBJ_CLASS_INSTANCE(orte_job_map_t,
                    opal_object_t,
                    orte_job_map_construct,
                    orte_job_map_destruct);
+
+#if OPAL_HAVE_HWLOC
+static void tcon(orte_topology_t *t)
+{
+    t->topo = NULL;
+    t->sig = NULL;
+}
+static void tdes(orte_topology_t *t)
+{
+    if (NULL != t->topo) {
+        hwloc_topology_destroy(t->topo);
+    }
+    if (NULL != t->sig) {
+        free(t->sig);
+    }
+}
+OBJ_CLASS_INSTANCE(orte_topology_t,
+                   opal_object_t,
+                   tcon, tdes);
+#endif

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -566,6 +566,16 @@ struct orte_proc_t {
 typedef struct orte_proc_t orte_proc_t;
 ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_proc_t);
 
+#if OPAL_HAVE_HWLOC
+/* define an object for storing node topologies */
+typedef struct {
+    opal_object_t super;
+    hwloc_topology_t topo;
+    char *sig;
+} orte_topology_t;
+ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_topology_t);
+#endif
+
 /**
  * Get a job data object
  * We cannot just reference a job data object with its jobid as
@@ -609,6 +619,7 @@ ORTE_DECLSPEC extern char *orte_local_cpu_model;
 ORTE_DECLSPEC extern char *orte_basename;
 ORTE_DECLSPEC extern bool orte_coprocessors_detected;
 ORTE_DECLSPEC extern opal_hash_table_t *orte_coprocessors;
+ORTE_DECLSPEC extern char *orte_topo_signature;
 
 /* ORTE OOB port flags */
 ORTE_DECLSPEC extern bool orte_static_ports;


### PR DESCRIPTION
Users are having a hard time adjusting to the --hetero-nodes option, so add a short topology "signature" to the orted cmd line so they can compare it to their local topology and return a topo if theirs differs from that found by mpirun.

Based on master commits:
open-mpi/ompi@bb529eb
open-mpi/ompi@9b2f8cd
open-mpi/ompi@18d9fdf

@jsquyres see what you think
