### PR TITLE
Fix CUDA registering of shared memory. 

### DIFF
--- a/ompi/mca/btl/smcuda/btl_smcuda.c
+++ b/ompi/mca/btl/smcuda/btl_smcuda.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Los Alamos National Security, LLC.  
  *                         All rights reserved. 
- * Copyright (c) 2012-2013 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2012-2014 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -341,6 +341,15 @@ smcuda_btl_first_time_init(mca_btl_smcuda_t *smcuda_btl,
         }
     }
 #if OPAL_CUDA_SUPPORT
+    /* Register the entire shared memory region with the CUDA library which will
+     * force it to be pinned.  This aproach was chosen as there is no way for this
+     * local process to know which parts of the memory are being utilized by a
+     * remote process. */
+    opal_output_verbose(10, ompi_btl_base_framework.framework_output,
+                        "btl:smcuda: CUDA cuMemHostRegister address=%p, size=%d",
+                        mca_btl_smcuda_component.sm_mpool_base, (int)res->size);
+    mca_common_cuda_register(mca_btl_smcuda_component.sm_mpool_base, res->size, "smcuda");
+
     /* Create a local memory pool that sends handles to the remote
      * side.  Note that the res argument is not really used, but
      * needed to satisfy function signature. */

--- a/ompi/mca/btl/smcuda/btl_smcuda_component.c
+++ b/ompi/mca/btl/smcuda/btl_smcuda_component.c
@@ -182,7 +182,7 @@ static int smcuda_register(void)
 #endif /* OPAL_CUDA_SUPPORT */
     mca_btl_smcuda.super.btl_eager_limit = 4*1024;
     mca_btl_smcuda.super.btl_rndv_eager_limit = 4*1024;
-    mca_btl_smcuda.super.btl_max_send_size = 32*1024;
+    mca_btl_smcuda.super.btl_max_send_size = 128*1024;
     mca_btl_smcuda.super.btl_rdma_pipeline_send_length = 64*1024;
     mca_btl_smcuda.super.btl_rdma_pipeline_frag_size = 64*1024;
     mca_btl_smcuda.super.btl_min_rdma_pipeline_size = 64*1024;

--- a/ompi/mca/mpool/sm/mpool_sm_module.c
+++ b/ompi/mca/mpool/sm/mpool_sm_module.c
@@ -96,13 +96,6 @@ void* mca_mpool_sm_alloc(
 #endif
     }
 
-#if OPAL_CUDA_SUPPORT
-    if ((flags & MCA_MPOOL_FLAGS_CUDA_REGISTER_MEM) && (NULL != mseg.mbs_start_addr)) {
-        mca_common_cuda_register(mseg.mbs_start_addr, size,
-                                 mpool->mpool_component->mpool_version.mca_component_name);
-    }
-#endif
-
     return mseg.mbs_start_addr;
 }
 


### PR DESCRIPTION
Now we register the entire region.  Otherwise, we were only registering our local pieces and this gave bad performance.

Backported from commits: 
- https://github.com/open-mpi/ompi/commit/f55de452abdeeaa282205b21f6183e3e09cfdeba
- https://github.com/open-mpi/ompi/commit/26482db7366a8f544d429ffcc800ae5e23b7e95b

@bosilca Could you review this George?  The change here is that I am registering the entire mapped memory block with CUDA so copying into and out of the memory is faster.  Without this change, I only mapped in the memory that was locally allocated within the region.  This has been in the master for about a month.
