### PR TITLE
HCOLL: hcoll dte fixes

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
@@ -63,6 +63,9 @@ static dte_data_representation_t ompi_dtype_2_dte_dtype(ompi_datatype_t *dtype){
     int ompi_type_id = dtype->id;
     int opal_type_id = dtype->super.id;
     dte_data_representation_t dte_data_rep;
+    if (!(dtype->super.flags & OPAL_DATATYPE_FLAG_NO_GAPS)) {
+        ompi_type_id = -1;
+    }
     if (OPAL_UNLIKELY( ompi_type_id < 0 ||
                        ompi_type_id >= OPAL_DATATYPE_MAX_PREDEFINED)){
         dte_data_rep = DTE_ZERO;
@@ -91,7 +94,10 @@ static hcoll_dte_op_t* ompi_op_2_hcoll_op[OMPI_OP_BASE_FORTRAN_OP_MAX + 1] = {
    &hcoll_dte_op_null,          /* OMPI_OP_BASE_FORTRAN_NO_OP */
    &hcoll_dte_op_null           /* OMPI_OP_BASE_FORTRAN_OP_MAX */
 };
-static hcoll_dte_op_t* ompi_op_2_hcolrte_op(ompi_op_t *op){
+static hcoll_dte_op_t* ompi_op_2_hcolrte_op(ompi_op_t *op) {
+    if (op->o_f_to_c_index > OMPI_OP_BASE_FORTRAN_OP_MAX) {
+        return ompi_op_2_hcoll_op[0]; /* return null */
+    }
     return ompi_op_2_hcoll_op[op->o_f_to_c_index];
 }
 


### PR DESCRIPTION
```
- hcoll currently do not support datatype with gaps around it (i.e dtsize !=
```

dtextent)
    - check for user defined Ops.

https://github.com/open-mpi/ompi/commit/71c28cea6522186ea25ed4d6fe71c57f7a0a5795
