### PR TITLE
correct path to configure file

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -49,7 +49,7 @@ developer's checkout, you have three main options:
      shell$ ./autogen.pl
      shell$ mkdir build
      shell$ cd build
-     shell$ ./configure --with-platform=optimized ...
+     shell$ ../configure --with-platform=optimized ...
      [...lots of output...]
      shell$ make all install
 


### PR DESCRIPTION
HACKING: ./configure changed to ../configure

(cherry picked from commit open-mpi/ompi@748d38b48ae7727bdd351b152c81ad4283df9418)

bot:label:documentation
:+1:
