### PR TITLE
Fix a overwrite of the args buffer identified by Lisandro Dalcin.

### DIFF
--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
@@ -107,7 +107,7 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
 
         a_i[0] = &r;
         a_i[1] = &p;
-        ompi_datatype_set_args( datatype, 1, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_COMPLEX );
+        ompi_datatype_set_args( datatype, 2, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_COMPLEX );
 
         rc = opal_hash_table_set_value_uint64( &ompi_mpi_f90_complex_hashtable, key, datatype );
         if (OMPI_SUCCESS != rc) {

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
@@ -105,7 +105,7 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
         snprintf(datatype->name, MPI_MAX_OBJECT_NAME, "COMBINER %s",
                  (*newtype)->name);
 
-        ompi_datatype_set_args( datatype, 1, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_REAL );
+        ompi_datatype_set_args( datatype, 2, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_REAL );
 
         rc = opal_hash_table_set_value_uint64( &ompi_mpi_f90_real_hashtable, key, datatype );
         if (OMPI_SUCCESS != rc) {


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@3af8dfd3e263f5eb93fd6d2992e40868a14ad773)

Let's see how the commit shakes out on master in MTT (I added Lisandro's test in ibm/datatype/type_f90.c).  Assuming it works fine, is good to merge to v1.8.6.

@bosilca @dalcinl
