### PR TITLE
fix pmi2 process map parsing in ess/pmi reusing the correct one in grpomm/pmi

### DIFF
--- a/opal/mca/common/pmi/Makefile.am
+++ b/opal/mca/common/pmi/Makefile.am
@@ -40,5 +40,8 @@ endif
 lib_LTLIBRARIES = $(component_install)
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_common_pmi_la_SOURCES = common_pmi.h common_pmi.c
+if WANT_PMI2_SUPPORT
+libmca_common_pmi_la_SOURCES += pmi2_pmap_parser.c
+endif
 libmca_common_pmi_la_LDFLAGS = $(common_pmi_LDFLAGS) -version-info $(libmca_opal_common_pmi_so_version)
 libmca_common_pmi_la_LIBADD = $(common_pmi_LIBS)

--- a/opal/mca/common/pmi/common_pmi.c
+++ b/opal/mca/common/pmi/common_pmi.c
@@ -159,3 +159,45 @@ bool mca_common_pmi_size(int *size) {
     *size = mca_common_pmi_init_size;
     return true;
 }
+
+int *mca_common_pmi_local_ranks(int my_rank, int *local_rank_count) {
+    int rc;
+    int *local_ranks = NULL;
+    *local_rank_count = 0;
+#if WANT_PMI2_SUPPORT
+    {
+        char *pmapping = (char*)malloc(PMI2_MAX_VALLEN);
+        int found;
+        int my_node;
+
+        rc = PMI2_Info_GetJobAttr("PMI_process_mapping", pmapping, PMI2_MAX_VALLEN, &found);
+        if (!found || PMI_SUCCESS != rc) { /* can't check PMI2_SUCCESS as some folks (i.e., Cray) don't define it */
+            OPAL_PMI_ERROR(rc, "PMI_Info_GetJobAttr(PMI_process_mapping)");
+            return NULL;
+        }
+
+        local_ranks = mca_common_pmi2_parse_pmap(pmapping, my_rank, &my_node, local_rank_count);
+        free(pmapping);
+        return local_ranks;
+    }
+#else
+    rc = PMI_Get_clique_size (local_rank_count);
+    if (PMI_SUCCESS != rc) {
+        OPAL_PMI_ERROR(rc, "PMI_Get_clique_size");
+        return NULL;
+    }
+
+    local_ranks = calloc (*local_rank_count, sizeof (int));
+    if (NULL == local_ranks) {
+        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+        return NULL;
+    }
+
+    rc = PMI_Get_clique_ranks (local_ranks, local_rank_count);
+    if (PMI_SUCCESS != rc) {
+        OPAL_PMI_ERROR(rc, "PMI_Get_clique_ranks");
+        return NULL;
+    }
+    return local_ranks;
+#endif
+}

--- a/opal/mca/common/pmi/common_pmi.h
+++ b/opal/mca/common/pmi/common_pmi.h
@@ -48,3 +48,9 @@ OPAL_DECLSPEC char* opal_errmgr_base_pmi_error(int pmi_err);
 
 bool mca_common_pmi_rank(int *rank);
 bool mca_common_pmi_size(int *size);
+
+
+#if WANT_PMI2_SUPPORT
+OPAL_DECLSPEC int *mca_common_pmi2_parse_pmap(char *pmap, int my_rank,
+                                              int *node, int *nlrs);
+#endif

--- a/opal/mca/common/pmi/common_pmi.h
+++ b/opal/mca/common/pmi/common_pmi.h
@@ -54,3 +54,15 @@ bool mca_common_pmi_size(int *size);
 OPAL_DECLSPEC int *mca_common_pmi2_parse_pmap(char *pmap, int my_rank,
                                               int *node, int *nlrs);
 #endif
+
+
+/**
+ * mca_common_pmi_local_ranks:
+ *
+ * @param my_rank
+ * @param local_rank_count set to the number of local ranks returned
+ *
+ * @retval array that contains ranks local to my_rank or NULL
+ * on failure. Array must be freed by the caller.
+ */
+OPAL_DECLSPEC int *mca_common_pmi_local_ranks (int my_rank, int *local_rank_count);

--- a/opal/mca/common/pmi/pmi2_pmap_parser.c
+++ b/opal/mca/common/pmi/pmi2_pmap_parser.c
@@ -13,11 +13,7 @@
 #ifdef STANDALONE_TEST
 #define WANT_PMI2_SUPPORT 1
 #else
-#include "orte_config.h"
-#include "orte/constants.h"
-#include "orte/types.h"
-
-#include "grpcomm_pmi.h"
+#include "common_pmi.h"
 #endif
 
 /**
@@ -134,8 +130,8 @@ static int *find_lrs(char *map, int my_node, int *nlrs)
  * @return array that contains ranks local to my_rank or NULL
  * on failure. Array must be freed by the caller. 
  */ 
-int *orte_grpcomm_pmi2_parse_pmap(char *pmap, int my_rank,
-                                  int *node, int *nlrs)
+int *mca_common_pmi2_parse_pmap(char *pmap, int my_rank,
+                                int *node, int *nlrs)
 {
     char *p;
 

--- a/opal/mca/common/pmi/pmi2_pmap_parser.c
+++ b/opal/mca/common/pmi/pmi2_pmap_parser.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
     if (argc == 3) {
         me = atoi(argv[1]);
-        lrs = orte_grpcomm_pmi2_parse_pmap(argv[2], me, &node, &n);
+        lrs = mca_common_pmi2_parse_pmap(argv[2], me, &node, &n);
         if (NULL == lrs) {
             printf("can not parse pmap\n");
             exit(1);
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
 
     pmap = "(vector,(0,2,2))";
     me = 1;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 2);
     assert(memcmp(lrs, a1, 2) == 0);
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
 
     pmap = "(vector,(0,2,2))";
     me = 2;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 2);
     assert(memcmp(lrs, a2, 2) == 0);
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
     /* cyclic distro which skips node 0 */
     pmap = "(vector,(1,2,1),(1,2,1))";
     me = 0;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 2);
     assert(memcmp(lrs, a3, n) == 0);
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
 
     pmap = "(vector,(1,2,1),(1,2,1))";
     me = 3;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 2);
     assert(memcmp(lrs, a4, n) == 0);
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
 
     pmap = "(vector,(0,4,4),(0,1,2),(1,3,1))";
     me = 3;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 6);
     assert(memcmp(lrs, a5, n) == 0);
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 
     pmap = "(vector,(0,4,4),(0,1,2),(1,3,1))";
     me = 10;
-    lrs = orte_grpcomm_pmi2_parse_pmap(pmap, me, &node, &n);
+    lrs = mca_common_pmi2_parse_pmap(pmap, me, &node, &n);
     assert(lrs);
     assert(n == 5);
     assert(memcmp(lrs, a6, n) == 0);

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -266,45 +266,10 @@ static int rte_init(void)
         goto error;
     }
 
-#if WANT_PMI2_SUPPORT
-    {
-        /* get our local proc info to find our local rank */
-        char *pmapping = (char*)malloc(PMI2_MAX_VALLEN);
-        int found, k;
-        ret = PMI2_Info_GetJobAttr("PMI_process_mapping", pmapping, PMI2_MAX_VALLEN, &found);
-        if (!found || PMI_SUCCESS != ret) { /* can't check PMI2_SUCCESS as some folks (i.e., Cray) don't define it */
-            error = "could not get PMI_process_mapping (PMI2_Info_GetJobAttr() failed)";
-            goto error;
-        }
-
-        ranks = mca_common_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &k, &procs);
-        free(pmapping);
-
-        if (NULL == ranks) {
-            error = "could not get PMI_process_mapping";
-            goto error;
-        }
-    }
-#else
-    /* get our local proc info to find our local rank */
-    if (PMI_SUCCESS != (ret = PMI_Get_clique_size(&procs))) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_clique_size");
-        error = "could not get PMI clique size";
+    if (NULL == (ranks = mca_common_pmi_local_ranks(ORTE_PROC_MY_NAME->vpid, &procs))) {
+        error = "could not get local ranks";
         goto error;
     }
-    /* now get the specific ranks */
-    ranks = (int*)calloc(procs, sizeof(int));
-    if (NULL == ranks) {
-        error = "could not get memory for local ranks";
-        ret = ORTE_ERR_OUT_OF_RESOURCE;
-        goto error;
-    }
-    if (PMI_SUCCESS != (ret = PMI_Get_clique_ranks(ranks, procs))) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_clique_ranks");
-        error = "could not get clique ranks";
-        goto error;
-    }
-#endif
     /* store the number of local peers - remember, we want the number
      * of peers that share the node WITH ME, so we have to subtract
      * ourselves from that number

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -67,7 +67,6 @@
 #include "orte/mca/ess/ess.h"
 #include "orte/mca/ess/base/base.h"
 #include "orte/mca/ess/pmi/ess_pmi.h"
-#include "orte/mca/grpcomm/pmi/grpcomm_pmi.h"
 
 static int rte_init(void);
 static int rte_finalize(void);
@@ -278,7 +277,7 @@ static int rte_init(void)
             goto error;
         }
 
-        ranks = orte_grpcomm_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &k, &procs);
+        ranks = mca_common_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &k, &procs);
         free(pmapping);
 
         if (NULL == ranks) {

--- a/orte/mca/grpcomm/pmi/Makefile.am
+++ b/orte/mca/grpcomm/pmi/Makefile.am
@@ -17,10 +17,6 @@ sources = \
 	grpcomm_pmi_module.c \
 	grpcomm_pmi_component.c
 
-if WANT_PMI2_SUPPORT
-sources += pmi2_pmap_parser.c
-endif
-
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
 # (for static builds).

--- a/orte/mca/grpcomm/pmi/grpcomm_pmi.h
+++ b/orte/mca/grpcomm/pmi/grpcomm_pmi.h
@@ -34,11 +34,6 @@ int orte_grpcomm_pmi_component_query(mca_base_module_t **module, int *priority);
 ORTE_MODULE_DECLSPEC extern orte_grpcomm_base_component_t mca_grpcomm_pmi_component;
 extern orte_grpcomm_base_module_t orte_grpcomm_pmi_module;
 
-#if WANT_PMI2_SUPPORT
-ORTE_MODULE_DECLSPEC int *orte_grpcomm_pmi2_parse_pmap(char *pmap, int my_rank,
-                                                       int *node, int *nlrs);
-#endif
-
 END_C_DECLS
 
 #endif

--- a/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
+++ b/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
@@ -156,51 +156,12 @@ static int modex(orte_grpcomm_collective_t *coll)
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
 
     /* discover the local ranks */
-#if WANT_PMI2_SUPPORT
-    {
-        char *pmapping = (char*)malloc(PMI2_MAX_VALLEN);
-        int found;
-        int my_node;
-
-        rc = PMI2_Info_GetJobAttr("PMI_process_mapping", pmapping, PMI2_MAX_VALLEN, &found);
-        if (!found || PMI_SUCCESS != rc) { /* can't check PMI2_SUCCESS as some folks (i.e., Cray) don't define it */
-            opal_output(0, "%s could not get PMI_process_mapping (PMI2_Info_GetJobAttr() failed)",
-                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-            return ORTE_ERROR;
-        }
-
-        local_ranks = mca_common_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &my_node, &local_rank_count);
-        if (NULL == local_ranks) {
-            opal_output(0, "%s could not get PMI_process_mapping",
-                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-            return ORTE_ERROR;
-        }
-
-        OPAL_OUTPUT_VERBOSE((1, orte_grpcomm_base_framework.framework_output,
-                "%s: pmapping: %s my_node=%d lr_count=%d\n",
-                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), pmapping, my_node, local_rank_count));
-       
-        free(pmapping);
+    if (NULL == (local_ranks = mca_common_pmi_local_ranks(ORTE_PROC_MY_NAME->vpid,
+                                                          &local_rank_count))) {
+        opal_output(0, "%s could not get local ranks",
+                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+        return ORTE_ERROR;
     }
-#else
-    rc = PMI_Get_clique_size (&local_rank_count);
-    if (PMI_SUCCESS != rc) {
-	ORTE_ERROR_LOG(ORTE_ERROR);
-	return ORTE_ERROR;
-    }
-
-    local_ranks = calloc (local_rank_count, sizeof (int));
-    if (NULL == local_ranks) {
-	ORTE_ERROR_LOG(ORTE_ERR_OUT_OF_RESOURCE);
-	return ORTE_ERR_OUT_OF_RESOURCE;
-    }
-
-    rc = PMI_Get_clique_ranks (local_ranks, local_rank_count);
-    if (PMI_SUCCESS != rc) {
-	ORTE_ERROR_LOG(ORTE_ERROR);
-	return ORTE_ERROR;
-    }
-#endif
 
 
     /* our RTE data was constructed and pushed in the ESS pmi component */

--- a/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
+++ b/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
@@ -169,7 +169,7 @@ static int modex(orte_grpcomm_collective_t *coll)
             return ORTE_ERROR;
         }
 
-        local_ranks = orte_grpcomm_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &my_node, &local_rank_count);
+        local_ranks = mca_common_pmi2_parse_pmap(pmapping, ORTE_PROC_MY_NAME->vpid, &my_node, &local_rank_count);
         if (NULL == local_ranks) {
             opal_output(0, "%s could not get PMI_process_mapping",
                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));


### PR DESCRIPTION
This fixes launching of openmpi-1.8 with mxm or sm in cases of
unpopulated nodes like this :

```
$ srun  -N2 -n7  --cpu_bind=core -m block --mpi=pmi2 -K ./IMB-MPI1 Pingpong
[btp19:24155] Error: mtl_mxm.c:310 - ompi_mtl_mxm_module_init() Unable to obtain local node rank
[btp19:24157] Error: mtl_mxm.c:310 - ompi_mtl_mxm_module_init() Unable to obtain local node rank
--------------------------------------------------------------------------
WARNING: Missing locality information required for sm initialization.
Continuing without shared memory support.
--------------------------------------------------------------------------
[...]
```

Here mxm and sm need the local/node rank, whose parsing in ess/pmi is
buggy when Slurm gives process mapping vectors with an offset like
`(1,X,X)`. There is already a function that correctly reads Slurm's
process mapping in grpcomm/pmi/pmi2_pmap_parser.c.

I propose to fix the bug by reusing this pmap parsing function, and to
be a little bit prettier in the 2nd commit I move this common function
to opal/mca/common/pmi.

If this seems okay to you, the pmi process mapping query code could be
factorised even further in a `mca_common_pmapping()` function.
