### PR TITLE
v1.10 btl_tcp_proc.c: add missing "continue"

### DIFF
--- a/ompi/mca/btl/tcp/btl_tcp_proc.c
+++ b/ompi/mca/btl/tcp/btl_tcp_proc.c
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2010 Oracle and/or its affiliates.  All rights reserved
  * Copyright (c) 2013      Intel, Inc. All rights reserved
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -545,6 +546,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
                         weights[i][j] = CQ_PRIVATE_DIFFERENT_NETWORK;
                     }
                     best_addr[i][j] = peer_interfaces[j]->ipv4_endpoint_addr;
+                    continue;
                 }
             }
 
@@ -572,6 +574,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
                     weights[i][j] = CQ_PUBLIC_DIFFERENT_NETWORK;
                 }
                 best_addr[i][j] = peer_interfaces[j]->ipv6_endpoint_addr;
+                continue;
             } 
 
         } /* for each peer interface */


### PR DESCRIPTION
Also add another (superflous but symmetric) continue statement.

This missing "continue" statement allows IPv4 "private network" matches to fall through and allow IPv6 matches to be made -- thereby overriding the IPv4 match that was already made.

Fixes open-mpi/ompi#585 (although several of the other issues identified on open-mpi/ompi#585 still exist, the primary / initial bug that was reported there is now fixed).

(cherry picked from commit open-mpi/ompi@cddc8945e056eb05e5ad49de4578fe36f1c198a6)

@bosilca @ggouaillardet This is the v1.10 version of #304 -- the patch is exactly the same.
