### PR TITLE
Datatype fixes

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -468,11 +470,12 @@ static inline int __ompi_datatype_pack_description( ompi_datatype_t* datatype,
     position = (int*)next_packed;
     next_packed += sizeof(int) * args->cd;
 
-    /* description of next datatype should be 64 bits aligned */
-    OMPI_DATATYPE_ALIGN_PTR(next_packed, char*);
     /* copy the aray of counts (32 bits aligned) */
     memcpy( next_packed, args->i, sizeof(int) * args->ci );
     next_packed += args->ci * sizeof(int);
+
+    /* description of next datatype should be 64 bits aligned */
+    OMPI_DATATYPE_ALIGN_PTR(next_packed, char*);
 
     /* copy the rest of the data */
     for( i = 0; i < args->cd; i++ ) {

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -579,8 +579,11 @@ static ompi_datatype_t* __ompi_datatype_create_from_packed_description( void** p
                                                    number_of_datatype );
     next_buffer += (4 * sizeof(int));  /* move after the header */
 
-    /* The pointer should always be aligned on MPI_Aint, aka OPAL_PTRDIFF_TYPE */
-    OMPI_DATATYPE_ALIGN_PTR(next_buffer, char*);
+    /* description of the displacements (if ANY !)  should always be aligned
+       on MPI_Aint, aka OPAL_PTRDIFF_TYPE */
+    if (number_of_disp > 0) {
+        OMPI_DATATYPE_ALIGN_PTR(next_buffer, char*);
+    }
 
     array_of_disp   = (OPAL_PTRDIFF_TYPE*)next_buffer;
     next_buffer    += number_of_disp * sizeof(OPAL_PTRDIFF_TYPE);

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -238,15 +238,6 @@ int32_t ompi_datatype_set_args( ompi_datatype_t* pData,
              */
             OBJ_RETAIN( d[pos] );
             pArgs->total_pack_size += ((ompi_datatype_args_t*)d[pos]->args)->total_pack_size;
-#if OPAL_ALIGN_WORD_SIZE_INTEGERS
-            /*
-             * as total_pack_size is always aligned to
-             * MPI_Aint (aka OPAL_PTRDIFF_TYPE) size their sum
-             * will be aligned to ...
-             */
-            assert( pArgs->total_pack_size ==
-                    OPAL_ALIGN(pArgs->total_pack_size, sizeof(OPAL_PTRDIFF_TYPE), int) );
-#endif  /* OPAL_ALIGN_WORD_SIZE_INTEGERS */
         } else {
             pArgs->total_pack_size += 2 * sizeof(int);  /* _NAMED + predefined id */
         }

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -718,7 +718,7 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         ompi_datatype_create_indexed_block( i[0], i[1], &(i[2]), d[0], &datatype );
         {
             const int* a_i[3] = {&i[0], &i[1], &i[2]};
-            ompi_datatype_set_args( datatype, 2 * i[0], a_i, 0, NULL, 1, d, MPI_COMBINER_INDEXED_BLOCK );
+            ompi_datatype_set_args( datatype, i[0] + 2, a_i, 0, NULL, 1, d, MPI_COMBINER_INDEXED_BLOCK );
         }
         break;
         /******************************************************************/

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -12,7 +12,7 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_pack
     MPI_CHECKS = to_self ddt_pack
 endif
 TESTS = opal_datatype_test $(MPI_TESTS)

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2004-2009 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 # $COPYRIGHT$
 # 
@@ -12,7 +12,7 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_pack
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw
     MPI_CHECKS = to_self ddt_pack
 endif
 TESTS = opal_datatype_test $(MPI_TESTS)

--- a/test/datatype/ddt_pack.c
+++ b/test/datatype/ddt_pack.c
@@ -111,9 +111,6 @@ main(int argc, char* argv[])
 
     memcpy(payload, packed_ddt, packed_ddt_len);
 
-    ret = MPI_Type_free(&struct_type);
-    if (ret != 0) goto cleanup;
-
     unpacked_dt = ompi_datatype_create_from_packed_description(&payload, ompi_proc_local());
     free(ptr);
     if (unpacked_dt == NULL) {
@@ -132,6 +129,9 @@ main(int argc, char* argv[])
         }
         printf("\tPASSED\n");
     }
+    ret = MPI_Type_free(&struct_type);
+    if (ret != 0) goto cleanup;
+
     ret = MPI_Type_free(&unpacked_dt);
     if (ret != 0) goto cleanup;
 
@@ -158,8 +158,6 @@ main(int argc, char* argv[])
     if (ret != 0) goto cleanup;
 
     memcpy(payload, packed_ddt, packed_ddt_len);
-    ret = MPI_Type_free(&vec_type);
-    if (ret != 0) goto cleanup;
 
     unpacked_dt = ompi_datatype_create_from_packed_description(&payload,
                                                           ompi_proc_local());
@@ -180,6 +178,9 @@ main(int argc, char* argv[])
         }
         printf("\tPASSED\n");
     }
+    ret = MPI_Type_free(&vec_type);
+    if (ret != 0) goto cleanup;
+
     ret = MPI_Type_free(&unpacked_dt);
     if (ret != 0) goto cleanup;
 
@@ -209,9 +210,6 @@ main(int argc, char* argv[])
     ret = ompi_datatype_get_pack_description(newType, &packed_ddt);
     if (ret != 0) goto cleanup;
 
-    ret = MPI_Type_free(&newType);
-    if (ret != 0) goto cleanup;
-
     memcpy(payload, packed_ddt, packed_ddt_len);
     unpacked_dt = ompi_datatype_create_from_packed_description(&payload,
                                                                ompi_proc_local());
@@ -232,6 +230,9 @@ main(int argc, char* argv[])
         }
         printf("\tPASSED\n");
     }
+    ret = MPI_Type_free(&newType);
+    if (ret != 0) goto cleanup;
+
     ret = MPI_Type_free(&unpacked_dt);
     if (ret != 0) goto cleanup;
 
@@ -281,6 +282,10 @@ main(int argc, char* argv[])
         }
         printf("\tPASSED\n");
     }
+    ret = MPI_Type_free(&newType);
+    if (ret != 0) goto cleanup;
+
+    newType = unpacked_dt;  /* save it for later */
 
     /**
      *
@@ -313,9 +318,6 @@ main(int argc, char* argv[])
     if (ret != 0) goto cleanup;
     memcpy(payload, packed_ddt, packed_ddt_len);
 
-    ret = MPI_Type_free(&struct_type);
-    if (ret != 0) goto cleanup;
-
     unpacked_dt = ompi_datatype_create_from_packed_description(&payload,
                                                           ompi_proc_local());
     free(ptr);
@@ -335,6 +337,12 @@ main(int argc, char* argv[])
         }
         printf("\tPASSED\n");
     }
+    ret = MPI_Type_free(&struct_type);
+    if (ret != 0) goto cleanup;
+
+    ret = MPI_Type_free(&unpacked_dt);
+    if (ret != 0) goto cleanup;
+
 
  cleanup:
     MPI_Finalize();

--- a/test/datatype/ddt_pack.c
+++ b/test/datatype/ddt_pack.c
@@ -11,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Sun Microsystems Inc. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -56,7 +58,7 @@ main(int argc, char* argv[])
     unpacked_dt = ompi_datatype_create_from_packed_description(&payload,
                                                           ompi_proc_local());
     free(ptr);
-    if (unpacked_dt == MPI_INT) {
+    if (unpacked_dt == MPI_INT32_T) {
         printf("\tPASSED\n");
     } else {
         printf("\tFAILED: datatypes don't match\n");


### PR DESCRIPTION
This PR fixes 2 datatype issues that evolved over several days with @ggouaillardet and @bosilca.  It replaces #267 (which, itself, slurped in the contents of the #268 PR), because @ggouaillardet is on vacation and can't easily update that PR.  Here's the two main issues fixed:
1. INDEXED_BLOCK issue discovered by Satish Balay @balay
2. fix ddt_pack issue

It updates but then temporarily disables the `test/datatype/ddt_pack` test because this test calls MPI_INIT (instead of opal_init_util).  @ggouaillardet is going to work on updating that test so that it can be called at `make check` time, but not until next week.  It is fine for v1.8.5 to ship without running this test during `make check`.
