### PR TITLE
btl/vader: fix typo in xpmem setup

### DIFF
--- a/ompi/mca/btl/vader/btl_vader_component.c
+++ b/ompi/mca/btl/vader/btl_vader_component.c
@@ -373,9 +373,8 @@ static void mca_btl_vader_check_single_copy (void)
             mca_btl_vader_select_next_single_copy_mechanism ();
         } else {
             mca_btl_vader.super.btl_get = mca_btl_vader_get_xpmem;
-            mca_btl_vader.super.btl_put = mca_btl_vader_get_xpmem;
+            mca_btl_vader.super.btl_put = mca_btl_vader_put_xpmem;
         }
-
     }
 #endif
 


### PR DESCRIPTION
Master commit open-mpi/ompi@c65f026feec5a65f5c927034deb3f963aa19ffa7
