### PR TITLE
v1.8: fix ompi_timing which is using vpid before it is set

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -436,7 +436,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
         mca_base_var_set_value(ret, allvalue, 4, MCA_BASE_VAR_SOURCE_DEFAULT, NULL);
     }
 
-    if (ompi_enable_timing && 0 == OMPI_PROC_MY_NAME->vpid) {
+    if (ompi_enable_timing) {
         gettimeofday(&ompistart, NULL);
     }
 


### PR DESCRIPTION
In v1.8, the ompi_timing "from start to completion of rte_init" gives dummy values as the start time is not measured: rte is not initialized yet at this point so `OMPI_PROC_MY_NAME->vpid` has not been set to 0.

In master the timing is done differently so this does not apply.
