### PR TITLE
Fix singleton comm_spawn

### DIFF
--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved. 
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -39,6 +39,7 @@
 #include "opal/util/argv.h"
 #include "opal/util/path.h"
 #include "opal/mca/installdirs/installdirs.h"
+#include "opal/mca/db/db.h"
 
 #include "orte/util/show_help.h"
 #include "orte/util/proc_info.h"
@@ -209,6 +210,37 @@ static int rte_init(void)
     putenv("OMPI_APP_CTX_NUM_PROCS=1");
     putenv("OMPI_MCA_orte_ess_num_procs=1");
 
+    /* push some useful info */
+
+    /* store the name of the local leader */
+    if (ORTE_SUCCESS != (rc = opal_db.store((opal_identifier_t*)ORTE_PROC_MY_NAME, OPAL_SCOPE_INTERNAL,
+                                            OPAL_DB_LOCALLDR, (opal_identifier_t*)ORTE_PROC_MY_NAME, OPAL_ID_T))) {
+        return rc;
+    }
+    /* store our hostname */
+    if (ORTE_SUCCESS != (rc = opal_db.store((opal_identifier_t*)ORTE_PROC_MY_NAME,
+                                            OPAL_SCOPE_GLOBAL, ORTE_DB_HOSTNAME,
+                                            orte_process_info.nodename, OPAL_STRING))) {
+        return rc;
+    }
+    /* store our cpuset */
+    if (ORTE_SUCCESS != (rc = opal_db.store((opal_identifier_t*)ORTE_PROC_MY_NAME,
+                                            OPAL_SCOPE_GLOBAL, OPAL_DB_CPUSET,
+                                            orte_process_info.cpuset, OPAL_STRING))) {
+        return rc;
+    }
+    /* store our local rank */
+    if (ORTE_SUCCESS != (rc = opal_db.store((opal_identifier_t*)ORTE_PROC_MY_NAME,
+                                            OPAL_SCOPE_GLOBAL, ORTE_DB_LOCALRANK,
+                                            &orte_process_info.my_local_rank, ORTE_LOCAL_RANK))) {
+        return rc;
+    }
+    /* store our node rank */
+    if (ORTE_SUCCESS != (rc = opal_db.store((opal_identifier_t*)ORTE_PROC_MY_NAME,
+                                            OPAL_SCOPE_GLOBAL, ORTE_DB_NODERANK,
+                                            &orte_process_info.my_node_rank, ORTE_NODE_RANK))) {
+        return rc;
+    }
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/plm/base/plm_base_proxy.c
+++ b/orte/mca/plm/base/plm_base_proxy.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved. 
- * Copyright (c) 2013      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +34,7 @@
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/rml/rml.h"
 #include "orte/mca/rml/rml_types.h"
+#include "orte/mca/rml/base/rml_contact.h"
 #include "orte/mca/routed/routed.h"
 #include "orte/runtime/orte_globals.h"
 
@@ -410,10 +411,24 @@ int orte_plm_base_fork_hnp(void)
          * if/when we attempt to send to it
          */
         orte_rml.set_contact_info(orte_process_info.my_daemon_uri);
+        /* and set the name */
+        if (ORTE_SUCCESS != (rc = orte_rml_base_parse_uris(orte_process_info.my_daemon_uri,
+                                                           ORTE_PROC_MY_DAEMON, NULL))) {
+            ORTE_ERROR_LOG(rc);
+            return rc;
+        }
 
         /* likewise, since this is also the HNP, set that uri too */
         orte_process_info.my_hnp_uri = strdup(orted_uri);
-        
+        /* set that contact info */
+        orte_rml.set_contact_info(orte_process_info.my_hnp_uri);
+        /* and set the name */
+        if (ORTE_SUCCESS != (rc = orte_rml_base_parse_uris(orte_process_info.my_hnp_uri,
+                                                           ORTE_PROC_MY_HNP, NULL))) {
+            ORTE_ERROR_LOG(rc);
+            return rc;
+        }
+
         /* all done - report success */
         free(orted_uri);
         return ORTE_SUCCESS;

--- a/orte/mca/routed/direct/routed_direct.c
+++ b/orte/mca/routed/direct/routed_direct.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2004-2011 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -117,6 +118,11 @@ static orte_process_name_t get_route(orte_process_name_t *target)
         goto found;
     }
 
+    /* if we are a proc and have a daemon, then route it there */
+    if (ORTE_PROC_IS_APP && NULL != orte_process_info.my_daemon_uri) {
+        ret = ORTE_PROC_MY_DAEMON;
+        goto found;
+    }
     /* all routes go direct */
     ret = target;
 

--- a/orte/mca/routed/direct/routed_direct_component.c
+++ b/orte/mca/routed/direct/routed_direct_component.c
@@ -3,6 +3,7 @@
  *                         All rights reserved. 
  * Copyright (c) 2004-2008 The Trustees of Indiana University.
  *                         All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -14,6 +15,8 @@
 #include "orte/constants.h"
 
 #include "opal/mca/base/base.h"
+
+#include "orte/util/proc_info.h"
 
 #include "orte/mca/routed/base/base.h"
 #include "routed_direct.h"
@@ -46,8 +49,14 @@ orte_routed_component_t mca_routed_direct_component = {
 
 static int orte_routed_direct_component_query(mca_base_module_t **module, int *priority)
 {
-    /* allow selection only when specifically requested */
-    *priority = 0;
+    opal_output(0, "DIRECT TYPE: %x", orte_process_info.proc_type);
+    if (ORTE_PROC_IS_SINGLETON) {
+        /* we must be selected */
+        *priority = 100;
+    } else {
+        /* allow selection only when specifically requested */
+        *priority = 0;
+    }
     *module = (mca_base_module_t *) &orte_routed_direct_module;
     return ORTE_SUCCESS;
 }

--- a/orte/mca/routed/direct/routed_direct_component.c
+++ b/orte/mca/routed/direct/routed_direct_component.c
@@ -49,7 +49,6 @@ orte_routed_component_t mca_routed_direct_component = {
 
 static int orte_routed_direct_component_query(mca_base_module_t **module, int *priority)
 {
-    opal_output(0, "DIRECT TYPE: %x", orte_process_info.proc_type);
     if (ORTE_PROC_IS_SINGLETON) {
         /* we must be selected */
         *priority = 100;

--- a/orte/mca/state/novm/state_novm.c
+++ b/orte/mca/state/novm/state_novm.c
@@ -214,19 +214,19 @@ static void allocation_complete(int fd, short args, void *cbdata)
 
 #if OPAL_HAVE_HWLOC
     {
-        hwloc_topology_t t;
+        orte_topology_t *t;
         orte_node_t *node;
         int i;
 
         /* ensure that all nodes point to our topology - we
          * cannot support hetero nodes with this state machine
          */
-        t = (hwloc_topology_t)opal_pointer_array_get_item(orte_node_topologies, 0);
+        t = (orte_topology_t*)opal_pointer_array_get_item(orte_node_topologies, 0);
         for (i=1; i < orte_node_pool->size; i++) {
             if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
                 continue;
             }
-            node->topology = t;
+            node->topology = t->topo;
         }
     }
 #endif


### PR DESCRIPTION
Had to recreate the pull request due to some difficulty in pushing an update to the existing branch. Fixes the case where a singleton comm_spawn's processes that span multiple nodes by ensuring that the correct routed module is being used, the prefix for the daemon launch is set, etc.

Also fix a corner case reported by Jeff by ensuring that all the usual info about the singleton gets put in the opal/db
