### PR TITLE
OSHMEM: spml ikrit: disable rdmap op DCI pool

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -93,6 +93,12 @@ static inline int set_mxm_tls()
 {
     char *tls;
 
+    /* disable dci pull for rdma ops. Use single pool.
+     * Pool size is controlled by MXM_DC_QP_LIMIT 
+     * variable
+     */
+    opal_setenv("MXM_OSHMEM_DC_RNDV_QP_LIMIT", "0", 0, &environ);
+
     tls = getenv("MXM_OSHMEM_TLS");
     if (NULL != tls) {
         return check_mxm_tls("MXM_OSHMEM_TLS");


### PR DESCRIPTION
@miked-mellanox @jladd-mlnx 
Instead use single pool for both rdma and send receive ops.
(cherry picked from commit ompi/open-mpi@e1cf6f37baf2b6240ab3aa3a219b8856cfa2caf4)
