### PR TITLE
Correct a typo that reversed the default binding pattern

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -516,13 +516,11 @@ int opal_hwloc_base_set_binding_policy(opal_binding_policy_t *policy, char *spec
     if (NULL == spec) {
         if (opal_hwloc_use_hwthreads_as_cpus) {
             /* default to bind-to hwthread */
-            OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_HWTHREAD);
+            OPAL_SET_DEFAULT_BINDING_POLICY(tmp, OPAL_BIND_TO_HWTHREAD);
         } else {
             /* default to bind-to core */
-            OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_CORE);
+            OPAL_SET_DEFAULT_BINDING_POLICY(tmp, OPAL_BIND_TO_CORE);
         }
-        /* note that no binding policy was specified */
-        tmp &= ~OPAL_BIND_GIVEN;
     } else if (0 == strncasecmp(spec, "none", strlen("none"))) {
         OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_NONE);
     } else {

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -242,14 +242,19 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
         } else {
             /* if nothing was specified, then we default to a policy
              * based on number of procs and cpus_per_rank */
-            if (2 <= nprocs) {
+            if (nprocs <= 2) {
                 if (1 < orte_rmaps_base.cpus_per_rank) {
                     /* assigning multiple cpus to a rank implies threading,
                      * so we only bind to the NUMA level */
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 } else {
-                    /* for performance, bind to core */
-                    OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
+                    if (opal_hwloc_use_hwthreads_as_cpus) {
+                        /* if we are using hwthread cpus, then bind to those */
+                        OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_HWTHREAD);
+                    } else {
+                        /* for performance, bind to core */
+                        OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
+                    }
                 }
             } else {
                 if (1 < orte_rmaps_base.cpus_per_rank) {


### PR DESCRIPTION
Ensure we default bind to hwthread if user specified --use-hwthread-cpus if nprocs <= 2, and bind to hwthread if told to do so.

(cherry picked from commit openmpi/ompi@033418f62a5a9d5f2970814db955e804ca191117)

Thanks to Bill Lane for reporting it

@jsquyres please review
