### PR TITLE
Topic/issue 324

### DIFF
--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -378,7 +378,9 @@ AC_DEFUN([OPAL_FLAGS_UNIQ],[
 
         # Check for special cases where we do want to allow repeated
         # arguments (per
-        # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php).
+        # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php
+        # and
+        # https://github.com/open-mpi/ompi/issues/324).
 
         case $val in
         -Xclang)

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -385,6 +385,10 @@ AC_DEFUN([OPAL_FLAGS_UNIQ],[
                 ompi_found=0
                 ompi_i=`expr $ompi_count + 1`
                 ;;
+        --param)
+                ompi_found=0
+                ompi_i=`expr $ompi_count + 1`
+                ;;
         esac
 
         # If we didn't find the token, add it to the "array"


### PR DESCRIPTION
Turns out the OPAL_FLAGS_UNIQ function was chopping
off multiple instances of --param when set in the
CFLAGS. This can happen when -mnative or other machine
target is specified as part of CFLAGS.

Thanks to QuesarVII for reporting this and supplying a patch.

Tested using -mnative to see that gcc was being passed the right
set of --param options multiple times.

@rhc54 would you mind reviewing this?

Fixes #324 for the 1.8 release.
