### PR TITLE
Check only the major and minor release numbers in the oob/tcp component ...

### DIFF
--- a/opal/mca/if/posix_ipv4/if_posix.c
+++ b/opal/mca/if/posix_ipv4/if_posix.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -19,6 +20,7 @@
 #include "opal/constants.h"
 #include "opal/util/output.h"
 #include "opal/mca/if/if.h"
+#include "opal/mca/if/base/base.h"
 
 static int if_posix_open(void);
 
@@ -148,6 +150,7 @@ static int if_posix_open(void)
     } while (ifc_len < MAX_IFCONF_SIZE);
     if (!successful_locate) {
         opal_output(0, "opal_ifinit: unable to find network interfaces.");
+        close(sd);
         return OPAL_ERR_FATAL;
     }
         
@@ -220,7 +223,10 @@ static int if_posix_open(void)
             
         /* every new address gets its own internal if_index */
         intf->if_index = opal_list_get_size(&opal_if_list)+1;
-            
+
+        opal_output_verbose(1, opal_if_base_framework.framework_output,
+                            "found interface %s", intf->if_name);
+        
         /* assign the kernel index to distinguish different NICs */
 #ifndef SIOCGIFINDEX
         intf->if_kernel_index = intf->if_index;

--- a/opal/runtime/opal_finalize.c
+++ b/opal/runtime/opal_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,11 +67,6 @@ opal_finalize_util(void)
     }
 
     /* close interfaces code. */
-    if (opal_if_base_framework.framework_refcnt > 1) {
-        /* opal if may have been opened many times -- FIXME */
-        opal_if_base_framework.framework_refcnt = 1;
-    }
-
     (void) mca_base_framework_close(&opal_if_base_framework);
 
     /* Clear out all the registered MCA params */

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -599,7 +599,6 @@ static bool component_available(void)
     /* set the module event base - this is where we would spin off a separate
      * progress thread if so desired */
     mca_oob_tcp_module.ev_base = orte_event_base;
-
     return true;
 }
 

--- a/orte/mca/oob/tcp/oob_tcp_connection.c
+++ b/orte/mca/oob/tcp/oob_tcp_connection.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -776,7 +776,10 @@ int mca_oob_tcp_peer_recv_connect_ack(mca_oob_tcp_peer_t* pr,
 
     /* check that this is from a matching version */
     version = (char*)(msg);
-    if (0 != strcmp(version, orte_version_string)) {
+    /* we are an even series, so only check that the
+     * caller matches us at the minor version level - i.e.,
+     * that the caller is also from the 1.8 series */
+    if (0 != strncmp(version, orte_version_string, 3)) {
         opal_output(0, "%s tcp_peer_recv_connect_ack: "
                     "received different version from %s: %s instead of %s\n",
                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),


### PR DESCRIPTION
...when making connections. This allows a stable series to accept connections from any other release within that stable series.

Stop an ugly infinite loop caused by continual re-opening of the opal if framework.

(cherry picked from commit open-mpi/ompi@9dbc69df0fe247719f33650fd020ec2488db98cf)

Thanks to Alan Wild for requesting it.
