### PR TITLE
libfabric: fix wrappers for static builds

### DIFF
--- a/opal/mca/common/libfabric/configure.m4
+++ b/opal/mca/common/libfabric/configure.m4
@@ -5,6 +5,7 @@
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -12,18 +13,16 @@
 # $HEADER$
 #
 
-#
-# If LIBFABRIC support was requested, then build the LIBFABRIC support library.
-# This code checks just makes sure the check was done earlier by the
-# opal_check_libfabric.m4 code.
-#
-
 AC_DEFUN([MCA_opal_common_libfabric_CONFIG],[
     AC_CONFIG_FILES([opal/mca/common/libfabric/Makefile])
 
-    # check for libfabric request
+    # Check for libfabric.  Note that $opal_common_libfabric_happy is
+    # used in other configure.m4's to know if libfabric configured
+    # successfully.
     OPAL_CHECK_LIBFABRIC([opal_common_libfabric],
                          [opal_common_libfabric_happy=yes
+                          common_libfabric_WRAPPER_EXTRA_LDFLAGS=$opal_common_libfabric_LDFLAGS
+                          common_libfabric_WRAPPER_EXTRA_LIBS=$opal_common_libfabric_LIBS
                           $1],
                          [opal_common_libfabric_happy=no
                           $2])


### PR DESCRIPTION
Need to set the WRAPPER_EXTRA flags so that the wrappers for static builds pull in -lfabric.

Also update/fix some comments.

(cherry picked from commit open-mpi/ompi@f1353947ffd0f1f395e3b90ce33fe28eb60f105f)

@yburette Please review
