### PR TITLE
fix NBC_Copy for legitimate zero size messages

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -9,6 +9,8 @@
  *
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  */
 #ifndef __NBC_INTERNAL_H__
@@ -501,7 +503,10 @@ static inline int NBC_Copy(void *src, int srccount, MPI_Datatype srctype, void *
   } else {
     /* we have to pack and unpack */
     res = MPI_Pack_size(srccount, srctype, comm, &size);
-    if (MPI_SUCCESS != res || 0 == size) { printf("MPI Error in MPI_Pack_size() (%i:%i)\n", res, size); return (MPI_SUCCESS == res) ? MPI_ERR_SIZE : res;}
+    if (MPI_SUCCESS != res) { printf("MPI Error in MPI_Pack_size() (%i:%i)\n", res, size); return (MPI_SUCCESS == res) ? MPI_ERR_SIZE : res; }
+    if (0 == size) {
+        return NBC_OK;
+    }
     packbuf = malloc(size);
     if (NULL == packbuf) { printf("Error in malloc()\n"); return res; }
     pos=0;


### PR DESCRIPTION
this fixes a regression from open-mpi/ompi@9a70765f27fdf17e70e1a115754fef7e5f16132a

(back-ported from commit open-mpi/ompi@0bd765eddd33e3d4ac18ec644c60a5c160cb48dc)
