### PR TITLE
Remove extraneous , from oshmem/mca/sshmem/verbs/configure.m4

### DIFF
--- a/oshmem/mca/sshmem/verbs/configure.m4
+++ b/oshmem/mca/sshmem/verbs/configure.m4
@@ -88,7 +88,7 @@ AC_DEFUN([MCA_oshmem_sshmem_verbs_CONFIG],[
                 [],
                 [#include <infiniband/verbs_exp.h>])
          ])
-    AC_DEFINE_UNQUOTED(MPAGE_HAVE_IBV_EXP_REG_MR_CREATE_FLAGS, $exp_reg_mr_happy, [create_flags field is part of ibv_exp_reg_mr_in]),
+    AC_DEFINE_UNQUOTED(MPAGE_HAVE_IBV_EXP_REG_MR_CREATE_FLAGS, $exp_reg_mr_happy, [create_flags field is part of ibv_exp_reg_mr_in])
 
     AS_IF([test "$enable_verbs_sshmem" = "yes" -a "$oshmem_verbs_sm_build_verbs" = "0"],
           [AC_MSG_WARN([VERBS shared memory support requested but not found])


### PR DESCRIPTION
This resulted in:

 ./configure: line 271954: ,: command not found

with 1.8.4rc2
