### PR TITLE
HCOLL/OSHMEM fixes

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -189,7 +189,7 @@ static int hcoll_register(void)
 
     CHECK(reg_int("enable",NULL,
                   "[1|0|] Enable/Disable HCOL",
-                  0 /*disable by default*/,
+                  1,
                   &mca_coll_hcoll_component.hcoll_enable,
                   0));
 

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -18,6 +18,11 @@ int hcoll_comm_attr_keyval;
  */
 int mca_coll_hcoll_init_query(bool enable_progress_threads, bool enable_mpi_threads)
 {
+
+    if (enable_mpi_threads) {
+        HCOL_VERBOSE(1, "MPI_THREAD_MULTIPLE not suppported; skipping hcoll component");
+        return OMPI_ERROR;
+    }
     return OMPI_SUCCESS;
 }
 

--- a/oshmem/mca/scoll/mpi/scoll_mpi_component.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_component.c
@@ -56,7 +56,7 @@ mca_scoll_mpi_component_t mca_scoll_mpi_component = {
     },
     77, /* priority */
     0,  /* verbose level */
-    0,   /* mpi_enable */
+    1,   /* mpi_enable */
     2   /*mpi_np */
 };
 


### PR DESCRIPTION
- -Enable HCOLL by default if it is configured

https://github.com/open-mpi/ompi/commit/dd8e9fa17600d18e22d12e59772193996c29a9da
- -Enable MPI collectives from OSHMEM

https://github.com/open-mpi/ompi/commit/3dbd95fa73b5859873479d52851941c709f96f24
- \- FIx HCOLL with thread multiple

https://github.com/open-mpi/ompi/commit/19f5a3eff4164d12fcefaa2bd112c67049b8708d
