### PR TITLE
Sync opal_path_nfs test with master

### DIFF
--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -159,7 +159,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
         }
 
         /* If we can not stat the fs, skip it */
-        if (statfs (dirs_tmp[i], statfs)) {
+        if (statfs (dirs_tmp[i], &statfs)) {
             continue;
         }
 

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -31,9 +31,7 @@
 #include "opal/util/path.h"
 #include "opal/util/output.h"
 
-/*
 #define DEBUG
-*/
 
 #if !defined(__linux__)
 /* This test currently only works on Linux */

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -32,12 +32,6 @@
 
 #include <sys/param.h>
 #include <sys/mount.h>
-#ifdef HAVE_SYS_STATFS_H
-#include <sys/statfs.h>
-#endif
-#ifdef HAVE_SYS_VFS_H
-#include <sys/vfs.h>
-#endif
 
 #include "support.h"
 #include "opal/util/path.h"
@@ -116,7 +110,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
     char ** dirs_tmp;
     bool * nfs_tmp;
     char buffer[SIZE];
-    struct statfs statfs;
+    struct statfs mystatfs;
 
     rc = system (cmd);
 
@@ -165,7 +159,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
         }
 
         /* If we can not stat the fs, skip it */
-        if (statfs (dirs_tmp[i], &statfs)) {
+        if (statfs (dirs_tmp[i], &mystatfs)) {
             continue;
         }
 

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -32,6 +32,12 @@
 
 #include <sys/param.h>
 #include <sys/mount.h>
+#ifdef HAVE_SYS_STATFS_H
+#include <sys/statfs.h>
+#endif
+#ifdef HAVE_SYS_VFS_H
+#include <sys/vfs.h>
+#endif
 
 #include "support.h"
 #include "opal/util/path.h"

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -26,6 +29,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <dirent.h>
+
+#include <sys/param.h>
+#include <sys/mount.h>
 
 #include "support.h"
 #include "opal/util/path.h"
@@ -104,6 +110,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
     char ** dirs_tmp;
     bool * nfs_tmp;
     char buffer[SIZE];
+    struct statfs statfs;
 
     rc = system (cmd);
 
@@ -112,7 +119,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
         **dirs = NULL;
         *nfs = NULL;
     }
-    dirs_tmp = (char**) malloc (MAX_DIR * sizeof(char**));
+    dirs_tmp = (char**) calloc (MAX_DIR, sizeof(char**));
     nfs_tmp = (bool*) malloc (MAX_DIR * sizeof(bool));
 
     file = fopen("opal_path_nfs.out", "r");
@@ -122,7 +129,10 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
         int mount_known;
         char fs[MAXNAMLEN];
 
-        dirs_tmp[i] = malloc (MAXNAMLEN);
+        if (!dirs_tmp[i]) {
+            dirs_tmp[i] = malloc (MAXNAMLEN);
+        }
+
         if (2 != (rc = sscanf (buffer, "%s %s\n", dirs_tmp[i], fs))) {
             goto out;
         }
@@ -145,6 +155,11 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
         /* If we get an fs type of "none", skip it (e.g.,
            http://www.open-mpi.org/community/lists/devel/2012/09/11493.php) */
         if (0 == strcasecmp(fs, "none")) {
+            continue;
+        }
+
+        /* If we can not stat the fs, skip it */
+        if (statfs (dirs_tmp[i], statfs)) {
             continue;
         }
 


### PR DESCRIPTION
This PR syncs opal_path_nfs.c test with the commits that have occurred on master, but were never brought over to v1.8.  This enables v1.8 "make check" to pass on my systems:

Here's the commits taken from master:
- open-mpi/ompi@9b18b4b2d2cf1e9989a1ef516a7b5494b6394992 
- open-mpi/ompi@0fc8777aa87671cfbcbcca882b54a9ac12c29b22
- open-mpi/ompi@23d59b0f5d9efe4f46f4ed816ef9a2620799dcc5 
- open-mpi/ompi@aff1f0ee49f0bcb8b8f8b1ba42ddcf626eb5d476 
- open-mpi/ompi@4a0b4ad5efd758791822561bf7ba43d56a1d5ca1 
- open-mpi/ompi@595740a8e3dc6d780021903366ac048989ef27c9
