### PR TITLE
MPI_Barrier.3in: fix prototypes

### DIFF
--- a/ompi/mpi/man/man3/MPI_Barrier.3in
+++ b/ompi/mpi/man/man3/MPI_Barrier.3in
@@ -1,11 +1,11 @@
 .\" -*- nroff -*-
-.\" Copyright 2014 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
 .TH MPI_Barrier 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
-\fBMPI_Barrier, MPI_Ibcarrier\fP \- Synchronization between MPI processes in a group
+\fBMPI_Barrier, MPI_Ibarrier\fP \- Synchronization between MPI processes in a group
 
 .SH SYNTAX
 .ft R
@@ -14,7 +14,7 @@
 #include <mpi.h>
 int MPI_Barrier(MPI_Comm \fIcomm\fP)
 
-int MPI_Ibarrier(MPI_Comm \fIcomm\fP)
+int MPI_Ibarrier(MPI_Comm \fIcomm\fP, MPI_Request \fIrequest\fP)
 
 .fi
 .SH Fortran Syntax
@@ -23,8 +23,8 @@ INCLUDE 'mpif.h'
 MPI_BARRIER(\fICOMM\fP,\fI IERROR\fP)
 	INTEGER	\fICOMM\fP,\fI IERROR\fP
 
-MPI_IBARRIER(\fICOMM\fP,\fI IERROR\fP)
-	INTEGER	\fICOMM\fP,\fI IERROR\fP
+MPI_IBARRIER(\fICOMM\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	INTEGER	\fICOMM\fP, \fIREQUEST\fP, \fIIERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_Ibarrier.3in
+++ b/ompi/mpi/man/man3/MPI_Ibarrier.3in
@@ -1,1 +1,1 @@
-.so man3/MPI_Ibarrier.3
+.so man3/MPI_Barrier.3


### PR DESCRIPTION
Also fix MPI_Ibarrier.3in to .so to the right MPI_Barrier.3 page.

Thanks to Maximilian for bringing the issue to our attention.

(cherry picked from commit open-mpi/ompi@4c91bdfb0c106f66590aa20b245946dea4af6d61)
