### PR TITLE
v1.8 keepalive fixes

### DIFF
--- a/orte/mca/oob/tcp/help-oob-tcp.txt
+++ b/orte/mca/oob/tcp/help-oob-tcp.txt
@@ -10,7 +10,8 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2014      Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -73,4 +74,21 @@ attempt to fail, so you may experience a significant hang time.
 
 You may wish to ctrl-c out of your job and activate loopback support
 on at least one interface before trying again.
+#
+[accept failed]
+WARNING: The accept(3) system call failed on a TCP socket.  While this
+should generally never happen on a well-configured HPC system, the
+most common causes when it does occur are:
 
+  * The process ran out of file descriptors
+  * The operating system ran out of file descriptors
+  * The operating system ran out of memory
+
+Your Open MPI job will likely hang until the failure resason is fixed
+(e.g., more file descriptors and/or memory becomes available), and may
+eventually timeout / abort.
+
+  Local host:     %s
+  Errno:          %d (%s)
+  Probable cause: %s
+#

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -194,8 +194,8 @@ static int tcp_component_close(void)
 static char *static_port_string;
 #if OPAL_ENABLE_IPV6
 static char *static_port_string6;
-#endif
-#endif
+#endif // OPAL_ENABLE_IPV6
+#endif // OPAL_ENABLE_STATIC_PORTS
 
 static char *dyn_port_string;
 #if OPAL_ENABLE_IPV6
@@ -316,9 +316,8 @@ static int tcp_component_register(void)
     } else {
         orte_static_ports = true;
     }
-#endif
-#endif
-    
+#endif // OPAL_ENABLE_IPV6
+#endif // OPAL_ENABLE_STATIC_PORTS
     dyn_port_string = NULL;
     (void)mca_base_component_var_register(component, "dynamic_ipv4_ports",
                                           "Range of ports to be dynamically used by daemons and procs (IPv4)",
@@ -384,7 +383,7 @@ static int tcp_component_register(void)
     } else {
         mca_oob_tcp_component.tcp6_dyn_ports = NULL;
     }
-#endif
+#endif // OPAL_ENABLE_IPV6
 
     mca_oob_tcp_component.disable_ipv4_family = false;
     (void)mca_base_component_var_register(component, "disable_ipv4_family",
@@ -402,7 +401,7 @@ static int tcp_component_register(void)
                                           OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.disable_ipv6_family);
-#endif
+#endif // OPAL_ENABLE_IPV6
 
     // Default to keepalives every 60 seconds
     mca_oob_tcp_component.keepalive_time = 60;
@@ -573,7 +572,7 @@ static bool component_available(void)
                                 opal_net_get_hostname((struct sockaddr*) &my_ss),
                                 (AF_INET == my_ss.ss_family) ? "V4" : "V6");
             opal_argv_append_nosize(&mca_oob_tcp_component.ipv6conns, opal_net_get_hostname((struct sockaddr*) &my_ss));
-#endif
+#endif // OPAL_ENABLE_IPV6
         } else {
             opal_output_verbose(10, orte_oob_base_framework.framework_output,
                                 "%s oob:tcp:init ignoring %s from out list of connections",
@@ -723,7 +722,7 @@ static char* component_get_addr(void)
         free(tmp);
         free(tp);
     }
-#endif
+#endif // OPAL_ENABLE_IPV6
 
     /* return our uri */
     return cptr;
@@ -753,13 +752,13 @@ static int component_set_addr(orte_process_name_t *peer,
             af_family = AF_INET6;
             tcpuri = strdup(uris[i]);
             host = tcpuri + strlen("tcp6://");
-#else
+#else // OPAL_ENABLE_IPV6
             /* we don't support this connection type */
             opal_output_verbose(2, orte_oob_base_framework.framework_output,
                                 "%s oob:tcp: address %s not supported",
                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), uris[i]);
             continue;
-#endif
+#endif // OPAL_ENABLE_IPV6
         } else {
             /* not one of ours */
             opal_output_verbose(2, orte_oob_base_framework.framework_output,
@@ -793,6 +792,7 @@ static int component_set_addr(orte_process_name_t *peer,
          * end - we need to remove those extra characters
          */
         hptr = host;
+#if OPAL_ENABLE_IPV6
         if (AF_INET6 == af_family) {
             if ('[' == host[0]) {
                 hptr = &host[1];
@@ -801,6 +801,7 @@ static int component_set_addr(orte_process_name_t *peer,
                 host[strlen(host)-1] = '\0';
             }
         }
+#endif // OPAL_ENABLE_IPV6
         addrs = opal_argv_split(hptr, ',');
 
 
@@ -816,7 +817,7 @@ static int component_set_addr(orte_process_name_t *peer,
                     }
                     host = mca_oob_tcp_component.ipv6conns[0];
                 } else {
-#endif
+#endif // OPAL_ENABLE_IPV6
                     if (NULL == mca_oob_tcp_component.ipv4conns ||
                         NULL == mca_oob_tcp_component.ipv4conns[0]) {
                         continue;

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -404,25 +404,29 @@ static int tcp_component_register(void)
                                           &mca_oob_tcp_component.disable_ipv6_family);
 #endif
 
-    
-    mca_oob_tcp_component.keepalive_time = 10;
+    // Default to keepalives every 60 seconds
+    mca_oob_tcp_component.keepalive_time = 60;
     (void)mca_base_component_var_register(component, "keepalive_time",
-                                          "Idle time in seconds before starting to send keepalives (num <= 0 ----> disable keepalive)",
+                                          "Idle time in seconds before starting to send keepalives (keepalive_time <= 0 disables keepalive functionality)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                           OPAL_INFO_LVL_9,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.keepalive_time);
 
-    mca_oob_tcp_component.keepalive_intvl = 60;
+    // Default to keepalive retry interval time of 5 seconds
+    mca_oob_tcp_component.keepalive_intvl = 5;
     (void)mca_base_component_var_register(component, "keepalive_intvl",
-                                          "Time between keepalives, in seconds",
+                                          "Time between successive keepalive pings when peer has not responded, in seconds (ignored if keepalive_time <= 0)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                           OPAL_INFO_LVL_9,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.keepalive_intvl);
+
+    // Default to retrying a keepalive 3 times before declaring the
+    // peer kaput
     mca_oob_tcp_component.keepalive_probes = 3;
     (void)mca_base_component_var_register(component, "keepalive_probes",
-                                          "Number of keepalives that can be missed before declaring error",
+                                          "Number of keepalives that can be missed before declaring error (ignored if keepalive_time <= 0)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                           OPAL_INFO_LVL_9,
                                           MCA_BASE_VAR_SCOPE_READONLY,

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -212,7 +212,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "peer_limit",
                                           "Maximum number of peer connections to simultaneously maintain (-1 = infinite)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_5,
                                           MCA_BASE_VAR_SCOPE_LOCAL,
                                           &mca_oob_tcp_component.peer_limit);
 
@@ -220,7 +220,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "peer_retries",
                                           "Number of times to try shutting down a connection before giving up",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_5,
                                           MCA_BASE_VAR_SCOPE_LOCAL,
                                           &mca_oob_tcp_component.max_retries);
 
@@ -228,7 +228,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "sndbuf",
                                           "TCP socket send buffering size (in bytes)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_LOCAL,
                                           &mca_oob_tcp_component.tcp_sndbuf);
 
@@ -236,7 +236,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "rcvbuf",
                                           "TCP socket receive buffering size (in bytes)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_LOCAL,
                                           &mca_oob_tcp_component.tcp_rcvbuf);
 
@@ -244,7 +244,7 @@ static int tcp_component_register(void)
     var_id = mca_base_component_var_register(component, "if_include",
                                              "Comma-delimited list of devices and/or CIDR notation of TCP networks to use for Open MPI bootstrap communication (e.g., \"eth0,192.168.0.0/16\").  Mutually exclusive with oob_tcp_if_exclude.",
                                              MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                             OPAL_INFO_LVL_9,
+                                             OPAL_INFO_LVL_2,
                                              MCA_BASE_VAR_SCOPE_LOCAL,
                                              &mca_oob_tcp_component.if_include);
     (void)mca_base_var_register_synonym(var_id, "orte", "oob", "tcp", "include",
@@ -254,7 +254,7 @@ static int tcp_component_register(void)
     var_id = mca_base_component_var_register(component, "if_exclude",
                                              "Comma-delimited list of devices and/or CIDR notation of TCP networks to NOT use for Open MPI bootstrap communication -- all devices not matching these specifications will be used (e.g., \"eth0,192.168.0.0/16\").  If set to a non-default value, it is mutually exclusive with oob_tcp_if_include.",
                                              MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                             OPAL_INFO_LVL_9,
+                                             OPAL_INFO_LVL_2,
                                              MCA_BASE_VAR_SCOPE_LOCAL,
                                              &mca_oob_tcp_component.if_exclude);
     (void)mca_base_var_register_synonym(var_id, "orte", "oob", "tcp", "exclude",
@@ -276,7 +276,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "static_ipv4_ports", 
                                           "Static ports for daemons and procs (IPv4)",
                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_2,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &static_port_string);
 
@@ -296,7 +296,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "static_ipv6_ports", 
                                           "Static ports for daemons and procs (IPv6)",
                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_2,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &static_port_string6);
 
@@ -323,7 +323,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "dynamic_ipv4_ports",
                                           "Range of ports to be dynamically used by daemons and procs (IPv4)",
                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &dyn_port_string);
     /* if ports were provided, parse the provided range */
@@ -350,7 +350,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "dynamic_ipv6_ports",
                                           "Range of ports to be dynamically used by daemons and procs (IPv6)",
                                           MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &dyn_port_string6);
     /* if ports were provided, parse the provided range */
@@ -390,7 +390,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "disable_ipv4_family",
                                           "Disable the IPv4 interfaces",
                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.disable_ipv4_family);
 
@@ -399,7 +399,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "disable_ipv6_family",
                                           "Disable the IPv6 interfaces",
                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_4,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.disable_ipv6_family);
 #endif
@@ -409,7 +409,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "keepalive_time",
                                           "Idle time in seconds before starting to send keepalives (keepalive_time <= 0 disables keepalive functionality)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_5,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.keepalive_time);
 
@@ -418,7 +418,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "keepalive_intvl",
                                           "Time between successive keepalive pings when peer has not responded, in seconds (ignored if keepalive_time <= 0)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_5,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.keepalive_intvl);
 
@@ -428,7 +428,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "keepalive_probes",
                                           "Number of keepalives that can be missed before declaring error (ignored if keepalive_time <= 0)",
                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_5,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.keepalive_probes);
     
@@ -436,7 +436,7 @@ static int tcp_component_register(void)
     (void)mca_base_component_var_register(component, "skip_version_check",
                                           "Skip checking versions between connections",
                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
+                                          OPAL_INFO_LVL_6,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_oob_tcp_component.skip_version_check);
     return ORTE_SUCCESS;

--- a/orte/mca/oob/tcp/oob_tcp_listener.c
+++ b/orte/mca/oob/tcp/oob_tcp_listener.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC. 
  *                         All rights reserved.
- * Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -304,9 +304,6 @@ static int create_listen(void)
             return ORTE_ERR_IN_ERRNO;
         }
 
-        /* setup socket options */
-        orte_oob_tcp_set_socket_options(sd);
-
         /* Enable/disable reusing ports */
         if (orte_static_ports) {
             flags = 1;
@@ -556,10 +553,6 @@ static int create_listen6(void)
             opal_argv_free(ports);
             return ORTE_ERROR;
         }
-
-
-        /* setup socket options */
-        orte_oob_tcp_set_socket_options(sd);
 
         /* Enable/disable reusing ports */
         if (orte_static_ports) {

--- a/orte/mca/oob/tcp/oob_tcp_listener.c
+++ b/orte/mca/oob/tcp/oob_tcp_listener.c
@@ -731,20 +731,43 @@ static void* listen_thread(opal_object_t *obj)
                                                 (struct sockaddr*)&(pending_connection->addr),
                                                 &addrlen);
                 if (pending_connection->fd < 0) {
-                    if (opal_socket_errno != EAGAIN || 
-                        opal_socket_errno != EWOULDBLOCK) {
-                        CLOSE_THE_SOCKET(pending_connection->fd);
-                        if (EMFILE == opal_socket_errno) {
-                            ORTE_ERROR_LOG(ORTE_ERR_SYS_LIMITS_SOCKETS);
-                            orte_show_help("help-orterun.txt", "orterun:sys-limit-sockets", true);
-                        } else {
-                            opal_output(0, "mca_oob_tcp_accept: accept() failed: %s (%d).",
-                                        strerror(opal_socket_errno), opal_socket_errno);
-                        }
-                        OBJ_RELEASE(pending_connection);
+                    OBJ_RELEASE(pending_connection);
+
+                    /* Non-fatal errors */
+                    if (EAGAIN == opal_socket_errno ||
+                        EWOULDBLOCK == opal_socket_errno) {
+                        continue;
+                    }
+
+                    /* If we run out of file descriptors, log an extra
+                       warning (so that the user can know to fix this
+                       problem) and abandon all hope. */
+                    else if (EMFILE == opal_socket_errno) {
+                        CLOSE_THE_SOCKET(sd);
+                        ORTE_ERROR_LOG(ORTE_ERR_SYS_LIMITS_SOCKETS);
+                        orte_show_help("help-oob-tcp.txt",
+                                       "accept failed",
+                                       true,
+                                       orte_process_info.nodename,
+                                       opal_socket_errno,
+                                       strerror(opal_socket_errno),
+                                       "Out of file descriptors");
                         goto done;
                     }
-                    continue;
+
+                    /* For all other cases, close the socket, print a
+                       warning but try to continue */
+                    else {
+                        CLOSE_THE_SOCKET(sd);
+                        orte_show_help("help-oob-tcp.txt",
+                                       "accept failed",
+                                       true,
+                                       orte_process_info.nodename,
+                                       opal_socket_errno,
+                                       strerror(opal_socket_errno),
+                                       "Unknown cause; job will try to continue");
+                        continue;
+                    }
                 }
 
                 opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
@@ -830,26 +853,43 @@ static void connection_event_handler(int incoming_sd, short flags, void* cbdata)
                         opal_net_get_hostname((struct sockaddr*) &addr),
                         opal_net_get_port((struct sockaddr*) &addr));
     if (sd < 0) {
-        if (EINTR == opal_socket_errno) {
+        /* Non-fatal errors */
+        if (EINTR == opal_socket_errno ||
+            EAGAIN == opal_socket_errno ||
+            EWOULDBLOCK == opal_socket_errno) {
             return;
         }
-        if (opal_socket_errno != EAGAIN && opal_socket_errno != EWOULDBLOCK) {
-            if (EMFILE == opal_socket_errno) {
-                /*
-                 * Close incoming_sd so that orte_show_help will have a file
-                 * descriptor with which to open the help file.  We will be
-                 * exiting anyway, so we don't need to keep it open.
-                 */
-                CLOSE_THE_SOCKET(incoming_sd);
-                ORTE_ERROR_LOG(ORTE_ERR_SYS_LIMITS_SOCKETS);
-                orte_show_help("help-orterun.txt", "orterun:sys-limit-sockets", true);
-            } else {
-                opal_output(0, "mca_oob_tcp_accept: accept() failed: %s (%d).", 
-                            strerror(opal_socket_errno), opal_socket_errno);
-            }
+
+        /* If we run out of file descriptors, log an extra warning (so
+           that the user can know to fix this problem) and abandon all
+           hope. */
+        else if (EMFILE == opal_socket_errno) {
+            CLOSE_THE_SOCKET(incoming_sd);
+            ORTE_ERROR_LOG(ORTE_ERR_SYS_LIMITS_SOCKETS);
+            orte_show_help("help-oob-tcp.txt",
+                           "accept failed",
+                           true,
+                           orte_process_info.nodename,
+                           opal_socket_errno,
+                           strerror(opal_socket_errno),
+                           "Out of file descriptors");
             orte_errmgr.abort(ORTE_ERROR_DEFAULT_EXIT_CODE, NULL);
+            return;
         }
-        return;
+
+        /* For all other cases, close the socket, print a warning but
+           try to continue */
+        else {
+            CLOSE_THE_SOCKET(incoming_sd);
+            orte_show_help("help-oob-tcp.txt",
+                           "accept failed",
+                           true,
+                           orte_process_info.nodename,
+                           opal_socket_errno,
+                           strerror(opal_socket_errno),
+                           "Unknown cause; job will try to continue");
+            return;
+        }
     }
 
     /* process the connection */


### PR DESCRIPTION
The long saga of fixing the keepalive memory leak is nearly complete.  :-)

This PR replaces #275, and is the v1.8 fix for open-mpi/ompi#579.

It's the cherry-pick (and slight adaptation) of several commits from master:
- Note that I did _not_ take @rhc54's initial commits of disabling keepalive for the Mac (and then a few changes around that stuff, and then my commit which effectively reverted that stuff)
- open-mpi/ompi@c95215d do not set keepalive on listening sockets
- open-mpi/ompi@1a4c996 set keepalive timeout to 60s, retry interval to 5s
- open-mpi/ompi@4b2f0d4 reset OOB TCP MCA params from level 9
- open-mpi/ompi@e43c8dc label a few #endifs
- open-mpi/ompi@3069daa slightly refactor EAGAIN/EWOULDBLOCK code

Still waiting for a master fix for open-mpi/ompi#592, but that can be a different v1.8 PR.

Persons of interest: @rhc54 @bosilca @scobey @ggouaillardet @ianhinder @barrywardell @rolfv 

@rhc54 @bosilca please review
