### PR TITLE
ess/singleton: do not put component strings into the environment

### DIFF
--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -14,6 +15,8 @@
  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -130,8 +133,7 @@ static int rte_init(void)
         /* save the daemon uri - we will process it later */
         orte_process_info.my_daemon_uri = strdup(orte_process_info.my_hnp_uri);
         /* for convenience, push the pubsub version of this param into the environ */
-        asprintf(&param,"OMPI_MCA_pubsub_orte_server=%s",orte_process_info.my_hnp_uri);
-        putenv(param);
+        opal_setenv ("OMPI_MCA_pubsub_orte_server", orte_process_info.my_hnp_uri, 1, &environ);
     }
 
     /* indicate we are a singleton so orte_init knows what to do */
@@ -207,10 +209,10 @@ static int rte_init(void)
     orte_process_info.my_local_rank = 0;
 
     /* set some envars */
-    putenv("OMPI_NUM_APP_CTX=1");
-    putenv("OMPI_FIRST_RANKS=0");
-    putenv("OMPI_APP_CTX_NUM_PROCS=1");
-    putenv("OMPI_MCA_orte_ess_num_procs=1");
+    opal_setenv("OMPI_NUM_APP_CTX", "1", 1, &environ);
+    opal_setenv("OMPI_FIRST_RANKS", "0", 1, &environ);
+    opal_setenv("OMPI_APP_CTX_NUM_PROCS", "1", 1, &environ);
+    opal_setenv("OMPI_MCA_orte_ess_num_procs", "1", 1, &environ);
 
     /* push some useful info */
 
@@ -261,11 +263,11 @@ static int rte_finalize(void)
     }
 
     /* cleanup the environment */
-    unsetenv("OMPI_NUM_APP_CTX");
-    unsetenv("OMPI_FIRST_RANKS");
-    unsetenv("OMPI_APP_CTX_NUM_PROCS");
-    unsetenv("OMPI_MCA_orte_ess_num_procs");
-    unsetenv("OMPI_MCA_pubsub_orte_server");  // just in case it is there
+    opal_unsetenv("OMPI_NUM_APP_CTX", &environ);
+    opal_unsetenv("OMPI_FIRST_RANKS", &environ);
+    opal_unsetenv("OMPI_APP_CTX_NUM_PROCS", &environ);
+    opal_unsetenv("OMPI_MCA_orte_ess_num_procs", &environ);
+    opal_unsetenv("OMPI_MCA_pubsub_orte_server", &environ);  // just in case it is there
 
     return ret;
 }


### PR DESCRIPTION
putenv requires that any string put into the environment is not
changed or freed. That is not the case with constant strings as they
will go away when dlclose is called on the component. Instead, just
use opal_setenv which does not have this restriction.

master commit open-mpi/ompi@c416c423bb25a5f8fefd65cae4c4e4ca7f3e62c8

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

Conflicts:
    orte/mca/ess/singleton/ess_singleton_module.c
