### PR TITLE
Fix compile error in fork code

### DIFF
--- a/ompi/mca/btl/openib/btl_openib_mca.c
+++ b/ompi/mca/btl/openib/btl_openib_mca.c
@@ -34,6 +34,7 @@
 #include "opal/util/os_dirpath.h"
 #include "opal/util/output.h"
 #include "opal/util/show_help.h"
+#include "ompi/mca/common/verbs/common_verbs.h"
 #include "btl_openib.h"
 #include "btl_openib_mca.h"
 #include "btl_openib_ini.h"
@@ -807,13 +808,10 @@ int btl_openib_verify_mca_params (void)
      * fork support, then turn it off in the presence of GDR.  */
     if (mca_btl_openib_component.cuda_want_gdr && mca_btl_openib_component.cuda_have_gdr &&
         mca_btl_openib_component.driver_have_gdr) {
-        if (1 == mca_btl_openib_component.want_fork_support) {
+        if (1 == ompi_common_verbs_want_fork_support) {
               opal_show_help("help-mpi-btl-openib.txt", "no_fork_with_gdr",
                              true, ompi_process_info.nodename);
               return OMPI_ERR_BAD_PARAM;
-        }
-        if (-1 == mca_btl_openib_component.want_fork_support) {
-            mca_btl_openib_component.want_fork_support = 0;
         }
     }
 #endif


### PR DESCRIPTION
When the fork init code was brought to v1.10, a few pieces were missed.  This should fix the CUDA-aware compile errors.
