### PR TITLE
usnic: fix wrappers for static builds

### DIFF
--- a/ompi/mca/btl/usnic/configure.m4
+++ b/ompi/mca/btl/usnic/configure.m4
@@ -111,7 +111,9 @@ AC_DEFUN([_OMPI_BTL_USNIC_DO_CONFIG],[
 
     # All done
     AS_IF([test "$ompi_btl_usnic_happy" = "yes"],
-          [$1],
+          [$1
+           btl_usnic_WRAPPER_EXTRA_LDFLAGS=$ompi_btl_usnic_LDFLAGS
+           btl_usnic_WRAPPER_EXTRA_LIBS=$ompi_btl_usnic_LIBS],
           [AS_IF([test "$with_usnic" = "yes"],
                  [AC_MSG_WARN([--with-usnic was specified, but Cisco usNIC support cannot be built])
                   AC_MSG_ERROR([Cannot continue])],


### PR DESCRIPTION
Ensure to pass the relevant WRAPPER_EXTRA flags so that wrappers will use them for static builds (i.e., so that "-lfabric" and friends will be added to the wrappers).

@rhc54 Please review (it's a simple configury issue)
