### PR TITLE
README: OMPI needs a C99 compiler to build

### DIFF
--- a/README
+++ b/README
@@ -143,6 +143,8 @@ General notes
 Compiler Notes
 --------------
 
+- Open MPI requires a C99-capable compiler to build.
+
 - Mixing compilers from different vendors when building Open MPI
   (e.g., using the C/C++ compiler from one vendor and the Fortran
   compiler from a different vendor) has been successfully employed by


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@dc9932a7861259a555b1c5e96558cdc2a1b30eba)
