### PR TITLE
fix opal config subdir

### DIFF
--- a/config/ompi_config_subdir.m4
+++ b/config/ompi_config_subdir.m4
@@ -19,6 +19,7 @@ dnl $HEADER$
 dnl
 
 AC_DEFUN([OMPI_CONFIG_SUBDIR],[
+OPAL_VAR_SCOPE_PUSH([subdir_parent sub_configure subdir_dir subdir_srcdir subdir_cache_file unset subdir_args subdir_dots total_dir dir_part temp])
 #
 # Invoke configure in a specific subdirectory.
 #
@@ -143,5 +144,4 @@ fi
 # Clean up
 #
 
-unset subdir_parent sub_configure subdir_dir subdir_srcdir subdir_cache_file
-unset subdir_args subdir_dots total_dir dir_part temp])dnl
+OPAL_VAR_SCOPE_POP])dnl

--- a/config/ompi_config_subdir.m4
+++ b/config/ompi_config_subdir.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl 
 dnl Additional copyrights may follow
@@ -108,16 +108,6 @@ if test "$subdir_dir" != ":" -a -d $srcdir/$subdir_dir; then
     # Construct the --cache-file argument
     #
 
-dnl    case $cache_file in
-dnl    [[\\/]* | ?:[\\/]*] )
-dnl	# Absolute path
-dnl	subdir_cache_file="$cache_file"
-dnl	;;
-dnl    *)
-dnl	# Relative path
-dnl        subdir_cache_file="$subdir_dots$cache_file"
-dnl	;;
-dnl    esac
     # BWB - subdir caching is a pain since we change CFLAGS and all that.  
     # Just disable it for now
     subdir_cache_file="/dev/null"

--- a/config/ompi_config_subdir.m4
+++ b/config/ompi_config_subdir.m4
@@ -117,10 +117,6 @@ if test "$subdir_dir" != ":" -a -d $srcdir/$subdir_dir; then
     # Invoke the configure script in the subdirectory
     #
 
-    export CFLAGS CPPFLAGS
-    export CXXFLAGS CXXCPPFLAGS
-    export FCFLAGS
-    export LDFLAGS LIBS
     sub_configure="$SHELL '$subdir_srcdir/configure'"
     AC_MSG_NOTICE([running $sub_configure $subdir_args --cache-file=$subdir_cache_file --srcdir=$subdir_srcdir --disable-option-checking])
     eval "$sub_configure $subdir_args \

--- a/config/ompi_config_subdir_args.m4
+++ b/config/ompi_config_subdir_args.m4
@@ -18,6 +18,7 @@ dnl $HEADER$
 dnl
 
 AC_DEFUN([OMPI_CONFIG_SUBDIR_ARGS],[
+OPAL_VAR_SCOPE_PUSH([subdirs_str subdirs_skip subdirs_args subdirs_arg])
 #
 # Invoke configure in subdirectories.
 #
@@ -74,4 +75,4 @@ eval "$subdirs_str"
 # Clean up
 #
 
-unset subdirs_str subdirs_skip subdirs_args subdirs_arg])dnl
+OPAL_VAR_SCOPE_POP])dnl

--- a/ompi/contrib/vt/configure.m4
+++ b/ompi/contrib/vt/configure.m4
@@ -132,7 +132,9 @@ AC_DEFUN([OMPI_contrib_vt_CONFIG],[
             esac
         done
 
-        contrib_vt_args="$contrib_vt_args $with_contrib_vt_flags"
+        # Must also pass down CPPFLAGS/LDFLAGS so that VT's MPI
+        # applications can find mpi.h and -lmpi.
+        contrib_vt_args="$contrib_vt_args CPPFLAGS=-I$OMPI_TOP_SRCDIR/ompi/include LDFLAGS=-L$OMPI_TOP_BUILDDIR/ompi/.libs $with_contrib_vt_flags"
 
         # Run VampirTrace's configure and see if it succeeded
         OMPI_CONFIG_SUBDIR([ompi/contrib/vt/vt],


### PR DESCRIPTION
Fix the problem identified in open-mpi/ompi#471: don't let an external hwloc config taint the LDFLAGS/LIBS passed down to a sub configure script.

Technically, we really only need the 3rd commit to fix the bug (do not export the vars); I brought over the other 2 because they're general code cleanup that I did on master at the same time as fixing this bug.

@rhc54 @eschnett
