### PR TITLE
shmem base fixes

### DIFF
--- a/opal/mca/shmem/base/base.h
+++ b/opal/mca/shmem/base/base.h
@@ -124,14 +124,12 @@ OPAL_DECLSPEC extern bool opal_shmem_base_selected;
 /**
  * Global component struct for the selected component
  */
-OPAL_DECLSPEC extern const opal_shmem_base_component_2_0_0_t
-*opal_shmem_base_component;
+OPAL_DECLSPEC extern opal_shmem_base_component_t *opal_shmem_base_component;
 
 /**
  * Global module struct for the selected module
  */
-OPAL_DECLSPEC extern const opal_shmem_base_module_2_0_0_t
-*opal_shmem_base_module;
+OPAL_DECLSPEC extern opal_shmem_base_module_t *opal_shmem_base_module;
 
 /**
  * Runtime hint

--- a/opal/mca/shmem/base/base.h
+++ b/opal/mca/shmem/base/base.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -55,17 +55,6 @@ opal_shmem_unlink(opal_shmem_ds_t *ds_buf);
 /*
  * Global functions for MCA overall shmem open and close
  */
-
-/**
- * Performs a run-time query across all available shmem components.  Similar to
- * mca_base_select, but take into consideration environment hints provided by
- * orte.
- *
- * see: orte/mca/odls/base/odls_base_default_fns.c
- */
-OPAL_DECLSPEC int
-opal_shmem_base_runtime_query(mca_base_module_t **best_module,
-                              mca_base_component_t **best_component);
 
 /**
  * returns the name of the best, runnable shmem component.  the caller is

--- a/opal/mca/shmem/base/shmem_base_select.c
+++ b/opal/mca/shmem/base/shmem_base_select.c
@@ -40,41 +40,13 @@ const opal_shmem_base_component_2_0_0_t *opal_shmem_base_component = NULL;
 const opal_shmem_base_module_2_0_0_t *opal_shmem_base_module = NULL;
 
 /* ////////////////////////////////////////////////////////////////////////// */
-char *
-opal_shmem_base_best_runnable_component_name(void)
-{
-    mca_base_component_t *best_component = NULL;
-    mca_base_module_t *best_module = NULL;
 
-    opal_output_verbose(10, opal_shmem_base_framework.framework_output,
-                        "shmem: base: best_runnable_component_name: "
-                        "Searching for best runnable component.");
-    /* select the best component so we can get its name. */
-    if (OPAL_SUCCESS != opal_shmem_base_runtime_query(&best_module,
-                                                      &best_component)) {
-        /* fail! */
-        return NULL;
-    }
-    else {
-        if (NULL != best_component) {
-            opal_output_verbose(10, opal_shmem_base_framework.framework_output,
-                                "shmem: base: best_runnable_component_name: "
-                                "Found best runnable component: (%s).",
-                                best_component->mca_component_name);
-            return strdup(best_component->mca_component_name);
-        }
-        else {
-            opal_output_verbose(10, opal_shmem_base_framework.framework_output,
-                                "shmem: base: best_runnable_component_name: "
-                                "Could not find runnable component.");
-            /* no component returned, so return NULL */
-            return NULL;
-        }
-    }
-}
-
-/* ////////////////////////////////////////////////////////////////////////// */
-int
+/*
+ * Performs a run-time query across all available shmem components.
+ * Similar to mca_base_select, but take into consideration environment
+ * hints provided by orte.
+ */
+static int
 opal_shmem_base_runtime_query(mca_base_module_t **best_module,
                               mca_base_component_t **best_component)
 {
@@ -166,6 +138,40 @@ opal_shmem_base_runtime_query(mca_base_module_t **best_module,
                                                 (mca_base_component_t *)(*best_component));
 
     return OPAL_SUCCESS;
+}
+
+/* ////////////////////////////////////////////////////////////////////////// */
+char *
+opal_shmem_base_best_runnable_component_name(void)
+{
+    mca_base_component_t *best_component = NULL;
+    mca_base_module_t *best_module = NULL;
+
+    opal_output_verbose(10, opal_shmem_base_framework.framework_output,
+                        "shmem: base: best_runnable_component_name: "
+                        "Searching for best runnable component.");
+    /* select the best component so we can get its name. */
+    if (OPAL_SUCCESS != opal_shmem_base_runtime_query(&best_module,
+                                                      &best_component)) {
+        /* fail! */
+        return NULL;
+    }
+    else {
+        if (NULL != best_component) {
+            opal_output_verbose(10, opal_shmem_base_framework.framework_output,
+                                "shmem: base: best_runnable_component_name: "
+                                "Found best runnable component: (%s).",
+                                best_component->mca_component_name);
+            return strdup(best_component->mca_component_name);
+        }
+        else {
+            opal_output_verbose(10, opal_shmem_base_framework.framework_output,
+                                "shmem: base: best_runnable_component_name: "
+                                "Could not find runnable component.");
+            /* no component returned, so return NULL */
+            return NULL;
+        }
+    }
 }
 
 /* ////////////////////////////////////////////////////////////////////////// */

--- a/opal/mca/shmem/base/shmem_base_select.c
+++ b/opal/mca/shmem/base/shmem_base_select.c
@@ -55,6 +55,15 @@ opal_shmem_base_runtime_query(mca_base_module_t **best_module,
     mca_base_module_t *module = NULL;
     int priority = 0, best_priority = INT32_MIN;
 
+    /* If we've already done this query, then just return the
+       results */
+    if (opal_shmem_base_selected) {
+        *best_component = &(opal_shmem_base_component->base_version);
+        *best_module = &(opal_shmem_base_module->base);
+
+        return OPAL_SUCCESS;
+    }
+
     *best_module = NULL;
     *best_component = NULL;
 
@@ -137,6 +146,11 @@ opal_shmem_base_runtime_query(mca_base_module_t **best_module,
     (void) mca_base_framework_components_close (&opal_shmem_base_framework,
                                                 (mca_base_component_t *)(*best_component));
 
+    /* save the winner */
+    opal_shmem_base_component = (opal_shmem_base_component_t*) *best_component;
+    opal_shmem_base_module = (opal_shmem_base_module_t*) *best_module;
+    opal_shmem_base_selected = true;
+
     return OPAL_SUCCESS;
 }
 
@@ -189,11 +203,6 @@ opal_shmem_base_select(void)
          */
         return OPAL_ERROR;
     }
-
-    /* save the winner */
-    opal_shmem_base_component = best_component;
-    opal_shmem_base_module    = best_module;
-    opal_shmem_base_selected  = true;
 
     /* initialize the winner */
     if (NULL != opal_shmem_base_module) {

--- a/opal/mca/shmem/base/shmem_base_select.c
+++ b/opal/mca/shmem/base/shmem_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2010 Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -36,8 +36,8 @@
  * globals
  */
 bool opal_shmem_base_selected = false;
-const opal_shmem_base_component_2_0_0_t *opal_shmem_base_component = NULL;
-const opal_shmem_base_module_2_0_0_t *opal_shmem_base_module = NULL;
+opal_shmem_base_component_t *opal_shmem_base_component = NULL;
+opal_shmem_base_module_t *opal_shmem_base_module = NULL;
 
 /* ////////////////////////////////////////////////////////////////////////// */
 

--- a/opal/mca/shmem/mmap/shmem_mmap_component.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_component.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -57,37 +57,27 @@ static int mmap_runtime_query(mca_base_module_t **module,
  * and pointers to our public functions in it
  */
 opal_shmem_mmap_component_t mca_shmem_mmap_component = {
-    /* ////////////////////////////////////////////////////////////////////// */
-    /* super */
-    /* ////////////////////////////////////////////////////////////////////// */
-    {
-        /**
-         * common MCA component data
-         */
-        {
+    .super = {
+        .base_version = {
             OPAL_SHMEM_BASE_VERSION_2_0_0,
 
             /* component name and version */
-            "mmap",
-            OPAL_MAJOR_VERSION,
-            OPAL_MINOR_VERSION,
-            OPAL_RELEASE_VERSION,
+            .mca_component_name = "mmap",
+            .mca_component_major_version = OPAL_MAJOR_VERSION,
+            .mca_component_minor_version = OPAL_MINOR_VERSION,
+            .mca_component_release_version = OPAL_RELEASE_VERSION,
 
-            /* component open */
-            mmap_open,
-            /* component close */
-            mmap_close,
-            /* component query */
-            mmap_query,
-            /* component register */
-            mmap_register
+            .mca_open_component = mmap_open,
+            .mca_close_component = mmap_close,
+            .mca_query_component = mmap_query,
+            .mca_register_component_params = mmap_register,
         },
         /* MCA v2.0.0 component meta data */
-        {
+        .base_data = {
             /* the component is checkpoint ready */
             MCA_BASE_METADATA_PARAM_CHECKPOINT
         },
-        mmap_runtime_query,
+        .runtime_query = mmap_runtime_query,
     },
 };
 

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -93,15 +93,14 @@ module_finalize(void);
  * mmap shmem module
  */
 opal_shmem_mmap_module_t opal_shmem_mmap_module = {
-    /* super */
-    {
-        module_init,
-        segment_create,
-        ds_copy,
-        segment_attach,
-        segment_detach,
-        segment_unlink,
-        module_finalize
+    .super = {
+        .module_init = module_init,
+        .segment_create = segment_create,
+        .ds_copy = ds_copy,
+        .segment_attach = segment_attach,
+        .segment_detach = segment_detach,
+        .unlink = segment_unlink,
+        .module_finalize = module_finalize
     }
 };
 

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
@@ -70,38 +70,27 @@ static bool rt_successful = false;
  * and pointers to our public functions in it
  */
 opal_shmem_posix_component_t mca_shmem_posix_component = {
-    /* ////////////////////////////////////////////////////////////////////// */
-    /* super */
-    /* ////////////////////////////////////////////////////////////////////// */
-    {
-        /* common MCA component data */
-        {
+    .super = {
+        .base_version = {
             OPAL_SHMEM_BASE_VERSION_2_0_0,
 
             /* component name and version */
-            "posix",
-            OPAL_MAJOR_VERSION,
-            OPAL_MINOR_VERSION,
-            OPAL_RELEASE_VERSION,
+            .mca_component_name = "posix",
+            .mca_component_major_version = OPAL_MAJOR_VERSION,
+            .mca_component_minor_version = OPAL_MINOR_VERSION,
+            .mca_component_release_version = OPAL_RELEASE_VERSION,
 
-            /* component open */
-            posix_open,
-            /* component close */
-            NULL,
-            /* component query */
-            posix_query,
-            posix_register
+            .mca_open_component = posix_open,
+            .mca_query_component = posix_query,
+            .mca_register_component_params = posix_register
         },
         /* MCA v2.0.0 component meta data */
-        {
+        .base_data = {
             /* the component is checkpoint ready */
             MCA_BASE_METADATA_PARAM_CHECKPOINT
         },
-        posix_runtime_query,
+        .runtime_query = posix_runtime_query,
     },
-    /* ////////////////////////////////////////////////////////////////////// */
-    /* posix component-specific information */
-    /* see: shmem_posix.h for more information */
 };
 
 

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -90,15 +90,14 @@ module_finalize(void);
 
 /* posix shmem module */
 opal_shmem_posix_module_t opal_shmem_posix_module = {
-    /* super */
-    {
-        module_init,
-        segment_create,
-        ds_copy,
-        segment_attach,
-        segment_detach,
-        segment_unlink,
-        module_finalize
+    .super = {
+        .module_init = module_init,
+        .segment_create = segment_create,
+        .ds_copy = ds_copy,
+        .segment_attach = segment_attach,
+        .segment_detach = segment_detach,
+        .unlink = segment_unlink,
+        .module_finalize = module_finalize
     }
 };
 

--- a/opal/mca/shmem/shmem.h
+++ b/opal/mca/shmem/shmem.h
@@ -161,6 +161,7 @@ typedef int (*opal_shmem_base_module_finalize_fn_t)(void);
  * structure for shmem modules
  */
 struct opal_shmem_base_module_2_0_0_t {
+    mca_base_module_t                           base;
     opal_shmem_base_module_init_fn_t            module_init;
     opal_shmem_base_module_segment_create_fn_t  segment_create;
     opal_shmem_base_ds_copy_fn_t                ds_copy;

--- a/opal/mca/shmem/shmem.h
+++ b/opal/mca/shmem/shmem.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2010-2011 Los Alamos National Security, LLC.
@@ -180,9 +180,12 @@ typedef struct opal_shmem_base_module_2_0_0_t opal_shmem_base_module_t;
  * macro for use in components that are of type shmem
  * see: opal/mca/mca.h for more information
  */
-#define OPAL_SHMEM_BASE_VERSION_2_0_0                                          \
-    MCA_BASE_VERSION_2_0_0,                                                    \
-    "shmem", 2, 0, 0
+#define OPAL_SHMEM_BASE_VERSION_2_0_0                                   \
+    MCA_BASE_VERSION_2_0_0,                                             \
+        .mca_type_name = "shmem",                                       \
+        .mca_type_major_version = 2,                                    \
+        .mca_type_minor_version = 0,                                    \
+        .mca_type_release_version = 0
 
 END_C_DECLS
 

--- a/opal/mca/shmem/sysv/shmem_sysv_component.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_component.c
@@ -74,38 +74,28 @@ static int sysv_runtime_query(mca_base_module_t **module,
  * and pointers to our public functions in it
  */
 opal_shmem_sysv_component_t mca_shmem_sysv_component = {
-    /* ////////////////////////////////////////////////////////////////////// */
-    /* super */
-    /* ////////////////////////////////////////////////////////////////////// */
-    {
+    .super = {
         /* common MCA component data */
         {
             OPAL_SHMEM_BASE_VERSION_2_0_0,
 
             /* component name and version */
-            "sysv",
-            OPAL_MAJOR_VERSION,
-            OPAL_MINOR_VERSION,
-            OPAL_RELEASE_VERSION,
+            .mca_component_name = "sysv",
+            .mca_component_major_version = OPAL_MAJOR_VERSION,
+            .mca_component_minor_version = OPAL_MINOR_VERSION,
+            .mca_component_release_version = OPAL_RELEASE_VERSION,
 
-            /* component open */
-            sysv_open,
-            /* component close */
-            NULL,
-            /* component query */
-            sysv_query,
-            sysv_register
+            .mca_open_component = sysv_open,
+            .mca_query_component = sysv_query,
+            .mca_register_component_params = sysv_register
         },
         /* MCA v2.0.0 component meta data */
-        {
+        .base_data = {
             /* the component is checkpoint ready */
             MCA_BASE_METADATA_PARAM_CHECKPOINT
         },
-        sysv_runtime_query,
+        .runtime_query = sysv_runtime_query,
     },
-    /* ////////////////////////////////////////////////////////////////////// */
-    /* sysv component-specific information */
-    /* see: shmem_sysv.h for more information */
 };
 
 /* ////////////////////////////////////////////////////////////////////////// */

--- a/opal/mca/shmem/sysv/shmem_sysv_module.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_module.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -92,15 +92,14 @@ module_finalize(void);
 
 /* sysv shmem module */
 opal_shmem_sysv_module_t opal_shmem_sysv_module = {
-    /* super */
-    {
-        module_init,
-        segment_create,
-        ds_copy,
-        segment_attach,
-        segment_detach,
-        segment_unlink,
-        module_finalize
+    .super = {
+        .module_init = module_init,
+        .segment_create = segment_create,
+        .ds_copy = ds_copy,
+        .segment_attach = segment_attach,
+        .segment_detach = segment_detach,
+        .unlink = segment_unlink,
+        .module_finalize = module_finalize
     }
 };
 


### PR DESCRIPTION
Several fixes to the shmem base.  Some are insignificant, but they build up to 1bc53407bbfd6a549e3a6e689f13ceeb295067e5.

All come from master:
- open-mpi/ompi@62259a74f5da53b23ab2f0395707d5023e54eca0
- open-mpi/ompi@9666884cf1e7452c2f6414edca838a7542631614
- open-mpi/ompi@90a2c3cd990360a728fb2ad36aa8fcf8c82af304
- open-mpi/ompi@312b0afb67b70d3d25221c6ca043493ff930a42b
- open-mpi/ompi@5215dc0db3fc8f944fbde89950a133def22bc484

@hjelmn Can you review?  The last one is the important one.
