### PR TITLE
Bring relevant fixes from master

### DIFF
--- a/ompi/mca/btl/vader/btl_vader_component.c
+++ b/ompi/mca/btl/vader/btl_vader_component.c
@@ -214,6 +214,7 @@ static int mca_btl_vader_component_register (void)
                                            "single_copy_mechanism", "Single copy mechanism to use (defaults to best available)",
                                            MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_GROUP, &mca_btl_vader_component.single_copy_mechanism);
+    OBJ_RELEASE(new_enum);
 
 #if OMPI_BTL_VADER_HAVE_KNEM
     /* Currently disabling DMA mode by default; it's not clear that this is useful in all applications and architectures. */

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -37,6 +37,15 @@ int MPI_T_finalize (void)
 
     if (0 == --mpit_init_count) {
         (void) ompi_info_close_components ();
+
+        if ((!ompi_mpi_initialized || ompi_mpi_finalized) &&
+            (NULL != ompi_mpi_main_thread)) {
+            /* we are not between MPI_Init and MPI_Finalize so we
+             * have to free the ompi_mpi_main_thread */
+            OBJ_RELEASE(ompi_mpi_main_thread);
+            ompi_mpi_main_thread = NULL;
+        }
+
         (void) opal_finalize_util ();
     }
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2006-2013 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * Copyright (c) 2006-2009 University of Houston. All rights reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
@@ -346,7 +347,10 @@ void ompi_mpi_thread_level(int requested, int *provided)
             ompi_mpi_thread_provided = *provided = requested;
         }
     }
-    ompi_mpi_main_thread = opal_thread_get_self();
+
+    if (!ompi_mpi_main_thread) {
+        ompi_mpi_main_thread = opal_thread_get_self();
+    }
 
     ompi_mpi_thread_multiple = (ompi_mpi_thread_provided == 
                                 MPI_THREAD_MULTIPLE);

--- a/opal/mca/installdirs/base/installdirs_base_components.c
+++ b/opal/mca/installdirs/base/installdirs_base_components.c
@@ -165,6 +165,7 @@ opal_installdirs_base_close(void)
     free(opal_install_dirs.ompidatadir);
     free(opal_install_dirs.ompilibdir);
     free(opal_install_dirs.ompiincludedir);
+    memset (&opal_install_dirs, 0, sizeof (opal_install_dirs));
 
     return mca_base_framework_components_close (&opal_installdirs_base_framework, NULL);
 }

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -284,11 +284,6 @@ opal_init_util(int* pargc, char*** pargv)
         goto return_error;
     }
 
-    if (OPAL_SUCCESS != (ret = opal_net_init())) {
-        error = "opal_net_init";
-        goto return_error;
-    }
-
     /* Setup the parameter system */
     if (OPAL_SUCCESS != (ret = mca_base_param_init())) {
         error = "mca_base_param_init";
@@ -298,6 +293,11 @@ opal_init_util(int* pargc, char*** pargv)
     /* register params for opal */
     if (OPAL_SUCCESS != (ret = opal_register_params())) {
         error = "opal_register_params";
+        goto return_error;
+    }
+
+    if (OPAL_SUCCESS != (ret = opal_net_init())) {
+        error = "opal_net_init";
         goto return_error;
     }
 


### PR DESCRIPTION
open-mpi/ompi@a7b0c00ab6d5160d345949da91da56ae2468294a

fix memory leaks and valgrind errors

This commit fixes several vagrind errors. Included:
- installdirs did not correctly reinitialize all pointers to NULL
  at close. This causes valgrind errors on a subsequent call to
  opal_init_tool.
- move opal_net_init to AFTER the variable system is initialized and
  opal's MCA variables have been registered. opal_net_init uses a
  variable registered by opal_register_params!
- do not leak ompi_mpi_main_thread when it is allocated by
  MPI_T_init_thread.
- do not overwrite ompi_mpi_main_thread if it is already set (by
  MPI_T_init_thread).
- mca_base_var: read_files was overwritting mca_base_var_file_list
  even if it was non-NULL.
- btl/vader: decrement enumerator reference count to ensure that it
  is freed.

master commit open-mpi/ompi@a7b0c00ab6d5160d345949da91da56ae2468294a

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
