### PR TITLE
osc/rdma: fix bugs that caused incorrect fragment counting

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -161,8 +161,8 @@ struct ompi_osc_rdma_module_t {
        received. */
     uint64_t flush_ack_received_count;
 
-    /** True if the access epoch is a passive target access epoch */
-    bool passive_target_access_epoch;
+    /** Number of targets locked/being locked */
+    unsigned int passive_target_access_epoch;
 
     /** start sending data eagerly */
     bool active_eager_send_active;


### PR DESCRIPTION
This commit fixes a bug identified by MTT that occurred when mixing
passive and active target synchronization. The bugs fixed in this
commit are:
- Do not update incoming fragment counts for any type of unbuffered
  control message. These messages are out-of-band and should not be
  considered towards the signal counts.
- Ensure that we always wake up when lock, unlock, and flush acks are
  recieved.
- Turn the passive_target_access_epoch module member into a
  counter. As long as at least one peer is locked we are in a
  passive-target epoch and not an active target one. This fix will
  ensure that fragment flags are set appropriately.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
