### PR TITLE
Correctly set the upper and lower bound for the subarray and darray.

### DIFF
--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -272,7 +272,7 @@ int32_t ompi_datatype_create_darray(int size,
 
             rc = ompi_datatype_create_struct(3, blength, displs, types, newtype);
         } else {
-            ompi_datatype_create_resized(lastType, displs[0], displs[2], newtype);
+            ompi_datatype_create_resized(lastType, displs[1], displs[2], newtype);
         }
         ompi_datatype_destroy(&lastType);
         /* need to destroy the old type even in error condition, so

--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -85,6 +85,7 @@ int32_t ompi_datatype_create_subarray(int ndims,
         ompi_datatype_create_hvector( subsize_array[i], 1, size * extent,
                                       last_type, newtype );
         ompi_datatype_destroy( &last_type );
+
         displ += size * start_array[i];
         size *= size_array[i];
         last_type = *newtype;
@@ -106,7 +107,7 @@ int32_t ompi_datatype_create_subarray(int ndims,
         types[0] = MPI_LB; types[1] = last_type; types[2] = MPI_UB;
         ompi_datatype_create_struct( 3, blength, displs, types, newtype );
     } else {
-        ompi_datatype_create_resized(last_type, 0, size * extent, newtype);
+        ompi_datatype_create_resized(last_type, displ * extent, size * extent, newtype);
     }
     ompi_datatype_destroy( &last_type );
 


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@ded4cbf20f1ef4d21e92cbe4cee7cb70719122b2)

Per open-mpi/ompi#380

@bosilca wrote this patch; @hjelmn Can you review?
