### PR TITLE
Fix PGI compilation of opal_condition test

### DIFF
--- a/test/threads/opal_condition.c
+++ b/test/threads/opal_condition.c
@@ -29,25 +29,9 @@
 #include "opal/threads/condition.h"
 #include "opal/sys/atomic.h"
 
-
-#if !OPAL_ENABLE_MULTI_THREADS
-
-/* If we don't have thread support, there's no point in running this
-   test */
-
-int main(int argc, char *argv[])
-{
-    printf("OMPI was compiled without thread support -- skipping this test\n");
-    return 77;
-}
-
-#else
-
-/* Only have the body of this test if we have thread support */
-
-opal_mutex_t mutex = {};
-opal_condition_t thr1_cond = {};
-opal_condition_t thr2_cond = {};
+static opal_mutex_t mutex;
+static opal_condition_t thr1_cond;
+static opal_condition_t thr2_cond;
 
 static volatile int thr1_count = 0;
 static volatile int thr2_count = 0;
@@ -134,5 +118,3 @@ int main(int argc, char** argv)
 
     return test_finalize();
 }
-
-#endif /* OPAL_ENABLE_MULTI_THREADS */


### PR DESCRIPTION
PGI was failing to build this test due to the {} initializers of some
of the global variables. The initializers were added to remove common
symbols from the test repository. This commit removes the initializers
and makes the variables static which should fix both the compile issue
and avoid the common symbols.

This commit additionally removes the check for
OPAL_ENABLE_MULTI_THREADS since Open MPI requires thread support.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
