### PR TITLE
btl/openib: add XRC support for OFED 3.12+

### DIFF
--- a/config/ompi_check_openfabrics.m4
+++ b/config/ompi_check_openfabrics.m4
@@ -16,6 +16,9 @@
 # Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
 # Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2014      Bull SAS.  All rights reserved.
+# Copyright (c) 2014-2015 Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -148,6 +151,7 @@ AC_DEFUN([OMPI_CHECK_OPENFABRICS],[
     # Set these up so that we can do an AC_DEFINE below
     # (unconditionally)
     $1_have_xrc=0
+    $1_have_xrc_domains=0
     $1_have_opensm_devel=0
 
     # If we have the openib stuff available, find out what we've got
@@ -161,9 +165,14 @@ AC_DEFUN([OMPI_CHECK_OPENFABRICS],[
                             [#include <infiniband/verbs.h>])
 
            # ibv_create_xrc_rcv_qp was added in OFED 1.3
+           # ibv_cmd_open_xrcd (aka XRC Domains) was added in  OFED 3.12
            if test "$enable_connectx_xrc" = "yes"; then
-               AC_CHECK_FUNCS([ibv_create_xrc_rcv_qp], [$1_have_xrc=1])
+               AC_CHECK_FUNCS([ibv_create_xrc_rcv_qp ibv_cmd_open_xrcd], [$1_have_xrc=1])
            fi
+           if test "$enable_connectx_xrc" = "yes"; then
+               AC_CHECK_FUNCS([ibv_cmd_open_xrcd], [$1_have_xrc_domains=1])
+           fi
+
 
            if test "no" != "$enable_openib_dynamic_sl"; then
                # We need ib_types.h file, which is installed with opensm-devel
@@ -223,6 +232,15 @@ AC_DEFUN([OMPI_CHECK_OPENFABRICS],[
     AC_DEFINE_UNQUOTED([OMPI_HAVE_CONNECTX_XRC], [$$1_have_xrc],
         [Enable features required for ConnectX XRC support])
     if test "1" = "$$1_have_xrc"; then
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
+
+    AC_MSG_CHECKING([if ConnectIB XRC support is enabled])
+    AC_DEFINE_UNQUOTED([OMPI_HAVE_CONNECTX_XRC_DOMAINS], [$$1_have_xrc_domains],
+        [Enable features required for XRC domains support])
+    if test "1" = "$$1_have_xrc_domains"; then
         AC_MSG_RESULT([yes])
     else
         AC_MSG_RESULT([no])

--- a/ompi/mca/btl/openib/btl_openib.c
+++ b/ompi/mca/btl/openib/btl_openib.c
@@ -19,8 +19,9 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Bull SAS.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -338,10 +339,26 @@ static int create_srq(mca_btl_openib_module_t *openib_btl)
             openib_btl->qps[qp].u.srq_qp.rd_posted = 0;
 #if HAVE_XRC
             if(BTL_OPENIB_QP_TYPE_XRC(qp)) {
+#if OMPI_HAVE_CONNECTX_XRC_DOMAINS
+                struct ibv_srq_init_attr_ex attr_ex;
+                memset(&attr_ex, 0, sizeof(struct ibv_srq_init_attr_ex));
+                attr_ex.attr.max_wr = attr.attr.max_wr;
+                attr_ex.attr.max_sge = attr.attr.max_sge;
+                attr_ex.comp_mask = IBV_SRQ_INIT_ATTR_TYPE | IBV_SRQ_INIT_ATTR_XRCD |
+                                    IBV_SRQ_INIT_ATTR_CQ | IBV_SRQ_INIT_ATTR_PD;
+                attr_ex.srq_type = IBV_SRQT_XRC;
+                attr_ex.xrcd = openib_btl->device->xrcd;
+                attr_ex.cq = openib_btl->device->ib_cq[qp_cq_prio(qp)];
+                attr_ex.pd = openib_btl->device->ib_pd;
+
+                openib_btl->qps[qp].u.srq_qp.srq =
+                ibv_create_srq_ex(openib_btl->device->ib_dev_context, &attr_ex);
+#else
                 openib_btl->qps[qp].u.srq_qp.srq =
                     ibv_create_xrc_srq(openib_btl->device->ib_pd,
                             openib_btl->device->xrc_domain,
                             openib_btl->device->ib_cq[qp_cq_prio(qp)], &attr);
+#endif
             } else
 #endif
             {
@@ -1963,14 +1980,20 @@ int mca_btl_openib_put( mca_btl_base_module_t* btl,
     to_com_frag(frag)->endpoint = ep;
 #if HAVE_XRC
     if (MCA_BTL_XRC_ENABLED && BTL_OPENIB_QP_TYPE_XRC(qp))
+#if OMPI_HAVE_CONNECTX_XRC_DOMAINS
+        frag->sr_desc.qp_type.xrc.remote_srqn=ep->rem_info.rem_srqs[qp].rem_srq_num;
+#else
         frag->sr_desc.xrc_remote_srq_num=ep->rem_info.rem_srqs[qp].rem_srq_num;
+#endif
 #endif
 
     descriptor->order = qp;
     /* Setting opcode on a frag constructor isn't enough since prepare_src
      * may return send_frag instead of put_frag */
     frag->sr_desc.opcode = IBV_WR_RDMA_WRITE;
-    frag->sr_desc.send_flags = ib_send_flags(src_seg->base.seg_len, &(ep->qps[qp]), 1);
+    frag->sr_desc.send_flags = ib_send_flags(descriptor->des_src->seg_len, &(ep->qps[qp]), 1);
+    qp_inflight_wqe_to_frag(ep, qp, to_com_frag(frag));
+    qp_reset_signal_count(ep, qp);
     
     qp_inflight_wqe_to_frag(ep, qp, to_com_frag(frag));
     qp_reset_signal_count(ep, qp);
@@ -2050,7 +2073,11 @@ int mca_btl_openib_get(mca_btl_base_module_t* btl,
 
 #if HAVE_XRC
     if (MCA_BTL_XRC_ENABLED && BTL_OPENIB_QP_TYPE_XRC(qp))
+#if OMPI_HAVE_CONNECTX_XRC_DOMAINS
+        frag->sr_desc.qp_type.xrc.remote_srqn=ep->rem_info.rem_srqs[qp].rem_srq_num;
+#else
         frag->sr_desc.xrc_remote_srq_num=ep->rem_info.rem_srqs[qp].rem_srq_num;
+#endif
 #endif
     descriptor->order = qp;
 

--- a/ompi/mca/btl/openib/btl_openib.h
+++ b/ompi/mca/btl/openib/btl_openib.h
@@ -17,6 +17,9 @@
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013-2014 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2014      Bull SAS.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -400,7 +403,11 @@ typedef struct mca_btl_openib_device_t {
     volatile bool got_port_event;
 #endif
 #if HAVE_XRC
+#if OMPI_HAVE_CONNECTX_XRC_DOMAINS
+    struct ibv_xrcd *xrcd;
+#else
     struct ibv_xrc_domain *xrc_domain;
+#endif
     int xrc_fd;
 #endif
     int32_t non_eager_rdma_endpoints;

--- a/ompi/mca/btl/openib/btl_openib_async.h
+++ b/ompi/mca/btl/openib/btl_openib_async.h
@@ -1,5 +1,8 @@
 /*
  * Copyright (c) 2007-2008 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2014      Bull SAS.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +19,7 @@
 int        start_async_event_thread(void);
 void       mca_btl_openib_load_apm(struct ibv_qp *qp, mca_btl_openib_endpoint_t *ep);
 int        btl_openib_async_command_done(int exp);
-#if HAVE_XRC
+#if HAVE_XRC && ! OMPI_HAVE_CONNECTX_XRC_DOMAINS
 void       mca_btl_openib_load_apm_xrc_rcv(uint32_t qp_num, mca_btl_openib_endpoint_t *ep);
 #endif
 

--- a/ompi/mca/btl/openib/btl_openib_component.c
+++ b/ompi/mca/btl/openib/btl_openib_component.c
@@ -19,8 +19,9 @@
  * Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Laboratory.  All rights reserved
  * Copyright (c) 2013      Intel, Inc. All rights reserved
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Bull SAS.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -988,6 +989,11 @@ static void device_destruct(mca_btl_openib_device_t *device)
     }
 
 #if HAVE_XRC
+
+    if (!mca_btl_openib_xrc_check_api()) {
+        return;
+    }
+
     if (MCA_BTL_XRC_ENABLED) {
         if (OMPI_SUCCESS != mca_btl_openib_close_xrc_domain(device)) {
             BTL_VERBOSE(("XRC Internal error. Failed to close xrc domain"));

--- a/ompi/mca/btl/openib/btl_openib_xrc.h
+++ b/ompi/mca/btl/openib/btl_openib_xrc.h
@@ -1,5 +1,8 @@
 /*
  * Copyright (c) 2007-2008 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2014      Bull SAS.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,5 +48,7 @@ int mca_btl_openib_open_xrc_domain(struct mca_btl_openib_device_t *device);
 int mca_btl_openib_close_xrc_domain(struct mca_btl_openib_device_t *device);
 int mca_btl_openib_ib_address_add_new (uint16_t lid, uint64_t s_id,
         ompi_jobid_t ep_jobid, mca_btl_openib_endpoint_t *ep);
+
+bool mca_btl_openib_xrc_check_api(void);
 
 #endif


### PR DESCRIPTION
based on an original patch contributed by Bull.

backported from commits
- open-mpi/ompi@b3617e736eef97da6ecacee952baf699b6f7068d
- open-mpi/ompi@7df648f1cff55fa9126d444c9f70083434b0d213
- open-mpi/ompi@135ecce0eb80251da0ef7982b206fdf53a30b0a2
- open-mpi/ompi@06e071454e04456b6799937b92cda465cd2dface
