### PR TITLE
Some cleanups required for transfer to 1.8.4:

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -2104,7 +2104,7 @@ int opal_hwloc_get_sorted_numa_list(hwloc_topology_t topo, char* device_name, op
 
 char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo)
 {
-    unsigned int nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt;
+    int nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt;
     char *sig=NULL, *arch=NULL;
     hwloc_obj_t obj;
     unsigned i;
@@ -2127,10 +2127,10 @@ char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo)
     }
 
     if (NULL == arch) {
-        asprintf(&sig, "%uN:%uS:%uL3:%uL2:%uL1:%uC:%uH",
+        asprintf(&sig, "%dN:%dS:%dL3:%dL2:%dL1:%dC:%dH",
                  nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt);
     } else {
-        asprintf(&sig, "%uN:%uS:%uL3:%uL2:%uL1:%uC:%uH:%s",
+        asprintf(&sig, "%dN:%dS:%dL3:%dL2:%dL1:%dC:%dH:%s",
                  nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt, arch);
     }
     return sig;

--- a/opal/util/printf.c
+++ b/opal/util/printf.c
@@ -48,6 +48,13 @@ static int guess_strlen(const char *fmt, va_list ap)
     int len;
     long larg;
 
+#if HAVE_VSNPRINTF
+    {
+        char dummy[1];
+        return 1 + vsnprintf(dummy, sizeof(dummy), fmt, ap);
+    }
+#endif
+    
     /* Start off with a fudge factor of 128 to handle the % escapes that
        we aren't calculating here */
 

--- a/opal/util/printf.c
+++ b/opal/util/printf.c
@@ -9,7 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -40,7 +41,14 @@
  */
 static int guess_strlen(const char *fmt, va_list ap)
 {
-    char *sarg;
+#if HAVE_VSNPRINTF
+    char dummy[1];
+
+    /* vsnprintf() returns the number of bytes that would have been
+       copied if the provided buffer were infinite. */
+    return 1 + vsnprintf(dummy, sizeof(dummy), fmt, ap);
+#else
+    char *sarg, carg;
     double darg;
     float farg;
     size_t i;
@@ -48,13 +56,6 @@ static int guess_strlen(const char *fmt, va_list ap)
     int len;
     long larg;
 
-#if HAVE_VSNPRINTF
-    {
-        char dummy[1];
-        return 1 + vsnprintf(dummy, sizeof(dummy), fmt, ap);
-    }
-#endif
-    
     /* Start off with a fudge factor of 128 to handle the % escapes that
        we aren't calculating here */
 
@@ -189,6 +190,7 @@ static int guess_strlen(const char *fmt, va_list ap)
     }
 
     return len;
+#endif
 }
 
 

--- a/orte/mca/rmaps/seq/rmaps_seq.c
+++ b/orte/mca/rmaps/seq/rmaps_seq.c
@@ -329,7 +329,7 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                 /* wasn't found - that is an error */
                 orte_show_help("help-orte-rmaps-seq.txt",
                                "orte-rmaps-seq:resource-not-found",
-                               true, nd->name);
+                               true, sq->hostname);
                 rc = ORTE_ERR_SILENT;
                 goto error;
             }


### PR DESCRIPTION
- Use %d format for the topo signature as some systems apparently have problems with %u
- Use correct variable in show_help message
- Fix guess_len function in printf.c when vsnprintf is available
