### PR TITLE
MPI_Comm_split_type.3in: remove erroneous "color" discussion

### DIFF
--- a/ompi/mpi/man/man3/MPI_Comm_split_type.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_split_type.3in
@@ -67,19 +67,6 @@ value MPI_UNDEFINED, in which case newcomm returns MPI_COMM_NULL.
 MPI_COMM_TYPE_SHARED
 This type splits the communicator into subcommunicators, each of which can create a shared memory region.
 
-.SH NOTES
-.ft R
-This is an extremely powerful mechanism for
-dividing a single communicating group of processes into k subgroups, with k
-chosen implicitly by the user (by the number of colors asserted over all
-the processes). Each resulting communicator will be nonoverlapping. Such a division could be useful for defining a hierarchy of computations, such as for multigrid or linear algebra.
-.sp
-Multiple calls to MPI_Comm_split_type can be used to overcome the requirement that any call have no overlap of the resulting communicators (each process is of only one color per call). In this way, multiple overlapping communication structures can be created. Creative use of the color and key in such splitting operations is encouraged.
-.sp
-Note that keys need not be unique. It is MPI_Comm_split_type's responsibility to sort processes in ascending order according to this key, and to break ties in a consistent way. If all the keys are specified in the same way, then all the processes in a given color will have the relative rank order as they did in their parent group. (In general, they will have different ranks.)
-.sp
-Essentially, making the key value zero for all processes of a given split_type means that one needn't really pay attention to the rank-order of the processes in the new communicator.
-
 .SH ERRORS
 Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument.
 .sp


### PR DESCRIPTION
Thanks to @eschnett for raising the issue.

(this is an abbreviated cherry-pick from open-mpi/ompi@4a998e3d2c2e5c88748befd3ebfcb45d3e5ce461 -- that commit contains other changes to the OMPI-specific keys for MPI_COMM_SPLIT_TYPE that do not exist in the v1.8 branch)
