### PR TITLE
Fix orted environment (PATH and friends) when there is no prefix.

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -370,9 +370,6 @@ static int setup_launch(int *argcptr, char ***argvptr,
      and use that on the remote node.
      */
     
-    lib_base = opal_basename(opal_install_dirs.libdir);
-    bin_base = opal_basename(opal_install_dirs.bindir);
-    
     /*
      * Build argv array
      */


### PR DESCRIPTION
This is a one-off patch that fixes commit open-mpi/ompi-release@10ff75e91c3f5dad18ea854fd0ee831b2ea066d7
that was incorrectly backported from open-mpi/ompi@12bfb27161fb2710d9b4327072776ff3333f0afc

Thanks to Siegmar Gross for reporting and help digging this issue.
