### PR TITLE
configury: manually remove some stamp-h? files

### DIFF
--- a/opal/mca/hwloc/hwloc191/Makefile.am
+++ b/opal/mca/hwloc/hwloc191/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All right reserved.
 # $COPYRIGHT$
 # 
@@ -7,6 +7,13 @@
 # 
 # $HEADER$
 #
+
+# Due to what might be a bug in Automake, we need to remove stamp-h?
+# files manually.  See
+# http://debbugs.gnu.org/cgi/bugreport.cgi?bug=19418.
+DISTCLEANFILES = \
+    hwloc/include/hwloc/autogen/stamp-h? \
+    hwloc/include/private/autogen/stamp-h?
 
 # Need to include these files so that these directories are carried in
 # the tarball (in case someone invokes autogen.sh on a dist tarball).


### PR DESCRIPTION
Due to what might be a bug in Automake, we need to remove stamp-h? files manually.  See http://debbugs.gnu.org/cgi/bugreport.cgi?bug=19418.

(cherry picked from commit open-mpi/ompi@40dd4c5b766ff62a681692b1fa6b72a1023fc81f) 

This was fixed long ago on master; it wasn't brought over to v1.8 (and therefore v1.10) because we didn't have embedded libfabric on v1.8(v1.10), and therefore didn't trip this (assumed) Automake bug.  Without this PR, "make distcheck" fails because some stamp-h? files are left in the build tree.
