### PR TITLE
Attribute "fixes"

### DIFF
--- a/ompi/mpi/man/man3/MPI_Attr_delete.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_delete.3in
@@ -39,13 +39,22 @@ IERROR
 Fortran only: Error status (integer). 
 
 .SH DESCRIPTION
-This deprecated routine is not available in C++. 
-.sp
-Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_delete_attr. 
+Note that use of this routine is \fIdeprecated\fP as of MPI-2, and
+was \fIdeleted\fP in MPI-3. Please use MPI_Comm_delete_attr.  This
+function does not have a C++ or mpi_f08 binding.
 .sp
 Delete attribute from cache by key. This function invokes the attribute delete function delete_fn specified when the keyval was created. The call will fail if the delete_fn function returns an error code other than MPI_SUCCESS.  
 
 Whenever a communicator is replicated using the function MPI_Comm_dup, all callback copy functions for attributes that are currently set are invoked (in arbitrary order). Whenever a communicator is deleted using the function MPI_Comm_free, all callback delete functions for attributes that are currently set are invoked. 
+
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+delete_fn callback invokes other MPI functions.  In Open MPI, it is
+not valid for delete_fn callbacks (or any of their children) to add or
+delete attributes on the same object on which the delete_fn callback
+is being invoked.
+
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.

--- a/ompi/mpi/man/man3/MPI_Attr_get.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_get.3in
@@ -49,9 +49,9 @@ Fortran only: Error status (integer).
 
 .SH DESCRIPTION
 .ft R
-Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_get_attr instead.
-.sp
-This deprecated routine is not available in C++. 
+Note that use of this routine is \fIdeprecated\fP as of MPI-2, and
+was \fIdeleted\fP in MPI-3. Please use MPI_Comm_create_attr.  This
+function does not have a C++ or mpi_f08 binding.
 .sp
 Retrieves attribute value by key. The call is erroneous if there is no key
 with value keyval. On the other hand, the call is correct if the key value exists, but no attribute is attached on comm for that key; in such case, the call returns flag = false. In particular MPI_KEYVAL_INVALID is an erroneous key value.  

--- a/ompi/mpi/man/man3/MPI_Attr_put.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_put.3in
@@ -43,9 +43,9 @@ Fortran only: Error status (integer).
 
 .SH DESCRIPTION
 .ft R
-Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_set_attr instead. 
-.sp
-This deprecated routine is not available in C++. 
+Note that use of this routine is \fIdeprecated\fP as of MPI-2, and
+was \fIdeleted\fP in MPI-3. Please use MPI_Comm_set_attr.  This
+function does not have a C++ or mpi_f08 binding.
 .sp
 MPI_Attr_put stores the stipulated attribute value attribute_val for subsequent retrieval by MPI_Attr_get. If the value is already present, then the outcome is as if MPI_Attr_delete was first called to delete the previous value (and the callback function delete_fn was executed), and a new value was next stored. The call is erroneous if there is no key with value keyval; in particular MPI_KEYVAL_INVALID is an erroneous key value. The call will fail if the delete_fn function returned an error code other than MPI_SUCCESS.
 

--- a/ompi/mpi/man/man3/MPI_Comm_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_delete_attr.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
 .\" $COPYRIGHT$
@@ -53,6 +53,14 @@ MPI_Comm_delete_attr deletes an attribute from cache by key. This function invok
 Whenever a communicator is replicated using the function MPI_Comm_dup, all callback copy functions for attributes that are currently set are invoked (in arbitrary order). Whenever a communicator is deleted using the function MPI_Comm_free, all callback delete functions for attributes that are currently set are invoked. 
 .sp
 This function is the same as MPI_Attr_delete but is needed to match the communicator-specific functions introduced in the MPI-2 standard. The use of MPI_Attr_delete is deprecated. 
+
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+delete_fn callback invokes other MPI functions.  In Open MPI, it is
+not valid for delete_fn callbacks (or any of their children) to add or
+delete attributes on the same object on which the delete_fn callback
+is being invoked.
 
 
 .SH ERRORS

--- a/ompi/mpi/man/man3/MPI_Comm_dup.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_dup.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -57,6 +57,12 @@ library call with a duplicate communication space that has the same properties a
 .sp
 This call applies to both intra- and intercommunicators. 
 
+Note that it is not defined by the MPI standard what happens if the
+attribute copy callback invokes other MPI functions.  In Open MPI, it
+is not valid for attribute copy callbacks (or any of their children)
+to add or delete attributes on the same object on which the attribute
+copy callback is being invoked.
+
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
 .sp
@@ -64,3 +70,8 @@ Before the error value is returned, the current MPI error handler is
 called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.  
 
 
+.SH SEE ALSO
+.ft R
+.nf
+MPI_Comm_dup_with_info
+MPI_Comm_idup

--- a/ompi/mpi/man/man3/MPI_Comm_dup_with_info.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_dup_with_info.3in
@@ -1,6 +1,6 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -55,6 +55,12 @@ This operation is used to provide a parallel
 library call with a duplicate communication space that has the same properties as the original communicator. This includes any attributes (see below) and topologies (see Chapter 6, "Process Topologies," in the MPI-1 Standard). This call is valid even if there are pending point-to-point communications involving the communicator comm. A typical call might involve an MPI_Comm_dup_with_info at the beginning of the parallel call, and an MPI_Comm_free of that duplicated communicator at the end of the call. Other models of communicator management are also possible.
 .sp
 This call applies to both intra- and intercommunicators.
+
+Note that it is not defined by the MPI standard what happens if the
+attribute copy callback invokes other MPI functions.  In Open MPI, it
+is not valid for attribute copy callbacks (or any of their children)
+to add or delete attributes on the same object on which the attribute
+copy callback is being invoked.
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.

--- a/ompi/mpi/man/man3/MPI_Comm_free.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_free.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -44,9 +44,22 @@ Fortran only: Error status (integer).
 .ft R
 This operation marks the communicator object for deallocation. The handle is set to MPI_COMM_NULL. Any pending operations that use this communicator will complete normally; the object is actually deallocated only if there are no other active references to it. This call applies to intracommunicators and intercommunicators. Upon actual deallocation, the delete callback functions for all cached attributes (see Section 5.7 in the MPI-1 Standard, "Caching") are called in arbitrary order.  
 
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+delete_fn callback invokes other MPI functions.  In Open MPI, it is
+not valid for delete_fn callbacks (or any of their children) to add or
+delete attributes on the same object on which the delete_fn callback
+is being invoked.
+
+
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
 .sp
 Before the error value is returned, the current MPI error handler is
 called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.  
 
+.SH SEE ALSO
+.ft R
+.nf
+MPI_Comm_delete_attr

--- a/ompi/mpi/man/man3/MPI_Comm_idup.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_idup.3in
@@ -1,6 +1,6 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -55,6 +55,12 @@ This operation is used to provide a parallel
 library call with a duplicate communication space that has the same properties as the original communicator. This includes any attributes (see below) and topologies (see Chapter 6, "Process Topologies," in the MPI-1 Standard). This call is valid even if there are pending point-to-point communications involving the communicator comm. A typical call might involve an MPI_Comm_idup at the beginning of the parallel call, and an MPI_Comm_free of that duplicated communicator at the end of the call. Other models of communicator management are also possible.
 .sp
 This call applies to both intra- and intercommunicators.
+
+Note that it is not defined by the MPI standard what happens if the
+attribute copy callback invokes other MPI functions.  In Open MPI, it
+is not valid for attribute copy callbacks (or any of their children)
+to add or delete attributes on the same object on which the attribute
+copy callback is being invoked.
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.

--- a/ompi/mpi/man/man3/MPI_Type_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Type_delete_attr.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
 .\" $COPYRIGHT$
@@ -49,6 +49,15 @@ Fortran only: Error status (integer).
 .SH DESCRIPTION
 .ft R
 MPI_Type_delete_attr deletes a datatype-caching attribute value associated with a key. This routines partially replaces MPI_Attr_delete, which is now deprecated. 
+
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+delete_fn callback invokes other MPI functions.  In Open MPI, it is
+not valid for delete_fn callbacks (or any of their children) to add or
+delete attributes on the same object on which the delete_fn callback
+is being invoked.
+
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.

--- a/ompi/mpi/man/man3/MPI_Type_dup.3in
+++ b/ompi/mpi/man/man3/MPI_Type_dup.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines
 .\" $COPYRIGHT$
@@ -46,6 +46,15 @@ Fortran only: Error status (integer).
 .SH DESCRIPTION
 .ft R
 MPI_Type_dup is a type constructor that duplicates the existing type with associated key values. For each key value, the respective copy callback function determines the attribute value associated with this key in the new communicator. One particular action that a copy callback may take is to delete the attribute from the new data type. Returns in \fInewtype\fP a new data type with exactly the same properties as \fItype\fP, as well as any copied cached information. The new data type has identical upper bound and lower bound and yields the same net result when fully decoded with the functions described in Section 8.6 of the MPI-2 standard. \fInewtype\fP has the same committed state as the old \fItype\fP.
+
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+attribute copy callback invokes other MPI functions.  In Open MPI, it
+is not valid for attribute copy callbacks (or any of their children)
+to add or delete attributes on the same object on which the attribute
+copy callback is being invoked.
+
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.

--- a/ompi/mpi/man/man3/MPI_Win_delete_attr.3in
+++ b/ompi/mpi/man/man3/MPI_Win_delete_attr.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -45,6 +45,13 @@ Key value (integer).
 .TP 1i
 IERROR
 Fortran only: Error status (integer). 
+
+.SH NOTES
+Note that it is not defined by the MPI standard what happens if the
+delete_fn callback invokes other MPI functions.  In Open MPI, it is
+not valid for delete_fn callbacks (or any of their children) to add or
+delete attributes on the same object on which the delete_fn callback
+is being invoked.
 
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.


### PR DESCRIPTION
I put "fixes" in quotes because I don't fully agree with the solution, but I don't fully disagree, either.

So pull it over, let it fix PETSc's current behavior.  But at least also update our man pages to indicate that users should not expect adding/deleting attributes to work in attribute callback functions.

I reviewed George's code; the man pages hypothetically don't need reviewing.
