### PR TITLE
fix uninitizalized variable in pmi2 modex

### DIFF
--- a/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
+++ b/orte/mca/grpcomm/pmi/grpcomm_pmi_module.c
@@ -149,7 +149,7 @@ static int modex(orte_grpcomm_collective_t *coll)
     orte_process_name_t name;
     orte_vpid_t v;
     bool local;
-    int rc, i;
+    int rc=ORTE_SUCCESS, i;
 
     OPAL_OUTPUT_VERBOSE((1, orte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:pmi: modex entered",


### PR DESCRIPTION
When openmpi-1.8 is compiled with `icc -O2` (it is ok with gcc), this
uninitialized variable causes modex to fail when only one task is run
like `srun -n1 hello`:

```
salloc -N1 -n1 srun  ~/src/mpi/mpi_hello
salloc: Granted job allocation 5740
--------------------------------------------------------------------------
It looks like MPI_INIT failed for some reason; your parallel process is
likely to abort.  There are many reasons that a parallel process can
fail during MPI_INIT; some of which are due to configuration or environment
problems.  This failure appears to be an internal failure; here's some
additional information (which may only be relevant to an Open MPI
developer):

  rte_modex failed
  --> Returned "(null)" (1575010904) instead of "Success" (0)
--------------------------------------------------------------------------
*** An error occurred in MPI_Init
*** on a NULL communicator
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
***    and potentially your MPI job)
```
