### PR TITLE
Minor touchup to ensure hwthreads are correctly bound, and setting LSF affinity operations to hwthreads-as-cpus by default

### DIFF
--- a/orte/mca/ras/lsf/ras_lsf_module.c
+++ b/orte/mca/ras/lsf/ras_lsf_module.c
@@ -30,6 +30,7 @@
 #include <lsf/lsbatch.h>
 
 #include "opal/util/argv.h"
+#include "opal/mca/hwloc/hwloc.h"
 
 #include "orte/mca/rmaps/rmaps_types.h"
 #include "orte/runtime/orte_globals.h"
@@ -119,6 +120,12 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
         jdata->map->req_mapper = strdup("seq"); // need sequential mapper
         /* tell the sequential mapper that all cpusets are to be treated as "physical" */
         jdata->controls |= ORTE_JOB_CONTROL_PHYS_CPUS;
+        /* LSF provides its info as hwthreads, so set the hwthread-as-cpus flag */
+        opal_hwloc_use_hwthreads_as_cpus = true;
+        /* don't override something provided by the user, but default to bind-to hwthread */
+        if (!OPAL_BINDING_POLICY_IS_SET(opal_hwloc_binding_policy)) {
+            OPAL_SET_BINDING_POLICY(opal_hwloc_binding_policy, OPAL_BIND_TO_HWTHREAD);
+        }
         /* get the apps and set the hostfile attribute in each to point to
          * the hostfile */
         for (i=0; i < jdata->apps->size; i++) {


### PR DESCRIPTION
Pulled from master commits:

open-mpi/ompi@b314bfb5e98c216db1ebb15052d3b678859de227
open-mpi/ompi@43a40f8aacaceb288f2e359367e6229a971de16d

@jsquyres should be quick review
