### PR TITLE
v1.10 - build: fix mxm configure

### DIFF
--- a/config/ompi_check_mxm.m4
+++ b/config/ompi_check_mxm.m4
@@ -36,7 +36,7 @@ AC_DEFUN([OMPI_CHECK_MXM],[
            AS_IF([test ! -z "$with_mxm_libdir" -a "$with_mxm_libdir" != "yes"],
                  [ompi_check_mxm_libdir="$with_mxm_libdir"])
 
-           ompi_check_mxm_extra_libs="-L$ompi_check_mxm_libdir"
+           AS_IF([test ! -z "$ompi_check_mxm_libdir"], [ompi_check_mxm_extra_libs="-L$ompi_check_mxm_libdir"],[])
 
            OMPI_CHECK_PACKAGE([$1],
                               [mxm/api/mxm_api.h],


### PR DESCRIPTION
configure w/ CPPFLAGS/LDFLAGS can add empty -L statement from mxm
Thanks to David Shrader dshrader@lanl.gov for patch
(cherry picked from commit 5a3599dce72ffb9628b408e9920c11d9718bc319)
