### PR TITLE
trivial spelling fixes

### DIFF
--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -748,7 +748,7 @@ void ompi_datatype_dump( const ompi_datatype_t* pData )
     if( ompi_datatype_is_predefined(pData) ) {
         index += snprintf( buffer + index, length - index, "predefined " );
     } else {
-        if( pData->super.flags & OPAL_DATATYPE_FLAG_COMMITED ) index += snprintf( buffer + index, length - index, "commited " );
+        if( pData->super.flags & OPAL_DATATYPE_FLAG_COMMITTED ) index += snprintf( buffer + index, length - index, "committed " );
         if( pData->super.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) index += snprintf( buffer + index, length - index, "contiguous " );
     }
     index += snprintf( buffer + index, length - index, ")" );

--- a/ompi/mca/bcol/ptpcoll/bcol_ptpcoll_mca.c
+++ b/ompi/mca/bcol/ptpcoll/bcol_ptpcoll_mca.c
@@ -166,17 +166,17 @@ int mca_bcol_ptpcoll_register_mca_params(void)
                   "(starts from 8)", 8, &cm->num_to_probe, REGINT_GE_ONE));
 
     CHECK(reg_int("bcast_small_msg_known_root_alg", NULL,
-                  "Algoritm selection for bcast small messages known root"
+                  "Algorithm selection for bcast small messages known root"
                   "(1 - K-nomial, 2 - N-array)", 1, &cm->bcast_small_messages_known_root_alg,
                   REGINT_GE_ZERO));
 
     CHECK(reg_int("bcast_large_msg_known_root_alg", NULL,
-                  "Algoritm selection for bcast large messages known root"
+                  "Algorithm selection for bcast large messages known root"
                   "(1 - Binomial scatther-gather, 2 - N-array scather, K-nomial gather)",
                   1, &cm->bcast_large_messages_known_root_alg, REGINT_GE_ZERO));
 
     CHECK(reg_int("barrier_alg", NULL,
-                  "Algoritm selection for Barrier"
+                  "Algorithm selection for Barrier"
                   "(1 - Recursive doubling, 2 - Recursive K-ing)",
                   1, &cm->barrier_alg, REGINT_GE_ZERO));
 

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -64,7 +64,7 @@ BEGIN_C_DECLS
 /* flags for the datatypes. */
 #define OPAL_DATATYPE_FLAG_UNAVAILABLE   0x0001  /**< datatypes unavailable on the build (OS or compiler dependant) */
 #define OPAL_DATATYPE_FLAG_PREDEFINED    0x0002  /**< cannot be removed: initial and predefined datatypes */
-#define OPAL_DATATYPE_FLAG_COMMITED      0x0004  /**< ready to be used for a send/recv operation */
+#define OPAL_DATATYPE_FLAG_COMMITTED      0x0004  /**< ready to be used for a send/recv operation */
 #define OPAL_DATATYPE_FLAG_OVERLAP       0x0008  /**< datatype is unpropper for a recv operation */
 #define OPAL_DATATYPE_FLAG_CONTIGUOUS    0x0010  /**< contiguous datatype */
 #define OPAL_DATATYPE_FLAG_NO_GAPS       0x0020  /**< no gaps around the datatype, aka OPAL_DATATYPE_FLAG_CONTIGUOUS and extent == size */
@@ -79,7 +79,7 @@ BEGIN_C_DECLS
                                           OPAL_DATATYPE_FLAG_CONTIGUOUS | \
                                           OPAL_DATATYPE_FLAG_NO_GAPS |    \
                                           OPAL_DATATYPE_FLAG_DATA |       \
-                                          OPAL_DATATYPE_FLAG_COMMITED)
+                                          OPAL_DATATYPE_FLAG_COMMITTED)
 
 
 /**
@@ -189,7 +189,7 @@ OPAL_DECLSPEC int32_t opal_datatype_destroy( opal_datatype_t** );
 static inline int32_t
 opal_datatype_is_committed( const opal_datatype_t* type )
 {
-    return ((type->flags & OPAL_DATATYPE_FLAG_COMMITED) == OPAL_DATATYPE_FLAG_COMMITED);
+    return ((type->flags & OPAL_DATATYPE_FLAG_COMMITTED) == OPAL_DATATYPE_FLAG_COMMITTED);
 }
 
 static inline int32_t

--- a/opal/datatype/opal_datatype_add.c
+++ b/opal/datatype/opal_datatype_add.c
@@ -280,7 +280,7 @@ int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtA
     if( (pdtAdd->flags & (OPAL_DATATYPE_FLAG_PREDEFINED | OPAL_DATATYPE_FLAG_DATA)) == (OPAL_DATATYPE_FLAG_PREDEFINED | OPAL_DATATYPE_FLAG_DATA) ) {
         pdtBase->btypes[pdtAdd->id] += count;
         if( (extent != (OPAL_PTRDIFF_TYPE)pdtAdd->size) && (count > 1) ) {  /* gaps around the datatype */
-            localFlags = pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITED | OPAL_DATATYPE_FLAG_CONTIGUOUS | OPAL_DATATYPE_FLAG_NO_GAPS);
+            localFlags = pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITTED | OPAL_DATATYPE_FLAG_CONTIGUOUS | OPAL_DATATYPE_FLAG_NO_GAPS);
             CREATE_LOOP_START( pLast, count, 2, extent, localFlags );
             pLast++;
             pLast->elem.common.type  = pdtAdd->id;
@@ -299,7 +299,7 @@ int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtA
             pLast->elem.disp        = disp;
             pLast->elem.extent      = extent;
             pdtBase->desc.used++;
-            pLast->elem.common.flags  = pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITED);
+            pLast->elem.common.flags  = pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITTED);
         }
     } else {
         /* keep trace of the total number of basic datatypes in the datatype definition */
@@ -323,7 +323,7 @@ int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtA
             if( count != 1 ) {
                 pLoop = pLast;
                 CREATE_LOOP_START( pLast, count, pdtAdd->desc.used + 1, extent,
-                                   (pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITED)) );
+                                   (pdtAdd->flags & ~(OPAL_DATATYPE_FLAG_COMMITTED)) );
                 pdtBase->btypes[OPAL_DATATYPE_LOOP] += 2;
                 pdtBase->desc.used += 2;
                 pLast++;

--- a/opal/datatype/opal_datatype_dump.c
+++ b/opal/datatype/opal_datatype_dump.c
@@ -55,7 +55,7 @@ int opal_datatype_dump_data_flags( unsigned short usflags, char* ptr, size_t len
     int index = 0;
     if( length < 22 ) return 0;
     index = snprintf( ptr, 22, "-----------[---][---]" );  /* set everything to - */
-    if( usflags & OPAL_DATATYPE_FLAG_COMMITED )   ptr[1]  = 'c';
+    if( usflags & OPAL_DATATYPE_FLAG_COMMITTED )   ptr[1]  = 'c';
     if( usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS ) ptr[2]  = 'C';
     if( usflags & OPAL_DATATYPE_FLAG_OVERLAP )    ptr[3]  = 'o';
     if( usflags & OPAL_DATATYPE_FLAG_USER_LB )    ptr[4]  = 'l';
@@ -120,7 +120,7 @@ void opal_datatype_dump( const opal_datatype_t* pData )
     if( pData->flags == OPAL_DATATYPE_FLAG_PREDEFINED )
         index += snprintf( buffer + index, length - index, "predefined " );
     else {
-        if( pData->flags & OPAL_DATATYPE_FLAG_COMMITED ) index += snprintf( buffer + index, length - index, "commited " );
+        if( pData->flags & OPAL_DATATYPE_FLAG_COMMITTED ) index += snprintf( buffer + index, length - index, "committed " );
         if( pData->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) index += snprintf( buffer + index, length - index, "contiguous " );
     }
     index += snprintf( buffer + index, length - index, ")" );

--- a/opal/datatype/opal_datatype_optimize.c
+++ b/opal/datatype/opal_datatype_optimize.c
@@ -255,8 +255,8 @@ int32_t opal_datatype_commit( opal_datatype_t * pData )
     ddt_endloop_desc_t* pLast = &(pData->desc.desc[pData->desc.used].end_loop);
     OPAL_PTRDIFF_TYPE first_elem_disp = 0;
 
-    if( pData->flags & OPAL_DATATYPE_FLAG_COMMITED ) return OPAL_SUCCESS;
-    pData->flags |= OPAL_DATATYPE_FLAG_COMMITED;
+    if( pData->flags & OPAL_DATATYPE_FLAG_COMMITTED ) return OPAL_SUCCESS;
+    pData->flags |= OPAL_DATATYPE_FLAG_COMMITTED;
 
     /* We have to compute the displacement of the first non loop item in the
      * description.

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -110,7 +110,7 @@ opal_err2str(int errnum, const char **errmsg)
         retval = "Not supported";
         break;
     case OPAL_ERR_INTERUPTED:
-        retval = "Interupted";
+        retval = "Interrupted";
         break;
     case OPAL_ERR_WOULD_BLOCK:
         retval = "Would block";

--- a/oshmem/mca/scoll/basic/scoll_basic_component.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_component.c
@@ -89,7 +89,7 @@ static int basic_register(void)
                                            &mca_scoll_basic_priority_param);
 
     sprintf(help_msg,
-            "Algoritm selection for Barrier (%d - Central Counter, %d - Tournament, %d - Recursive Doubling, %d - Dissemination, %d - Basic, %d - Adaptive)",
+            "Algorithm selection for Barrier (%d - Central Counter, %d - Tournament, %d - Recursive Doubling, %d - Dissemination, %d - Basic, %d - Adaptive)",
             SCOLL_ALG_BARRIER_CENTRAL_COUNTER,
             SCOLL_ALG_BARRIER_TOURNAMENT,
             SCOLL_ALG_BARRIER_RECURSIVE_DOUBLING,
@@ -105,7 +105,7 @@ static int basic_register(void)
                                            &mca_scoll_basic_param_barrier_algorithm);
 
     sprintf(help_msg,
-            "Algoritm selection for Broadcast (%d - Central Counter, %d - Binomial)",
+            "Algorithm selection for Broadcast (%d - Central Counter, %d - Binomial)",
             SCOLL_ALG_BROADCAST_CENTRAL_COUNTER,
             SCOLL_ALG_BROADCAST_BINOMIAL);
     (void) mca_base_component_var_register(comp,
@@ -117,7 +117,7 @@ static int basic_register(void)
                                            &mca_scoll_basic_param_broadcast_algorithm);
 
     sprintf(help_msg,
-            "Algoritm selection for Collect (%d - Central Counter, %d - Tournament, %d - Recursive Doubling, %d - Ring)",
+            "Algorithm selection for Collect (%d - Central Counter, %d - Tournament, %d - Recursive Doubling, %d - Ring)",
             SCOLL_ALG_COLLECT_CENTRAL_COUNTER,
             SCOLL_ALG_COLLECT_TOURNAMENT,
             SCOLL_ALG_COLLECT_RECURSIVE_DOUBLING,
@@ -131,7 +131,7 @@ static int basic_register(void)
                                            &mca_scoll_basic_param_collect_algorithm);
 
     sprintf(help_msg,
-            "Algoritm selection for Reduce (%d - Central Counter, %d - Tournament, %d - Recursive Doubling %d - Linear %d - Log)",
+            "Algorithm selection for Reduce (%d - Central Counter, %d - Tournament, %d - Recursive Doubling %d - Linear %d - Log)",
             SCOLL_ALG_REDUCE_CENTRAL_COUNTER,
             SCOLL_ALG_REDUCE_TOURNAMENT,
             SCOLL_ALG_REDUCE_RECURSIVE_DOUBLING,

--- a/test/datatype/ddt_lib.c
+++ b/test/datatype/ddt_lib.c
@@ -480,7 +480,7 @@ ompi_datatype_t* test_create_twice_two_doubles( void )
 /*
   Datatype 0x832cf28 size 0 align 1 id 0 length 4 used 0
   true_lb 0 true_ub 0 (true_extent 0) lb 0 ub 0 (extent 0)
-  nbElems 0 loops 0 flags 6 (commited contiguous )-cC--------[---][---]
+  nbElems 0 loops 0 flags 6 (committed contiguous )-cC--------[---][---]
   contain 13 disp 0x420 (1056) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x478 (1144) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x4d0 (1232) extent 4

--- a/test/datatype/ddt_lib.h
+++ b/test/datatype/ddt_lib.h
@@ -62,7 +62,7 @@ extern ompi_datatype_t* test_create_twice_two_doubles( void );
 /*
   Datatype 0x832cf28 size 0 align 1 id 0 length 4 used 0
   true_lb 0 true_ub 0 (true_extent 0) lb 0 ub 0 (extent 0)
-  nbElems 0 loops 0 flags 6 (commited contiguous )-cC--------[---][---]
+  nbElems 0 loops 0 flags 6 (committed contiguous )-cC--------[---][---]
   contain 13 disp 0x420 (1056) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x478 (1144) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x4d0 (1232) extent 4

--- a/test/datatype/opal_ddt_lib.c
+++ b/test/datatype/opal_ddt_lib.c
@@ -71,7 +71,7 @@ opal_datatype_t* test_create_twice_two_doubles( void )
 /*
   Datatype 0x832cf28 size 0 align 1 id 0 length 4 used 0
   true_lb 0 true_ub 0 (true_extent 0) lb 0 ub 0 (extent 0)
-  nbElems 0 loops 0 flags 6 (commited contiguous )-cC--------[---][---]
+  nbElems 0 loops 0 flags 6 (committed contiguous )-cC--------[---][---]
   contain 13 disp 0x420 (1056) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x478 (1144) extent 4
   --C-----D*-[ C ][INT]        MPI_INT count 13 disp 0x4d0 (1232) extent 4


### PR DESCRIPTION
Cherry picked from:
- open-mpi/ompi@4f11395
- open-mpi/ompi@8d04215
- open-mpi/ompi@336626d

@rhc54 can you review? Trivial stuff (these spelling errors actually brought up by the Debain packaging system...!).
