### PR TITLE
v1.8 osx clang warning fixes

### DIFF
--- a/ompi/mca/osc/base/osc_base_obj_convert.c
+++ b/ompi/mca/osc/base/osc_base_obj_convert.c
@@ -13,7 +13,8 @@
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -114,7 +115,7 @@ int ompi_osc_base_process_op (void *outbuf, void *inbuf, size_t inbuflen,
             iov_count = OMPI_OSC_BASE_DECODE_MAX;
             done = opal_convertor_raw (&convertor, iov, &iov_count, &size);
 
-            for (int i = 0 ; i < iov_count ; ++i) {
+            for (uint32_t i = 0 ; i < iov_count ; ++i) {
                 int primitive_count = iov[i].iov_len / primitive_size;
                 ompi_op_reduce (op, inbuf, iov[i].iov_base, primitive_count, primitive_datatype);
                 inbuf = (void *)((intptr_t) inbuf + iov[i].iov_len);

--- a/ompi/mca/osc/sm/osc_sm_passive_target.c
+++ b/ompi/mca/osc/sm/osc_sm_passive_target.c
@@ -151,18 +151,34 @@ ompi_osc_sm_unlock(int target,
     /* ensure all memory operations have completed */
     opal_atomic_mb();
 
-    if (lock_none == module->outstanding_locks[target]) {
+    switch (module->outstanding_locks[target]) {
+    case lock_none:
         return OMPI_ERR_RMA_SYNC;
-    }
 
-    if (module->outstanding_locks[target] == lock_nocheck) {
+    case lock_nocheck:
         ret = OMPI_SUCCESS;
-    } else if (module->outstanding_locks[target] == lock_exclusive) {
+        break;
+
+    case lock_exclusive:
         ret = end_exclusive(module, target);
-    } else if (module->outstanding_locks[target] == lock_shared) {
+        break;
+
+    case lock_shared:
         ret = end_shared(module, target);
-    } else {
-        ret = OMPI_SUCCESS;
+        break;
+
+    default:
+        // This is an OMPI programming error -- cause some pain.
+        assert(module->outstanding_locks[target] == lock_none ||
+               module->outstanding_locks[target] == lock_nocheck ||
+               module->outstanding_locks[target] == lock_exclusive ||
+               module->outstanding_locks[target] == lock_shared);
+
+         // In non-developer builds, assert() will be a no-op, so
+         // ensure the error gets reported
+        opal_output(0, "Unknown lock type in ompi_osc_sm_unlock -- this is an OMPI programming error");
+        ret = OMPI_ERR_BAD_PARAM;
+        break;
     }
 
     module->outstanding_locks[target] = lock_none;

--- a/ompi/mca/osc/sm/osc_sm_passive_target.c
+++ b/ompi/mca/osc/sm/osc_sm_passive_target.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2011      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -160,6 +161,8 @@ ompi_osc_sm_unlock(int target,
         ret = end_exclusive(module, target);
     } else if (module->outstanding_locks[target] == lock_shared) {
         ret = end_shared(module, target);
+    } else {
+        ret = OMPI_SUCCESS;
     }
 
     module->outstanding_locks[target] = lock_none;

--- a/opal/mca/base/mca_base_param.c
+++ b/opal/mca/base/mca_base_param.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -580,7 +580,15 @@ int mca_base_param_dump(opal_list_t **info, bool internal)
                     q->mbpp_deprecated = !!(syn->mbv_flags & MCA_BASE_VAR_FLAG_DEPRECATED);
                     q->mbpp_internal = !!(syn->mbv_flags & MCA_BASE_VAR_FLAG_INTERNAL);
                     q->mbpp_read_only = !!(syn->mbv_flags & MCA_BASE_VAR_FLAG_DEFAULT_ONLY);
-                    q->mbpp_type = syn->mbv_type;
+                    if (var->mbv_type == MCA_BASE_VAR_TYPE_INT ||
+                        var->mbv_type == MCA_BASE_VAR_TYPE_UNSIGNED_INT ||
+                        var->mbv_type == MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG ||
+                        var->mbv_type == MCA_BASE_VAR_TYPE_SIZE_T ||
+                        var->mbv_type == MCA_BASE_VAR_TYPE_BOOL) {
+                        q->mbpp_type = MCA_BASE_PARAM_TYPE_INT;
+                    } else {
+                        q->mbpp_type = MCA_BASE_PARAM_TYPE_STRING;
+                    }
                     q->mbpp_help_msg = syn->mbv_description;
 
                     /* Let this one point to the original */

--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved. 
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -75,7 +75,6 @@ orte_ess_base_module_t orte_ess_singleton_module = {
 static int rte_init(void)
 {
     int rc;
-    char *param;
     uint16_t jobfam;
     uint32_t hash32;
     uint32_t bias;


### PR DESCRIPTION
Minor compiler fixes for the v1.8 tree (noticed when compiling on OS X with clang).

2 commits are from master, 2 commits are unique to v1.8:
- open-mpi/ompi@692c093: fix from master for loop in osc base
- open-mpi/ompi@d9f97ad: fix from master to ensure ret is always defined
- open-mpi/ompi@49f52a535: better fix from master to ensure ret is always defined
- 2106d4d: remove a dead variable here on v1.8 (it's used in master, but not here)
- 2b2a9e1: convert enum properly (based on feedback from @hjelmn).  This code is not on master -- it's a shim to allow v1.8 code to use the old MCA param system.

@rhc54 and @hjelmn please review.  Pretty trivial.
