### PR TITLE
Correct the way we handle binding to objects during comm_spawn

### DIFF
--- a/orte/mca/plm/base/plm_base_receive.c
+++ b/orte/mca/plm/base/plm_base_receive.c
@@ -218,7 +218,9 @@ void orte_plm_base_recv(int status, orte_process_name_t* sender,
         } else {
             jdata->bookmark = parent->bookmark;
         }
-
+        /* provide the parent's last object */
+        jdata->bkmark_obj = parent->bkmark_obj;
+        
         /* launch it */
         OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
                              "%s plm:base:receive calling spawn",

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -496,6 +496,11 @@ int orte_rmaps_rr_byobj(orte_job_t *jdata,
             if (0 == nobjs) {
                 continue;
             }
+            /* if this is a comm_spawn situation, start with the object
+             * where the parent left off and increment */
+            if (ORTE_JOBID_INVALID != jdata->originator.jobid) {
+                start = (jdata->bkmark_obj + 1) % nobjs;
+            }
             /* compute the number of procs to go on this node */
             nprocs = (node->slots - node->slots_inuse) / orte_rmaps_base.cpus_per_rank;
             if (nprocs < 1) {
@@ -553,6 +558,7 @@ int orte_rmaps_rr_byobj(orte_job_t *jdata,
                     nprocs_mapped++;
                     nmapped++;
                     proc->locale = obj;
+                    jdata->bkmark_obj = i;
                 }
             } while (nmapped < nprocs && nprocs_mapped < (int)app->num_procs);
             add_one = true;

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -717,6 +717,7 @@ static void orte_job_construct(orte_job_t* job)
                             ORTE_GLOBAL_ARRAY_BLOCK_SIZE);
     job->map = NULL;
     job->bookmark = NULL;
+    job->bkmark_obj = 0;
     job->state = ORTE_JOB_STATE_UNDEF;
     job->restart = false;
 

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -422,6 +422,9 @@ typedef struct {
      * indicates the node where we stopped
      */
     orte_node_t *bookmark;
+    /* if we are binding, bookmark the index of the
+     * last object we bound to */
+    unsigned int bkmark_obj;
     /* state of the overall job */
     orte_job_state_t state;
     /* some procs in this job are being restarted */


### PR DESCRIPTION
For comm-spawned jobs that are mapping/binding by a given object type, track where we are so a request doesn't overload when it shouldn't

Cherry-picked from open-mpi/ompi@869b2891c4e5d4a9c29a3ea270aab4b059525ae0

@hppritcha please review
