### PR TITLE
configury: test the __sun macro to detect solaris OS.

### DIFF
--- a/config/opal_check_os_flavors.m4
+++ b/config/opal_check_os_flavors.m4
@@ -1,7 +1,9 @@
 dnl -*- shell-script -*-
 dnl
-dnl Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2014     Intel, Inc. All rights reserved.
+dnl Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2014      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -43,6 +45,8 @@ AC_DEFUN([OPAL_CHECK_OS_FLAVORS],
     OPAL_CHECK_OS_FLAVOR_SPECIFIC([__APPLE__], [apple])
     OPAL_CHECK_OS_FLAVOR_SPECIFIC([__linux__], [linux])
     OPAL_CHECK_OS_FLAVOR_SPECIFIC([__sun__], [sun])
+    AS_IF([test "$opal_found_sun" = "no"],
+          OPAL_CHECK_OS_FLAVOR_SPECIFIC([__sun], [sun]))
 
     AS_IF([test "$opal_found_sun" = "yes"],
           [opal_have_solaris=1


### PR DESCRIPTION
recent oraclestudio compilers do not set the **sun** macro

(cherry picked from commit open-mpi/ompi@6418d0d118aff87ac3f36b87fb951bd55de21e06)
