### PR TITLE
opal_config_asm.m4: enable inline assembly on little endian POWER

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -9,7 +9,7 @@ dnl Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 dnl $COPYRIGHT$
 dnl 
@@ -855,7 +855,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
             OMPI_GCC_INLINE_ASSIGN='"or %0,[$]0,[$]0" : "=&r"(ret)'
             ;;
 
-        powerpc-*|powerpc64-*|rs6000-*|ppc-*)
+        powerpc-*|powerpc64-*|powerpcle-*|powerpc64le-*|rs6000-*|ppc-*)
             OMPI_CHECK_POWERPC_REG
             if test "$ac_cv_sizeof_long" = "4" ; then
                 ompi_cv_asm_arch="POWERPC32"


### PR DESCRIPTION
Suggested by Paul Hargrove,
http://www.open-mpi.org/community/lists/devel/2015/04/17323.php,
amended by Nysal Jan for 32 bit, too.
