### PR TITLE
man pages: fix problem with MPI_Win_lock_all

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -127,6 +127,8 @@ included in the vX.Y.Z section and be denoted as:
     noticing and sending a patch.
   - Updated configure paths in HACKING.  Thanks to Maximilien Levesque
     for the fix.
+  - Fixed Fortran typo in MPI_WIN_LOCK_ALL.  Thanks to Thomas Jahns
+    for pointing out the issue.
 - Fixed a number of MPI one-sided bugs.
 - Fixed MPI_COMM_SPAWN when invoked from a singleton job.
 - Fixed a number of minor issues with CUDA support, including

--- a/ompi/mpi/man/man3/MPI_Win_lock_all.3in
+++ b/ompi/mpi/man/man3/MPI_Win_lock_all.3in
@@ -19,7 +19,7 @@ int MPI_Win_lock_all(int \fIassert\fP, MPI_Win \fIwin\fP)
 .SH Fortran Syntax
 .nf
 INCLUDE 'mpif.h'
-MPI_WIN_LOCK(\fIASSERT, WIN, IERROR\fP)
+MPI_WIN_LOCK_ALL(\fIASSERT, WIN, IERROR\fP)
 	INTEGER \fIASSERT, WIN, IERROR\fP
 
 .fi


### PR DESCRIPTION
Trivial man page fix.

Thanks to Thomas Jahns for pointing this out: http://www.open-mpi.org/community/lists/users/2015/04/26633.php

Signed-off-by: Howard Pritchard howardp@lanl.gov

(cherry picked from commit open-mpi/ompi@291c775e74bd5afe4f7f1f8df65dd1b8d3a22c63)

Reviewed by @jsquyres
