### PR TITLE
ompi/java: better error message if dlopen fails

### DIFF
--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -116,7 +116,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
     if(libmpi == NULL)
     {
-        fprintf(stderr, "Java bindings failed to load liboshmem.\n");
+        fprintf(stderr, "Java bindings failed to load libmpi: %s\n",dlerror());
         exit(1);
     }
 


### PR DESCRIPTION
The error message emitted by ompi/java when dlopen fails is misleading and not very informative.

Signed-off-by: Howard Pritchard howardp@lanl.gov

(cherry picked from commit open-mpi/ompi@18039b34b48345a4bc7e23ec0a1618a21394f04f)

@rhc54 I don't know if you want to take this so late in the process or not, but it's pretty harmless: it just changes the contents of an fprintf() error message.  Feel free to defer to v1.8.6 if you want.

@hppritcha Your fix was never PR'ed to the v1.8 branch, so I figured I'd do it for you. :-)
