### PR TITLE
v1.10 openib updates from master

### DIFF
--- a/ompi/mca/btl/openib/btl_openib_component.c
+++ b/ompi/mca/btl/openib/btl_openib_component.c
@@ -2509,11 +2509,6 @@ btl_openib_component_init(int *num_btl_modules,
         goto no_btls;
     }
 
-    /* Init CPC components */
-    if (OMPI_SUCCESS != (ret = ompi_btl_openib_connect_base_init())) {
-        goto no_btls;
-    }
-
     /* If we are using ptmalloc2 and there are no posix threads
        available, this will cause memory corruption.  Refuse to run.
        Right now, ptmalloc2 is the only memory manager that we have on
@@ -2776,6 +2771,12 @@ btl_openib_component_init(int *num_btl_modules,
                            "no active ports found", true, 
                            ompi_process_info.nodename);
         }
+        goto no_btls;
+    }
+
+    /* Now that we know we have devices and ports that we want to use,
+       init CPC components */
+    if (OPAL_SUCCESS != (ret = opal_btl_openib_connect_base_init())) {
         goto no_btls;
     }
 

--- a/ompi/mca/btl/openib/btl_openib_component.c
+++ b/ompi/mca/btl/openib/btl_openib_component.c
@@ -1576,7 +1576,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
     /* Open up the device */
     dev_context = ibv_open_device(ib_dev);
     if (NULL == dev_context) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
+        return OMPI_ERR_NOT_SUPPORTED;
     }
 
     /* Find out if this device supports RC QPs */
@@ -2732,7 +2732,10 @@ btl_openib_component_init(int *num_btl_modules,
 
         found = true;
         ret = init_one_device(&btl_list, dev_sorted[i].ib_dev);
-        if (OMPI_SUCCESS != ret && OMPI_ERR_NOT_SUPPORTED != ret) {
+        if (OMPI_ERR_NOT_SUPPORTED == ret) {
+            ++num_devices_intentionally_ignored;
+            continue;
+        } else if (OPAL_SUCCESS != ret) {
             free(dev_sorted);
             goto no_btls;
         }
@@ -2776,7 +2779,7 @@ btl_openib_component_init(int *num_btl_modules,
 
     /* Now that we know we have devices and ports that we want to use,
        init CPC components */
-    if (OPAL_SUCCESS != (ret = opal_btl_openib_connect_base_init())) {
+    if (OMPI_SUCCESS != (ret = ompi_btl_openib_connect_base_init())) {
         goto no_btls;
     }
 


### PR DESCRIPTION
Bring over 2 changes that make openib not complain about usnic verbs kernel devices.
- open-mpi/ompi@76222f462ec19fb43606300ca5c7c6bc6c86657b
- open-mpi/ompi@df6f7597a4ef6a422404a54f43a5e79eab6b59a1

@hjelmn please review
