### PR TITLE
rcache/vma: fix parent class of mca_rcache_vma_t

### DIFF
--- a/ompi/mca/rcache/vma/rcache_vma_tree.c
+++ b/ompi/mca/rcache/vma/rcache_vma_tree.c
@@ -1,28 +1,29 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
-/**
-  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
-  *                         University Research and Technology
-  *                         Corporation.  All rights reserved.
-  * Copyright (c) 2004-2013 The University of Tennessee and The University
-  *                         of Tennessee Research Foundation.  All rights
-  *                         reserved.
-  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
-  *                         University of Stuttgart.  All rights reserved.
-  * Copyright (c) 2004-2005 The Regents of the University of California.
-  *                         All rights reserved.
-  *
-  * Copyright (c) 2006      Voltaire. All rights reserved.
-  * Copyright (c) 2007      Mellanox Technologies. All rights reserved.
-  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
-  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
-  *
-  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
-  * $COPYRIGHT$
-  * 
-  * Additional copyrights may follow
-  * 
-  * $HEADER$
-  */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ *
+ * Copyright (c) 2006      Voltaire. All rights reserved.
+ * Copyright (c) 2007      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2009      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
 /**
   * @file
   * Description of the Registration Cache framework
@@ -49,7 +50,7 @@ static void mca_rcache_vma_destruct(opal_object_t *object)
     OBJ_DESTRUCT(&vma->reg_delete_list);
 }
 
-OBJ_CLASS_INSTANCE(mca_rcache_vma_t, ompi_free_list_item_t,
+OBJ_CLASS_INSTANCE(mca_rcache_vma_t, opal_list_item_t,
         mca_rcache_vma_construct, mca_rcache_vma_destruct); 
 
 


### PR DESCRIPTION
There was a mismatch between the structure for mca_rcache_vma_t and
the OBJ_CLASS_INSTANCE. One was opal_list_item_t and the other was
ompi_free_list_item_t. The super class in the structure looks like it
is the correct one. Changed the superclass in OBJ_CLASS_INSTANCE to
match.

master commit open-mpi/ompi@cf4975501d8ceea751a4b17e22a466014496e3f8
