### PR TITLE
v1.10 usnic libfabric update

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_compat.c
+++ b/ompi/mca/btl/usnic/btl_usnic_compat.c
@@ -26,10 +26,9 @@
 
 /************************************************************************/
 
-/* v1.9 and beyond */
+/* v2.0 and beyond */
 
-#if (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 9) || \
-    (OPAL_MAJOR_VERSION >= 2)
+#if (OPAL_MAJOR_VERSION >= 2)
 
 #include "opal/util/proc.h"
 
@@ -70,7 +69,7 @@ const char *usnic_compat_proc_name_print(opal_process_name_t *pname)
 
 /************************************************************************/
 
-/* v1.7 and v1.8 */
+/* v1.7, v1.8, and v1.10 (there was no v1.9) */
 
 #elif (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 7)
 

--- a/ompi/mca/btl/usnic/btl_usnic_compat.h
+++ b/ompi/mca/btl/usnic/btl_usnic_compat.h
@@ -15,10 +15,9 @@
 
 /************************************************************************/
 
-/* v1.9 and beyond */
+/* v2.0 and beyond */
 
-#if (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 9) || \
-    (OPAL_MAJOR_VERSION >= 2)
+#if (OPAL_MAJOR_VERSION >= 2)
 
 /* OMPI_ERROR_LOG and friends */
 #  include "opal/util/error.h"
@@ -79,7 +78,7 @@ usnic_compat_proc_name_compare(opal_process_name_t a,
 
 /************************************************************************/
 
-/* v1.7 and v1.8 */
+/* v1.7, v1.8, and v1.10 (there was no v1.9) */
 
 #elif (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 7)
 

--- a/ompi/mca/btl/usnic/btl_usnic_module.h
+++ b/ompi/mca/btl/usnic/btl_usnic_module.h
@@ -25,6 +25,7 @@
 #define OPAL_BTL_USNIC_MODULE_H
 
 #include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_errno.h>

--- a/ompi/mca/mtl/ofi/mtl_ofi_compat.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_compat.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,10 +16,9 @@
 
 /************************************************************************/
 
-/* v1.9 and beyond */
+/* v2.0 and beyond */
 
-#if (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 9) || \
-    (OPAL_MAJOR_VERSION >= 2)
+#if (OPAL_MAJOR_VERSION >= 2)
 
 #include "opal/mca/pmix/pmix.h"
 
@@ -42,7 +42,7 @@
 
 /************************************************************************/
 
-/* v1.7 and v1.8 */
+/* v1.7, v1.8, and v1.10 (there was no v1.9) */
 
 #elif (OPAL_MAJOR_VERSION == 1 && OPAL_MINOR_VERSION >= 7)
 


### PR DESCRIPTION
Bring over open-mpi/ompi@65b66ab and open-mpi/ompi@95a2b14.  These commits are not relevant to the v1.8 branch.

Submitted by @goodell, reviewed by @jsquyres

The VERSION update caused some problems with btl_usnic_compat.\* and mtl_ofi_compat.h; brought over 3 more commits from master to fix these issues:
- open-mpi/ompi@9c19dd4e5bbc7e68624a52dae2eace3b0b0874b7: fix btl_usnic_compat.h
- open-mpi/ompi@ec57aa18058e4f8836f6bb93e0e91fb3992a640f: fix btl_usnic_compat.c
- open-mpi/ompi@fb12572438f7c8ef43e1b6662645fdccc0c65694: fix mtl_ofi_compat.h
