### PR TITLE
timer_linux_component.c: fix the operator precedence

### DIFF
--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -9,6 +9,11 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -109,7 +114,7 @@ opal_timer_linux_open(void)
             ret = sscanf(loc, "%f", &cpu_f);
             if (1 == ret) {
                 /* numer is in MHz - convert to Hz and make an integer */
-                opal_timer_linux_freq = (opal_timer_t) cpu_f * 1000000;
+                opal_timer_linux_freq = (opal_timer_t) (cpu_f * 1000000);
             }
         }
     }


### PR DESCRIPTION
@PHHargrove noted in http://www.open-mpi.org/community/lists/devel/2015/04/17312.php that we need () to ensure that we get the correct mathemtical result.

(cherry picked from commit open-mpi/ompi@46aa20a9191db2f5cc1850c0f4f881ac51653cb4)
