### PR TITLE
help messages: fix obvious typos

### DIFF
--- a/ompi/mca/common/verbs/help-ompi-common-verbs.txt
+++ b/ompi/mca/common/verbs/help-ompi-common-verbs.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2014 Cisco Systems, Inc.  All rights reserved.
 #
 # $COPYRIGHT$
 # 
@@ -19,7 +19,7 @@ job may or may not continue.
 
   Hostname:    %s
   Device name: %s
-  Errror (%d): %s
+  Error (%d):  %s
 #
 [ibv_query_device fail]
 Open MPI failed to query an OpenFabrics device.  This is an unusual
@@ -33,7 +33,7 @@ job may or may not continue.
 
   Hostname:    %s
   Device name: %s
-  Errror (%d): %s
+  Error (%d):  %s
 #
 [nonexistent port]
 WARNING: One or more nonexistent OpenFabrics devices/ports were


### PR DESCRIPTION
Trivial show-help text file typo fixes.

(cherry picked from commit open-mpi/ompi@4551cab6f1bc51e4def6fdbc3cc983292958345b)

Can easily slip to 1.8.5.

@rhc54 can you review / decide which release you want it in?
