### PR TITLE
First part of compiler warning fixes

### DIFF
--- a/ompi/mca/bcol/ptpcoll/bcol_ptpcoll_allreduce.c
+++ b/ompi/mca/bcol/ptpcoll/bcol_ptpcoll_allreduce.c
@@ -232,10 +232,12 @@ int bcol_ptpcoll_allreduce_narraying_init(bcol_function_args_t *input_args,
     mca_bcol_ptpcoll_module_t *ptpcoll_module = (mca_bcol_ptpcoll_module_t *)const_args->bcol_module;
     uint64_t sequence_number = input_args->sequence_num;
     uint32_t buffer_index = input_args->buffer_index;
-    int count = input_args->count;
-    struct ompi_datatype_t *dtype = input_args->dtype;
     size_t buffer_size;
     int tag;
+#if OPAL_ENABLE_DEBUG
+    int count = input_args->count;
+    struct ompi_datatype_t *dtype = input_args->dtype;
+#endif
 
     tag = (PTPCOLL_TAG_OFFSET + sequence_number * PTPCOLL_TAG_FACTOR) & (ptpcoll_module->tag_mask);
     ptpcoll_module->ml_mem.ml_buf_desc[buffer_index].tag = tag = -tag;

--- a/ompi/mca/btl/openib/btl_openib_component.c
+++ b/ompi/mca/btl/openib/btl_openib_component.c
@@ -1497,6 +1497,9 @@ static uint64_t calculate_max_reg (const char *device_name)
         return (max_reg * 7) >> 3;
     }
 
+    /* Default to being able to register everything (to ensure that
+       max_reg is initialized in all cases) */
+    max_reg = mem_total;
     if (!strncmp(device_name, "mlx5", 4)) {
         max_reg = 2 * mem_total;
 

--- a/ompi/mca/btl/tcp/btl_tcp_frag.c
+++ b/ompi/mca/btl/tcp/btl_tcp_frag.c
@@ -105,12 +105,12 @@ size_t mca_btl_tcp_frag_dump(mca_btl_tcp_frag_t* frag, char* msg, char* buf, siz
 
     used = snprintf(buf, length, "%s frag %p iov_cnt %d iov_idx %d size %lu\n",
                     msg, (void*)frag, (int)frag->iov_cnt, (int)frag->iov_idx, frag->size);
-    if (used >= length) return length;
+    if ((size_t)used >= length) return length;
     for( i = 0; i < (int)frag->iov_cnt; i++ ) {
         used += snprintf(&buf[used], length - used, "[%s%p:%lu] ",
                          (i < (int)frag->iov_idx ? "*" : ""),
                          frag->iov[i].iov_base, frag->iov[i].iov_len);
-        if (used >= length) return length;
+        if ((size_t)used >= length) return length;
     }
     return used;
 }

--- a/ompi/mca/osc/rdma/osc_rdma_data_move.c
+++ b/ompi/mca/osc/rdma/osc_rdma_data_move.c
@@ -1640,8 +1640,10 @@ static int ompi_osc_rdma_callback (ompi_request_t *request)
     ompi_osc_rdma_module_t *module = (ompi_osc_rdma_module_t *) request->req_complete_cb_data;
     ompi_osc_rdma_header_base_t *base_header = 
         (ompi_osc_rdma_header_base_t *) module->incoming_buffer;
-    size_t incoming_length = request->req_status._ucount;
     int source = request->req_status.MPI_SOURCE;
+#if OPAL_ENABLE_DEBUG
+    size_t incoming_length = request->req_status._ucount;
+#endif
 
     OPAL_THREAD_UNLOCK(&ompi_request_lock);
 

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/gratuitious-symbol.c
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/gratuitious-symbol.c
@@ -6,6 +6,10 @@
  * $HEADER$
  */
 
+/* Declare the function below so that compilers don't complain about
+   the lack of prototype. */
+int ompi_mpi_ignore_tkr_module_abi_symbol(void);
+
 /*
  * This function is located in libmpi_usempi_ignore_tkr.la.
  *

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/usempi-dummy.c
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/usempi-dummy.c
@@ -6,6 +6,10 @@
  * $HEADER$
  */
 
+/* Declare the function below so that compilers don't complain about
+   the lack of prototype. */
+int ompi_mpi_tkr_module_abi_symbol(void);
+
 /*
  * This function is located in the dummy library libmpi_usempi.la.
  *

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -372,7 +372,7 @@ static int oshmem_mkey_recv_cb(void)
     n = 0;
     r = (oob_comm_request_t *)opal_list_get_first(&memheap_oob.req_list);
     assert(r);
-    while(r != opal_list_get_end(&memheap_oob.req_list)) {
+    while(r != (oob_comm_request_t*) opal_list_get_end(&memheap_oob.req_list)) {
         my_MPI_Test(&r->recv_req, &flag, &status);
         if (OPAL_LIKELY(0 == flag)) {
             return n;


### PR DESCRIPTION
Here's a few fixes.  Based on Ralph's comments, I think I need to compile differently to enable more of the warnings.  Waiting on @rhc54 to provide some guidance on how to generate those additional warnings.

So there will likely be more added to this PR.
