### PR TITLE
OSHMEM: spml ikrit: fix mxm disconnect flow

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -344,6 +344,7 @@ int mca_spml_ikrit_del_procs(oshmem_proc_t** procs, size_t nprocs)
     size_t i;
     opal_list_item_t *item;
 
+    oshmem_shmem_barrier();
 #if MXM_API >= MXM_VERSION(2,0)
     if (mca_spml_ikrit.bulk_disconnect) {
         mxm_ep_powerdown(mca_spml_ikrit.mxm_ep);


### PR DESCRIPTION
@miked-mellanox @jladd-mlnx 

Add out of band barrier before performing mxm disconnect.
It will make sure that every pe is ready to disconnect. Otherwise
bad things may happen.
(cherry picked from commit ompi/open-mpi@3f7ed5654802d4b5921263daba7811f77b7751fc)
