### PR TITLE
mpiext/affinity: #if OPAL_HAVE_HWLOC most parts of the code

### DIFF
--- a/ompi/mpiext/affinity/c/Makefile.am
+++ b/ompi/mpiext/affinity/c/Makefile.am
@@ -48,3 +48,6 @@ nodist_man_MANS = OMPI_Affinity_str.3
 
 # Man page sources
 EXTRA_DIST = $(nodist_man_MANS:.3=.3in) example.c
+
+distclean-local:
+	rm -f $(nodist_man_MANS)


### PR DESCRIPTION
that allow this extension to compile if configure'd with --without-hwloc

(cherry picked from commit open-mpi/ompi@6994d742fdd6ed9e3407929416dca0ec0b941588)
(cherry picked from commit open-mpi/ompi@f6882a85bbc1ee0ab347f31a838e5936e025bff9)
(cherry picked from commit open-mpi/ompi@a4cc83f4f769f006aa374931befd77a083e13352)
