### PR TITLE
ompi/datatype: fix subarray datatype

### DIFF
--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -92,13 +92,19 @@ int32_t ompi_datatype_create_subarray(int ndims,
     }
 
  replace_subarray_type:
-    /**
+    /*
      * Resized will only set the soft lb and ub markers without moving the real
      * data inside. Thus, in case the original data contains the hard markers
      * (MPI_LB or MPI_UB) we must force the displacement of the data upward to
      * the right position AND set the hard markers LB and UB.
+     *
+     * NTH: ompi_datatype_create_resized() does not do enough for the general
+     * pack/unpack functions to work correctly. Until this is fixed always use
+     * ompi_datatype_create_struct(). Once this is fixed remove 1 || below. To
+     * verify that the regression is fixed run the subarray test in the Open MPI
+     * ibm testsuite.
      */
-    if( oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
+    if(1 || oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
         MPI_Aint displs[3];
         MPI_Datatype types[3];
         int blength[3] = { 1, 1, 1 };


### PR DESCRIPTION
The subarray datatype was not packing/unpacking correctly. This was
leading to wrong results whenever the lb of the subarray datatype was
non-zero.

I tracked the issue to the use of ompi_datatype_create_resized. This
function simply duplicates the old datatype and sets the lb and
extent. This is unfortunately insufficent for the pack/unpack
functions which use the loop end first element offset NOT the lb. This
offset is 0 in the resized datatype. Once ompi_datatype_create_resized
has been fixed this commit should be reverted.

master commit open-mpi/ompi@e91084e20b616c5e133553fd4a6c53c352e46b0d

Fixes #380.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
