### PR TITLE
Fix cuda fini code where initialization did not complete

### DIFF
--- a/ompi/mca/common/cuda/common_cuda.c
+++ b/ompi/mca/common/cuda/common_cuda.c
@@ -742,6 +742,14 @@ void mca_common_cuda_fini(void)
 {
     int i;
     CUresult res;
+
+    if (false == common_cuda_initialized) {
+        stage_one_init_ref_count--;
+        opal_output_verbose(20, mca_common_cuda_output,
+                            "CUDA: mca_common_cuda_fini, never completed initialization so "
+                            "skipping fini, ref_count is now %d", stage_one_init_ref_count);
+        return;
+    }
     
     if (0 == stage_one_init_ref_count) {
         opal_output_verbose(20, mca_common_cuda_output,


### PR DESCRIPTION
This is a fix in the shutdown code of CUDA-aware support where either the user did not request support with MCA parameter or CUDA initialization never completed for some reason.  If we did not complete initialization, then no need to clean anything up.
- open-mpi/ompi@b3e4ae71d5303b91cf719303fc1eed8377e65ce4

@bosilca  Can you review?  
