### PR TITLE
wrappers: fix errant @{libdir} reference in pkg-config files

### DIFF
--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -236,6 +236,17 @@ AC_DEFUN([RPATHIFY_LDFLAGS],[
 ])
 
 
+dnl
+dnl Avoid some repetitive code below
+dnl
+AC_DEFUN([_OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG],[
+    AC_MSG_CHECKING([for $1 pkg-config LDFLAGS])
+    $1_PKG_CONFIG_LDFLAGS=`echo "$$1_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
+    AC_SUBST([$1_PKG_CONFIG_LDFLAGS])
+    AC_MSG_RESULT([$$1_PKG_CONFIG_LDFLAGS])
+])
+
+
 # OPAL_SETUP_WRAPPER_FINAL()
 # ---------------------------
 AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
@@ -288,10 +299,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_LDFLAGS])
 
        # Convert @{libdir} to ${libdir} for pkg-config
-       AC_MSG_CHECKING([for OPAL pkg-config LDFLAGS])
-       OPAL_PKG_CONFIG_LDFLAGS=`echo "$OPAL_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
-       AC_SUBST([OPAL_PKG_CONFIG_LDFLAGS])
-       AC_MSG_RESULT([$OPAL_PKG_CONFIG_LDFLAGS])
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([OPAL])
 
        # wrapper_extra_libs doesn't really get populated until after the mca system runs
        # since most of the libs come from libtool.  So this is the first time we can
@@ -338,10 +346,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_LDFLAGS])
 
        # Convert @{libdir} to ${libdir} for pkg-config
-       AC_MSG_CHECKING([for ORTE pkg-config LDFLAGS])
-       ORTE_PKG_CONFIG_LDFLAGS=`echo "$ORTE_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
-       AC_SUBST([ORTE_PKG_CONFIG_LDFLAGS])
-       AC_MSG_RESULT([$ORTE_PKG_CONFIG_LDFLAGS])
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([ORTE])
 
        AC_MSG_CHECKING([for ORTE LIBS])
        ORTE_WRAPPER_EXTRA_LIBS="$orte_mca_wrapper_extra_libs"
@@ -430,10 +435,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_LDFLAGS])
 
        # Convert @{libdir} to ${libdir} for pkg-config
-       AC_MSG_CHECKING([for OMPI pkg-config LDFLAGS])
-       OMPI_PKG_CONFIG_LDFLAGS=`echo "$OMPI_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
-       AC_SUBST([OMPI_PKG_CONFIG_LDFLAGS])
-       AC_MSG_RESULT([$OMPI_PKG_CONFIG_LDFLAGS])
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([OMPI])
 
        AC_MSG_CHECKING([for OMPI LIBS])
        OMPI_WRAPPER_EXTRA_LIBS="$ompi_mca_wrapper_extra_libs"

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -11,7 +11,9 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
-dnl Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl 
 dnl Additional copyrights may follow
@@ -246,6 +248,12 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
           [AC_MSG_WARN([RPATH support requested but not available])
            AC_MSG_ERROR([Cannot continue])])
 
+    # Note that we have to setup <package>_PKG_CONFIG_LDFLAGS for the
+    # pkg-config files to parallel the
+    # <package>_WRAPPER_EXTRA_LDFLAGS.  This is because pkg-config
+    # will not understand the @{libdir} notation in
+    # *_WRAPPER_EXTRA_LDFLAGS; we have to translate it to ${libdir}.
+
     # We now have all relevant flags.  Substitute them in everywhere.
     m4_ifdef([project_opal], [
        AC_MSG_CHECKING([for OPAL CPPFLAGS])
@@ -278,6 +286,12 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        RPATHIFY_LDFLAGS([OPAL_WRAPPER_EXTRA_LDFLAGS])
        AC_SUBST([OPAL_WRAPPER_EXTRA_LDFLAGS])
        AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       AC_MSG_CHECKING([for OPAL pkg-config LDFLAGS])
+       OPAL_PKG_CONFIG_LDFLAGS=`echo "$OPAL_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
+       AC_SUBST([OPAL_PKG_CONFIG_LDFLAGS])
+       AC_MSG_RESULT([$OPAL_PKG_CONFIG_LDFLAGS])
 
        # wrapper_extra_libs doesn't really get populated until after the mca system runs
        # since most of the libs come from libtool.  So this is the first time we can
@@ -322,6 +336,12 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        RPATHIFY_LDFLAGS([ORTE_WRAPPER_EXTRA_LDFLAGS])
        AC_SUBST([ORTE_WRAPPER_EXTRA_LDFLAGS])
        AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       AC_MSG_CHECKING([for ORTE pkg-config LDFLAGS])
+       ORTE_PKG_CONFIG_LDFLAGS=`echo "$ORTE_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
+       AC_SUBST([ORTE_PKG_CONFIG_LDFLAGS])
+       AC_MSG_RESULT([$ORTE_PKG_CONFIG_LDFLAGS])
 
        AC_MSG_CHECKING([for ORTE LIBS])
        ORTE_WRAPPER_EXTRA_LIBS="$orte_mca_wrapper_extra_libs"
@@ -408,6 +428,12 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
        RPATHIFY_LDFLAGS([OMPI_WRAPPER_EXTRA_LDFLAGS])
        AC_SUBST([OMPI_WRAPPER_EXTRA_LDFLAGS])
        AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       AC_MSG_CHECKING([for OMPI pkg-config LDFLAGS])
+       OMPI_PKG_CONFIG_LDFLAGS=`echo "$OMPI_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
+       AC_SUBST([OMPI_PKG_CONFIG_LDFLAGS])
+       AC_MSG_RESULT([$OMPI_PKG_CONFIG_LDFLAGS])
 
        AC_MSG_CHECKING([for OMPI LIBS])
        OMPI_WRAPPER_EXTRA_LIBS="$ompi_mca_wrapper_extra_libs"

--- a/ompi/tools/wrappers/ompi-c.pc.in
+++ b/ompi/tools/wrappers/ompi-c.pc.in
@@ -14,7 +14,7 @@ libdir=@libdir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_WRAPPER_EXTRA_LDFLAGS@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -lmpi
 Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because it

--- a/ompi/tools/wrappers/ompi-cxx.pc.in
+++ b/ompi/tools/wrappers/ompi-cxx.pc.in
@@ -14,7 +14,7 @@ libdir=@libdir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_WRAPPER_EXTRA_LDFLAGS@ @OMPI_WRAPPER_CXX_LIB@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_WRAPPER_CXX_LIB@ -lmpi
 Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because we

--- a/ompi/tools/wrappers/ompi-fort.pc.in
+++ b/ompi/tools/wrappers/ompi-fort.pc.in
@@ -14,6 +14,6 @@ libdir=@libdir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_WRAPPER_EXTRA_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi
 Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
 Cflags: @OMPI_FC_MODULE_FLAG@${libdir} -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_FCFLAGS@

--- a/ompi/tools/wrappers/ompi.pc.in
+++ b/ompi/tools/wrappers/ompi.pc.in
@@ -14,7 +14,7 @@ libdir=@libdir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_WRAPPER_EXTRA_LDFLAGS@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -lmpi
 Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because it

--- a/orte/tools/wrappers/orte.pc.in
+++ b/orte/tools/wrappers/orte.pc.in
@@ -14,7 +14,7 @@ libdir=@libdir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @ORTE_WRAPPER_EXTRA_LDFLAGS@ -lopen-rte
+Libs: -L${libdir} @ORTE_PKG_CONFIG_LDFLAGS@ -lopen-rte
 Libs.private: @ORTE_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because we


### PR DESCRIPTION
The RPATH support added a `@{libdir}` token into `<package>_WRAPPER_EXTRA_LDFLAGS`.  However, these flags are also substituted into the `pkg-config` data files, and they don't understand the `@{foo}` notation.  So convert `@{libdir}` into `${libdir}`, which `pkg-config` _does_ understand.

Thanks to Christoph Junghans (@junghans) for notifying us of the issue.

(cherry picked from commit open-mpi/ompi@9b716d946e308213186d5168cbb657299739f85b)
