### PR TITLE
v1.10: ompi/include/Makefile.am: rm mpi_portable_platform.h first

### DIFF
--- a/ompi/include/Makefile.am
+++ b/ompi/include/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2014-2015 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -104,4 +104,5 @@ distclean-local:
 	rm -f mpi-ext.h mpif-ext.h mpi_portable_platform.h mpif-sizeof.h
 
 mpi_portable_platform.h: $(top_srcdir)/opal/include/opal/opal_portable_platform.h
+	-@rm -f mpi_portable_platform.h
 	$(LN_S) $(top_srcdir)/opal/include/opal/opal_portable_platform.h mpi_portable_platform.h


### PR DESCRIPTION
We've seen this a few times (e.g., http://www.open-mpi.org/community/lists/users/2015/06/27057.php
reported via @siegmargross).  I'm not entirely sure why it happens -- the best I can come up with is a poorly-synchronized network filesystem and/or a bug in "make".  For example: this code hasn't changed in forever, and it only happens to users _sometimes_.

Regardless, avoid the error altogether by removing the file before making the sym link (it should be a sym link anyway -- if there's something there, it should be safe to remove it before we re-create the sym link that should be there in the first place).

(cherry picked from commit open-mpi/ompi@fbaf6888f8905acc428d9a26eab9983f378d9326)
