### PR TITLE
HCOLL:  Fix OMPI to HCOLL predefined datatypes, Ops mapping

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
@@ -73,41 +73,23 @@ static dte_data_representation_t ompi_dtype_2_dte_dtype(ompi_datatype_t *dtype){
     return *ompi_datatype_2_dte_data_rep[opal_type_id];
 }
 
-
-/*
-enum ompi_op_type {
-    OMPI_OP_BASE_FORTRAN_NULL = 0,
-    OMPI_OP_BASE_FORTRAN_MAX,
-    OMPI_OP_BASE_FORTRAN_MIN,
-    OMPI_OP_BASE_FORTRAN_SUM,
-    OMPI_OP_BASE_FORTRAN_PROD,
-    OMPI_OP_BASE_FORTRAN_LAND,
-    OMPI_OP_BASE_FORTRAN_BAND,
-    OMPI_OP_BASE_FORTRAN_LOR,
-    OMPI_OP_BASE_FORTRAN_BOR,
-    OMPI_OP_BASE_FORTRAN_LXOR,
-    OMPI_OP_BASE_FORTRAN_BXOR,
-    OMPI_OP_BASE_FORTRAN_MAXLOC,
-    OMPI_OP_BASE_FORTRAN_MINLOC,
-    OMPI_OP_BASE_FORTRAN_REPLACE,
-
-    OMPI_OP_BASE_FORTRAN_OP_MAX
-};*/
-static hcoll_dte_op_t* ompi_op_2_hcoll_op[OMPI_OP_BASE_FORTRAN_OP_MAX] = {
-   &hcoll_dte_op_null,
-   &hcoll_dte_op_max,
-   &hcoll_dte_op_min,
-   &hcoll_dte_op_sum,
-   &hcoll_dte_op_prod,
-   &hcoll_dte_op_land,
-   &hcoll_dte_op_band,
-   &hcoll_dte_op_lor,
-   &hcoll_dte_op_bor,
-   &hcoll_dte_op_lxor,
-   &hcoll_dte_op_bxor,
-   &hcoll_dte_op_null,
-   &hcoll_dte_op_null,
-   &hcoll_dte_op_null
+static hcoll_dte_op_t* ompi_op_2_hcoll_op[OMPI_OP_BASE_FORTRAN_OP_MAX + 1] = {
+   &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_NULL = 0 */
+   &hcoll_dte_op_max,           /* OMPI_OP_BASE_FORTRAN_MAX */
+   &hcoll_dte_op_min,           /* OMPI_OP_BASE_FORTRAN_MIN */
+   &hcoll_dte_op_sum,           /* OMPI_OP_BASE_FORTRAN_SUM */
+   &hcoll_dte_op_prod,          /* OMPI_OP_BASE_FORTRAN_PROD */
+   &hcoll_dte_op_land,          /* OMPI_OP_BASE_FORTRAN_LAND */
+   &hcoll_dte_op_band,          /* OMPI_OP_BASE_FORTRAN_BAND */
+   &hcoll_dte_op_lor,           /* OMPI_OP_BASE_FORTRAN_LOR */
+   &hcoll_dte_op_bor,           /* OMPI_OP_BASE_FORTRAN_BOR */
+   &hcoll_dte_op_lxor,          /* OMPI_OP_BASE_FORTRAN_LXOR */
+   &hcoll_dte_op_bxor,          /* OMPI_OP_BASE_FORTRAN_BXOR */
+   &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_MAXLOC */
+   &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_MINLOC */
+   &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_REPLACE */
+   &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_NO_OP */
+   &hcoll_dte_op_null           /* OMPI_OP_BASE_FORTRAN_OP_MAX */
 };
 static hcoll_dte_op_t* ompi_op_2_hcolrte_op(ompi_op_t *op){
     return ompi_op_2_hcoll_op[op->o_f_to_c_index];

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -36,7 +36,8 @@ int mca_coll_hcoll_bcast(void *buff, int count,
     HCOL_VERBOSE(20,"RUNNING HCOL BCAST");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     dtype = ompi_dtype_2_dte_dtype(datatype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(dtype) || HCOL_DTE_IS_COMPLEX(dtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -68,7 +69,9 @@ int mca_coll_hcoll_allgather(void *sbuf, int scount,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)
+                        || HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -106,7 +109,9 @@ int mca_coll_hcoll_gather(void *sbuf, int scount,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype))){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)
+                        || HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -143,7 +148,8 @@ int mca_coll_hcoll_allreduce(void *sbuf, void *rbuf, int count,
     HCOL_VERBOSE(20,"RUNNING HCOL ALLREDUCE");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     Dtype = ompi_dtype_2_dte_dtype(dtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(Dtype) || HCOL_DTE_IS_COMPLEX(Dtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -192,7 +198,9 @@ int mca_coll_hcoll_alltoall(void *sbuf, int scount,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)
+                        || HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -246,7 +254,8 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
     dtype = ompi_dtype_2_dte_dtype(datatype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(dtype) || HCOL_DTE_IS_COMPLEX(dtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -281,7 +290,9 @@ int mca_coll_hcoll_iallgather(void *sbuf, int scount,
     rt_handle = (void**) request;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)
+                        || HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -322,7 +333,8 @@ int mca_coll_hcoll_iallreduce(void *sbuf, void *rbuf, int count,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
     Dtype = ompi_dtype_2_dte_dtype(dtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY((HCOL_DTE_IS_ZERO(Dtype) || HCOL_DTE_IS_COMPLEX(Dtype)))
+                        && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -36,7 +36,7 @@ int mca_coll_hcoll_bcast(void *buff, int count,
     HCOL_VERBOSE(20,"RUNNING HCOL BCAST");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     dtype = ompi_dtype_2_dte_dtype(datatype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -68,7 +68,7 @@ int mca_coll_hcoll_allgather(void *sbuf, int scount,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -143,7 +143,7 @@ int mca_coll_hcoll_allreduce(void *sbuf, void *rbuf, int count,
     HCOL_VERBOSE(20,"RUNNING HCOL ALLREDUCE");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     Dtype = ompi_dtype_2_dte_dtype(dtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -192,7 +192,7 @@ int mca_coll_hcoll_alltoall(void *sbuf, int scount,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -246,7 +246,7 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
     dtype = ompi_dtype_2_dte_dtype(datatype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -281,7 +281,7 @@ int mca_coll_hcoll_iallgather(void *sbuf, int scount,
     rt_handle = (void**) request;
     stype = ompi_dtype_2_dte_dtype(sdtype);
     rtype = ompi_dtype_2_dte_dtype(rdtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_COMPLEX(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */
@@ -322,7 +322,7 @@ int mca_coll_hcoll_iallreduce(void *sbuf, void *rbuf, int count,
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
     Dtype = ompi_dtype_2_dte_dtype(dtype);
-    if (OPAL_UNLIKELY(HCOL_DTE_IS_COMPLEX(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(Dtype)) && mca_coll_hcoll_component.hcoll_datatype_fallback){
         /*If we are here then datatype is not simple predefined datatype */
         /*In future we need to add more complex mapping to the dte_data_representation_t */
         /* Now use fallback */


### PR DESCRIPTION
open-mpi/ompi@e398ad66196575196cd086a076d2c42ad3cc70ba
