### PR TITLE
Reduce confusion by having the devel-map display in the same format as report-bindings

### DIFF
--- a/orte/runtime/data_type_support/orte_dt_print_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_print_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013      Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -491,25 +491,24 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
     
 #if OPAL_HAVE_HWLOC
     {
-        char *locale=NULL;
-        char *bind = NULL;
+        char locale[1024], bind[1024];
 
         if (NULL != src->locale) {
-            hwloc_bitmap_list_asprintf(&locale, src->locale->cpuset);
+            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(locale, sizeof(locale), src->node->topology, src->locale->cpuset)) {
+                strcpy(locale, "UNKNOWN");
+            }
+        } else {
+            strcpy(locale, "UNKNOWN");
         }
         if (NULL != src->bind_location) {
-            hwloc_bitmap_list_asprintf(&bind, src->bind_location->cpuset);
+            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(bind, sizeof(bind), src->node->topology, src->bind_location->cpuset)) {
+                strcpy(bind, "UNBOUND");
+            }
+        } else {
+            strcpy(bind, "UNBOUND");
         }
-        asprintf(&tmp2, "%s\n%s\tState: %s\tRestarts: %d\tApp_context: %ld\tLocale: %s\tBind location: %s\tBinding: %s", tmp, pfx2,
-                 orte_proc_state_to_str(src->state), src->restarts, (long)src->app_idx,
-                 (NULL == locale) ? "UNKNOWN" : locale, bind,
-                 (NULL == src->cpu_bitmap) ? "NULL" : src->cpu_bitmap);
-        if (NULL != locale) {
-            free(locale);
-        }
-        if (NULL != bind) {
-            free(bind);
-        }
+        asprintf(&tmp2, "%s\n%s\tState: %s\tApp_context: %ld\n%s\tLocale: %s\n%s\tBinding: %s", tmp, pfx2,
+                 orte_proc_state_to_str(src->state), (long)src->app_idx, pfx2, locale, pfx2, bind);
     }
 #else
     asprintf(&tmp2, "%s\n%s\tState: %s\tRestarts: %d\tApp_context: %ld", tmp, pfx2,


### PR DESCRIPTION
@jsquyres please take a quick gander

(cherry picked from commit open-mpi/ompi@58e646ccfd44d7e0a9913352f02ed988c453126e)
