### PR TITLE
btl/vader: fix deadlock in mca_btl_vader_progress_endpoints

### DIFF
--- a/ompi/mca/btl/vader/btl_vader_component.c
+++ b/ompi/mca/btl/vader/btl_vader_component.c
@@ -675,7 +675,7 @@ static void mca_btl_vader_progress_endpoints (void)
     for (int i = 0 ; i < count ; ++i) {
         mca_btl_vader_progress_waiting ((mca_btl_base_endpoint_t *) opal_list_remove_first (&mca_btl_vader_component.pending_endpoints));
     }
-    OPAL_THREAD_LOCK(&mca_btl_vader_component.lock);
+    OPAL_THREAD_UNLOCK(&mca_btl_vader_component.lock);
 }
 
 static int mca_btl_vader_component_progress (void)


### PR DESCRIPTION
This commit fixes a typo in mca_btl_vader_progress_endpoints where
OPAL_THREAD_LOCK was used when OPAL_THREAD_UNLOCK was intended.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
