### PR TITLE
contrib/vt: Fix compile error when using Open64 4.5.2.1

### DIFF
--- a/ompi/contrib/vt/vt/config/m4/acinclude.omp.m4
+++ b/ompi/contrib/vt/vt/config/m4/acinclude.omp.m4
@@ -27,5 +27,29 @@ AC_DEFUN([ACVT_OMP],
 	])
 
 	AC_SUBST(VTPOMPLIB)
+
+	# Extract version from Open64, do not use -dumpversion, as this does not
+	# uniquely identify the Open64 compiler
+	opencc=`$CC -E -dM -x c /dev/null 2>/dev/null | sed -n -e 's/#define __OPENCC__ // p'`
+	AS_IF([test x"$opencc" != x"" ],
+	[
+		opencc_minor=`$CC -E -dM -x c /dev/null | sed -n -e 's/#define __OPENCC_MINOR__ // p'`
+		opencc_patchlevel=`$CC -E -dM -x c /dev/null | sed -n -e 's/#define __OPENCC_PATCHLEVEL__ // p'`
+		opencc_subpatchlevel=0
+		AS_CASE([$opencc_patchlevel],
+		[""],    [opencc_patchlevel=0],
+		[*.*],
+		[
+			opencc_subpatchlevel=${opencc_patchlevel##*.}
+			opencc_patchlevel=${opencc_patchlevel%.*}
+		])
+		opencc_version=`expr $opencc "*" 1000 + $opencc_minor "*" 100 + $opencc_patchlevel "*" 10 + $opencc_subpatchlevel`
+		AC_DEFINE_UNQUOTED([VT_OPENCC_VERSION], [$opencc_version], [Version of Open64 compiler as number.])
+		AS_UNSET([opencc_minor])
+		AS_UNSET([opencc_patchlevel])
+		AS_UNSET([opencc_subpatchlevel])
+		AS_UNSET([opencc_version])
+	])
+	AS_UNSET([opencc])
 ])
 

--- a/ompi/contrib/vt/vt/tools/vtfilter/vt_filter_config.h
+++ b/ompi/contrib/vt/vt/tools/vtfilter/vt_filter_config.h
@@ -31,17 +31,12 @@
 
   // using Open64 < v4.2.4 (causes "internal compiler error")
 # elif defined(__OPEN64__)
-#   if !defined(__OPENCC__) || !defined(__OPENCC_MINOR__) || !defined(__OPENCC_PATCHLEVEL__)
+#   if !defined(VT_OPENCC_VERSION)
       // unknown compiler version; disable OpenMP to be on the safe side
 #     undef HAVE_OMP
 #   else
-      // __OPENCC_PATCHLEVEL__ can be empty; redefine it to 0
-#     if !(__OPENCC_PATCHLEVEL__ + 0)
-#       undef __OPENCC_PATCHLEVEL__
-#       define __OPENCC_PATCHLEVEL__ 0
-#     endif
       // disable OpenMP, if compiler version is less than 4.2.4
-#     if __OPENCC__ < 4 || (__OPENCC__ == 4 && (__OPENCC_MINOR__ < 2 || (__OPENCC_MINOR__ == 2 && __OPENCC_PATCHLEVEL__ < 4)))
+#     if VT_OPENCC_VERSION < 4240
 #       undef HAVE_OMP
 #     endif
 #   endif

--- a/ompi/contrib/vt/vt/tools/vtunify/vt_unify_config.h
+++ b/ompi/contrib/vt/vt/tools/vtunify/vt_unify_config.h
@@ -39,17 +39,12 @@
 
    // using Open64 < v4.2.4 (causes "internal compiler error")
 #  elif defined(__OPEN64__)
-#     if !defined(__OPENCC__) || !defined(__OPENCC_MINOR__) || !defined(__OPENCC_PATCHLEVEL__)
+#     if !defined(VT_OPENCC_VERSION)
          // unknown compiler version; disable OpenMP to be on the safe side
 #        undef HAVE_OMP
 #     else
-         // __OPENCC_PATCHLEVEL__ can be empty; redefine it to 0
-#        if !(__OPENCC_PATCHLEVEL__ + 0)
-#           undef __OPENCC_PATCHLEVEL__
-#           define __OPENCC_PATCHLEVEL__ 0
-#        endif
          // disable OpenMP, if compiler version is less than 4.2.4
-#        if __OPENCC__ < 4 || (__OPENCC__ == 4 && (__OPENCC_MINOR__ < 2 || (__OPENCC_MINOR__ == 2 && __OPENCC_PATCHLEVEL__ < 4)))
+#        if VT_OPENCC_VERSION < 4240
 #           undef HAVE_OMP
 #        endif
 #     endif


### PR DESCRIPTION
The patchlevel used to be a single digit, but not with anymore. Use the
patchlevel in CPP expressions, only for version where we know the
patchlevel is still only one digit.

Reported by Paul H. Hargrove

Note, no master commit, as VampirTrace is already removed there.

@PHHargrove can you please verify this. Thanks.
