### PR TITLE
plm/alps: fix typo introduced in r31589

### DIFF
--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -522,6 +523,7 @@ static void alps_wait_cb(pid_t pid, int status, void* cbdata){
     
     if (0 != status) {
         if (failed_launch) {
+            /* report that the daemon has failed so we break out of the daemon
              * callback receive and exit
              */
             ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_FAILED_TO_START);            


### PR DESCRIPTION
Backported from commit: 
- open-mpi/ompi@2a57e71

This fixes open-mpi/ompi#345.

This commit was SVN r31747.

The following SVN revision numbers were found above:
  r31589 --> open-mpi/ompi@445b552d3a9ca1eeea57da65e240b11dfdead9d9
