### PR TITLE
If we are using HT cpus and have <= 2 procs, then map-by hwthread by default

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -116,6 +116,10 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                         "mca:rmaps mapping not given - using byslot");
                     ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYSLOT);
+                } else if (opal_hwloc_use_hwthreads_as_cpus) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps mapping not given - using byhwthread");
+                    ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYHWTHREAD);
                 } else {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                         "mca:rmaps mapping not given - using bycore");
@@ -189,6 +193,10 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                         "mca:rmaps mapping not given - using byslot");
                     ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYSLOT);
+                } else if (opal_hwloc_use_hwthreads_as_cpus) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps mapping not given - using byhwthread");
+                    ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYHWTHREAD);
                 } else {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                         "mca:rmaps mapping not given - using bycore");


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@9c6d452d6b95a2aebffb23a7a7c8a985b60edd36)
