### PR TITLE
Add extra checks in CUDA-aware to make sure we really should clean up CUDA resources

### DIFF
--- a/ompi/mca/common/cuda/help-mpi-common-cuda.txt
+++ b/ompi/mca/common/cuda/help-mpi-common-cuda.txt
@@ -42,12 +42,6 @@ The call to cuMemHostRegister(%p, %d, 0) failed.
   cuMemHostRegister return value:  %d
   Memory Pool:  %s
 #
-[cuMemHostUnregister failed]
-The call to cuMemHostUnregister(%p) failed.
-  Host:  %s
-  cuMemHostUnregister return value:  %d
-  Memory Pool:  %s
-#
 [cuIpcGetMemHandle failed]
 The call to cuIpcGetMemHandle failed. This means the GPU RDMA protocol
 cannot be used.


### PR DESCRIPTION
We have run into cases where users are doing some CUDA activities (like cudaDeviceReset) prior to calling MPI_Finalize.  When this happens, we should not be cleaning up CUDA resources as they are no longer available.  In fact, we can get SEGVs.  Therefore, we add an extra check that allows us to make sure everything is still OK before cleaning up.
- https://github.com/open-mpi/ompi/commit/237c268a090e247b648265398d090b0ae7c7d431

@bosilca  Can you review?

Do not integrate until sometime after Sunday, March 8, 2015 so i can see some overnight MTT runs.
