### PR TITLE
MPI_Intercomm_merge: fix typo in man page

### DIFF
--- a/ompi/mpi/man/man3/MPI_Intercomm_merge.3in
+++ b/ompi/mpi/man/man3/MPI_Intercomm_merge.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -13,7 +13,7 @@
 .nf
 #include <mpi.h>
 int MPI_Intercomm_merge(MPI_Comm \fIintercomm\fP, int\fI high\fP, 
-     MPI_Comm\fI *newintracomm\fP
+     MPI_Comm\fI *newintracomm\fP)
 
 .fi
 .SH Fortran Syntax


### PR DESCRIPTION
Thanks to Harald Servat for noticing and sending a patch.

(cherry picked from commit open-mpi/ompi@ae5424c18b063291ec0b6e870cf3c0f4f75560cf)
