### PR TITLE
errcode.h: fix typo: errnum, not errno

### DIFF
--- a/ompi/errhandler/errcode.h
+++ b/ompi/errhandler/errcode.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
- * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -98,7 +98,7 @@ static inline int ompi_mpi_errnum_is_class ( int errnum )
 {
     ompi_mpi_errcode_t *err;
 
-    if (errno < 0) {
+    if (errnum < 0) {
         return false;
     }
 


### PR DESCRIPTION
Thanks to Åke Sandgren (@akesandgren) for pointing out the error.

Reviewed by @jsquyres

(cherry picked from commit open-mpi/ompi@91d3b5f55517b4aa67dd311f6eb4db377d355fdf)
