### PR TITLE
opal_setup_cc.m4: don't use -finline-functions with clang

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -187,12 +187,26 @@ AC_DEFUN([OPAL_SETUP_CC],[
     if test "$GCC" = "yes"; then
         CFLAGS_orig="$CFLAGS"
 
+        # Note: Some versions of clang (at least >= 3.5 -- perhaps
+        # older versions, too?) will *warn* about -finline-functions,
+        # but still allow it.  This is very annoying, so check for
+        # that warning, too.
         CFLAGS="$CFLAGS_orig -finline-functions"
         add=
         AC_CACHE_CHECK([if $CC supports -finline-functions],
                    [ompi_cv_cc_finline_functions],
                    [AC_TRY_COMPILE([], [],
-                                   [ompi_cv_cc_finline_functions="yes"],
+                                   [ompi_cv_cc_finline_functions="yes"
+                                    if test -s conftest.err ; then
+                                        for i in unused 'not supported' ; do
+                                            $GREP -iq "$i" conftest.err
+                                            if test $? -eq 0; then
+                                                ompi_cv_cc_finline_functions="no"
+                                                break;
+                                            fi
+                                        done
+                                    fi
+                                   ],
                                    [ompi_cv_cc_finline_functions="no"])])
         if test "$ompi_cv_cc_finline_functions" = "yes" ; then
             add=" -finline-functions"

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -190,7 +190,9 @@ AC_DEFUN([OPAL_SETUP_CC],[
         # Note: Some versions of clang (at least >= 3.5 -- perhaps
         # older versions, too?) will *warn* about -finline-functions,
         # but still allow it.  This is very annoying, so check for
-        # that warning, too.
+        # that warning, too.  The clang warning looks like this:
+        # clang: warning: optimization flag '-finline-functions' is not supported
+        # clang: warning: argument unused during compilation: '-finline-functions'
         CFLAGS="$CFLAGS_orig -finline-functions"
         add=
         AC_CACHE_CHECK([if $CC supports -finline-functions],
@@ -199,8 +201,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
                                    [ompi_cv_cc_finline_functions="yes"
                                     if test -s conftest.err ; then
                                         for i in unused 'not supported' ; do
-                                            $GREP -iq "$i" conftest.err
-                                            if test $? -eq 0; then
+                                            if $GREP -iq "$i" conftest.err; then
                                                 ompi_cv_cc_finline_functions="no"
                                                 break;
                                             fi


### PR DESCRIPTION
Some versions of clang (at least >= 3.5 -- perhaps older versions, too?) will _warn_ about -finline-functions, but still allow it.  This is very annoying, so check for that warning, too.

(cherry picked from commit open-mpi/ompi@a50f103c0fc42b8f664cebd8eae79494c92da69b)

@goodell Low priority, but can you review?
