### PR TITLE
Don't error out with default bindings if binding isn't supported

### DIFF
--- a/opal/mca/hwloc/hwloc.h
+++ b/opal/mca/hwloc/hwloc.h
@@ -195,6 +195,8 @@ typedef uint16_t opal_binding_policy_t;
     ((pol) & 0x0fff)
 #define OPAL_SET_BINDING_POLICY(target, pol) \
     (target) = (pol) | (((target) & 0xf000) | OPAL_BIND_GIVEN)
+#define OPAL_SET_DEFAULT_BINDING_POLICY(target, pol) \
+    (target) = (pol) | (((target) & 0xf000) | OPAL_BIND_IF_SUPPORTED)
 /* check if policy is set */
 #define OPAL_BINDING_POLICY_IS_SET(pol) \
     ((pol) & 0x4000)

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -246,19 +246,19 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 if (1 < orte_rmaps_base.cpus_per_rank) {
                     /* assigning multiple cpus to a rank implies threading,
                      * so we only bind to the NUMA level */
-                    OPAL_SET_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
+                    OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 } else {
                     /* for performance, bind to core */
-                    OPAL_SET_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
+                    OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
                 }
             } else {
                 if (1 < orte_rmaps_base.cpus_per_rank) {
                     /* assigning multiple cpus to a rank implies threading,
                      * so we only bind to the NUMA level */
-                    OPAL_SET_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
+                    OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 } else {
                     /* for performance, bind to socket */
-                    OPAL_SET_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_SOCKET);
+                    OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_SOCKET);
                 }
             }
         }


### PR DESCRIPTION
If we are using the default bindings, and one or more nodes are not setup to support binding, then don't error out - just don't bind.

Thanks to Annu Desari for pointing out the problem.

(cherry picked from commit open-mpi/ompi@b67b3619fc7b629eb10c27b77add8fb111e8f6b2)

@jsquyres could you please review? I don't know if we need to print a warning if this happens - I hate to print warnings if unrequested actions can't be done.
