### PR TITLE
OSHMEM: atomic mxm: fix mkey conversion

### DIFF
--- a/oshmem/mca/atomic/mxm/atomic_mxm.h
+++ b/oshmem/mca/atomic/mxm/atomic_mxm.h
@@ -66,7 +66,7 @@ END_C_DECLS
 static inline mxm_mem_key_t *to_mxm_mkey(sshmem_mkey_t *mkey) {
 
     if (0 == mkey->len) {
-        return MXM_INVALID_MEM_HANDLE;
+        return &mxm_empty_mem_key;
     }
     return (mxm_mem_key_t *)mkey->u.data;
 }


### PR DESCRIPTION
Correctly return mxm_empty_mem_key when shmem mkey is empty
(cherry picked from commit open-mpi/ompi@c76261da0749b2f93ee1a425baa4cc36ce2e1bef)
