### PR TITLE
Fix definition of MPI_T_pvar_get_index

### DIFF
--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -110,6 +110,8 @@ ompi_mpi_errcode_t ompi_err_rma_range;
 ompi_mpi_errcode_t ompi_err_rma_attach;
 ompi_mpi_errcode_t ompi_err_rma_flavor;
 ompi_mpi_errcode_t ompi_err_rma_shared;
+ompi_mpi_errcode_t ompi_t_err_invalid;
+ompi_mpi_errcode_t ompi_t_err_invalid_name;
 
 static void ompi_mpi_errcode_construct(ompi_mpi_errcode_t* errcode);
 static void ompi_mpi_errcode_destruct(ompi_mpi_errcode_t* errcode);
@@ -209,6 +211,8 @@ int ompi_mpi_errcode_init (void)
     CONSTRUCT_ERRCODE( ompi_err_rma_attach, MPI_ERR_RMA_ATTACH, "MPI_ERR_RMA_ATTACH: Could not attach RMA segment" );
     CONSTRUCT_ERRCODE( ompi_err_rma_flavor, MPI_ERR_RMA_FLAVOR, "MPI_ERR_RMA_FLAVOR: Invalid type of window" );
     CONSTRUCT_ERRCODE( ompi_err_rma_shared, MPI_ERR_RMA_SHARED, "MPI_ERR_RMA_SHARED: Memory cannot be shared" );
+    CONSTRUCT_ERRCODE( ompi_t_err_invalid, MPI_T_ERR_INVALID, "MPI_T_ERR_INVALID: Invalid use of the interface or bad parameter value(s)" );
+    CONSTRUCT_ERRCODE( ompi_t_err_invalid_name, MPI_T_ERR_INVALID_NAME, "MPI_T_ERR_INVALID_NAME: The variable or category name is invalid" );
 
     /* Per MPI-3 p353:27-32, MPI_LASTUSEDCODE must be >= 
        MPI_ERR_LASTCODE.  So just start it as == MPI_ERR_LASTCODE. */ 
@@ -303,6 +307,8 @@ int ompi_mpi_errcode_finalize(void)
     OBJ_DESTRUCT(&ompi_err_rma_attach);
     OBJ_DESTRUCT(&ompi_err_rma_flavor);
     OBJ_DESTRUCT(&ompi_err_rma_shared);
+    OBJ_DESTRUCT(&ompi_t_err_invalid);
+    OBJ_DESTRUCT(&ompi_t_err_invalid_name);
 
     OBJ_DESTRUCT(&ompi_mpi_errcodes);
     return OMPI_SUCCESS;

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -601,11 +601,13 @@ enum {
 #define MPI_ERR_RMA_ATTACH            69
 #define MPI_ERR_RMA_FLAVOR            70
 #define MPI_ERR_RMA_SHARED            71
+#define MPI_T_ERR_INVALID             72
+#define MPI_T_ERR_INVALID_NAME        73
 
 /* Per MPI-3 p349 47, MPI_ERR_LASTCODE must be >= the last predefined
-   MPI_ERR_<foo> code.  So just set it equal to the last code --
-   MPI_ERR_RMA_SHARED, in this case. */
-#define MPI_ERR_LASTCODE              MPI_ERR_RMA_SHARED
+   MPI_ERR_<foo> code. Set the last code to allow some room for adding
+   error codes without breaking ABI. */
+#define MPI_ERR_LASTCODE              92
 
 #define MPI_ERR_SYSRESOURCE          -2
 
@@ -2577,7 +2579,7 @@ OMPI_DECLSPEC  int PMPI_T_pvar_get_info(int pvar_index, char *name, int *name_le
                                         int *verbosity, int *var_class, MPI_Datatype *datatype,
                                         MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind,
                                         int *readonly, int *continuous, int *atomic);
-OMPI_DECLSPEC  int PMPI_T_pvar_get_index (const char *name, int *pvar_index);
+OMPI_DECLSPEC  int PMPI_T_pvar_get_index (const char *name, int var_class, int *pvar_index);
 OMPI_DECLSPEC  int PMPI_T_pvar_session_create(MPI_T_pvar_session *session);
 OMPI_DECLSPEC  int PMPI_T_pvar_session_free(MPI_T_pvar_session *session);
 OMPI_DECLSPEC  int PMPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index,
@@ -2627,7 +2629,7 @@ OMPI_DECLSPEC  int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len
                                        int *verbosity, int *var_class, MPI_Datatype *datatype,
                                        MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind,
                                        int *readonly, int *continuous, int *atomic);
-OMPI_DECLSPEC  int MPI_T_pvar_get_index (const char *name, int *pvar_index);
+OMPI_DECLSPEC  int MPI_T_pvar_get_index (const char *name, int var_class, int *pvar_index);
 OMPI_DECLSPEC  int MPI_T_pvar_session_create(MPI_T_pvar_session *session);
 OMPI_DECLSPEC  int MPI_T_pvar_session_free(MPI_T_pvar_session *session);
 OMPI_DECLSPEC  int MPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index,

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -305,27 +305,11 @@ $constants->{MPI_ERR_SPAWN} = 50;
 $constants->{MPI_ERR_UNSUPPORTED_DATAREP} = 51;
 $constants->{MPI_ERR_UNSUPPORTED_OPERATION} = 52;
 $constants->{MPI_ERR_WIN} = 53;
-# these error codes will never be returned by a fortran function
-# since there are no fortran bindings for MPI_T
-$constants->{MPI_T_ERR_MEMORY} = 54;
-$constants->{MPI_T_ERR_NOT_INITIALIZED} = 55;
-$constants->{MPI_T_ERR_CANNOT_INIT} = 56;
-$constants->{MPI_T_ERR_INVALID_INDEX} = 57;
-$constants->{MPI_T_ERR_INVALID_ITEM} = 58;
-$constants->{MPI_T_ERR_INVALID_HANDLE} = 59;
-$constants->{MPI_T_ERR_OUT_OF_HANDLES} = 60;
-$constants->{MPI_T_ERR_OUT_OF_SESSIONS} = 61;
-$constants->{MPI_T_ERR_INVALID_SESSION} = 62;
-$constants->{MPI_T_ERR_CVAR_SET_NOT_NOW} = 63;
-$constants->{MPI_T_ERR_CVAR_SET_NEVER} = 64;
-$constants->{MPI_T_ERR_PVAR_NO_STARTSTOP} = 65;
-$constants->{MPI_T_ERR_PVAR_NO_WRITE} = 66;
-$constants->{MPI_T_ERR_PVAR_NO_ATOMIC} = 67;
 $constants->{MPI_ERR_RMA_RANGE} = 68;
 $constants->{MPI_ERR_RMA_ATTACH} = 69;
 $constants->{MPI_ERR_RMA_FLAVOR} = 70;
 $constants->{MPI_ERR_RMA_SHARED} = 71;
-$constants->{MPI_ERR_LASTCODE} = $constants->{MPI_ERR_RMA_SHARED};
+$constants->{MPI_ERR_LASTCODE} = 92;
 
 $constants->{MPI_ERR_SYSRESOURCE} = -2;
 

--- a/ompi/mpi/tool/category_get_index.c
+++ b/ompi/mpi/tool/category_get_index.c
@@ -36,6 +36,9 @@ int MPI_T_category_get_index (const char *name, int *category_index)
     mpit_lock ();
     ret = mca_base_var_group_find_by_name (name, category_index);
     mpit_unlock ();
+    if (OPAL_SUCCESS != ret) {
+        return MPI_T_ERR_INVALID_NAME;
+    }
 
-    return ompit_opal_to_mpit_error (ret);
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/cvar_get_index.c
+++ b/ompi/mpi/tool/cvar_get_index.c
@@ -36,6 +36,9 @@ int MPI_T_cvar_get_index (const char *name, int *cvar_index)
     mpit_lock ();
     ret = mca_base_var_find_by_name (name, cvar_index);
     mpit_unlock ();
+    if (OPAL_SUCCESS != ret) {
+        return MPI_T_ERR_INVALID_NAME;
+    }
 
-    return ompit_opal_to_mpit_error (ret);
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -32,6 +32,10 @@ void mpit_unlock (void)
 
 int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype)
 {
+    if (!datatype) {
+        return OMPI_SUCCESS;
+    }
+
     switch (type) {
     case MCA_BASE_VAR_TYPE_INT:
         *datatype = MPI_INT;

--- a/ompi/mpi/tool/pvar_get_index.c
+++ b/ompi/mpi/tool/pvar_get_index.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -21,7 +21,7 @@
 #endif
 
 
-int MPI_T_pvar_get_index (const char *name, int *pvar_index)
+int MPI_T_pvar_get_index (const char *name, int var_class, int *pvar_index)
 {
     int ret;
 
@@ -34,8 +34,11 @@ int MPI_T_pvar_get_index (const char *name, int *pvar_index)
     }
 
     mpit_lock ();
-    ret = mca_base_pvar_find_by_name (name, pvar_index);
+    ret = mca_base_pvar_find_by_name (name, var_class, pvar_index);
     mpit_unlock ();
+    if (OPAL_SUCCESS != ret) {
+        return MPI_T_ERR_INVALID_NAME;
+    }
 
-    return ompit_opal_to_mpit_error (ret);
+    return MPI_SUCCESS;
 }

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -75,7 +75,7 @@ int mca_base_pvar_find (const char *project, const char *framework, const char *
         return OPAL_ERROR;
     }
 
-    ret = mca_base_pvar_find_by_name (full_name, &index);
+    ret = mca_base_pvar_find_by_name (full_name, MCA_BASE_PVAR_CLASS_ANY, &index);
     free (full_name);
 
     /* NTH: should we verify the name components match the returned variable? */
@@ -83,8 +83,9 @@ int mca_base_pvar_find (const char *project, const char *framework, const char *
     return (OPAL_SUCCESS != ret) ? ret : index;
 }
 
-int mca_base_pvar_find_by_name (const char *full_name, int *index)
+int mca_base_pvar_find_by_name (const char *full_name, int var_class, int *index)
 {
+    mca_base_pvar_t *pvar;
     void *tmp;
     int rc;
 
@@ -92,6 +93,15 @@ int mca_base_pvar_find_by_name (const char *full_name, int *index)
                                         &tmp);
     if (OPAL_SUCCESS != rc) {
         return rc;
+    }
+
+    rc = mca_base_pvar_get_internal ((int)(uintptr_t) tmp, &pvar, false);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    if (MCA_BASE_PVAR_CLASS_ANY != var_class && pvar->var_class != var_class) {
+        return OPAL_ERR_NOT_FOUND;
     }
 
     *index = (int)(uintptr_t) tmp;

--- a/opal/mca/base/mca_base_pvar.h
+++ b/opal/mca/base/mca_base_pvar.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * Additional copyrights may follow
@@ -90,6 +90,8 @@ enum {
     /** Variable doesn't fit any other class */
     MCA_BASE_PVAR_CLASS_GENERIC
 };
+
+#define MCA_BASE_PVAR_CLASS_ANY -1
 
 /*
  * Reserved bindings; passed when registering a new pvar. OMPI will
@@ -356,7 +358,7 @@ OPAL_DECLSPEC int mca_base_pvar_find (const char *project, const char *framework
  *
  * See mca_base_pvar_find().
  */
-OPAL_DECLSPEC int mca_base_pvar_find_by_name (const char *full_name, int *index);
+OPAL_DECLSPEC int mca_base_pvar_find_by_name (const char *full_name, int var_class, int *index);
 
 /****************************************************************************
  * The following functions are the back-end to the MPI_T API functions


### PR DESCRIPTION
The definition of MPI_T_pvar_get_index was incorrect. This commit
fixes the definition and adds a missing return code. Also remove
all MPI_T error codes from mpif.h. They will never be returned in
fortran.

master commit open-mpi/ompi@e561f150d61a483ff251868191c47b88aea2fd14

Signed-off-by: Nathan Hjelm hjelmn@me.com
