### PR TITLE
v1.8: mpi_f08: move the f08 version of buffer_detach to use-mpi-f08

### DIFF
--- a/ompi/mpi/fortran/mpif-h/buffer_detach_f.c
+++ b/ompi/mpi/fortran/mpif-h/buffer_detach_f.c
@@ -65,17 +65,25 @@ OMPI_GENERATE_F77_BINDINGS (MPI_BUFFER_DETACH,
 #include "ompi/mpi/fortran/mpif-h/profile/defines.h"
 #endif
 
+/* (this comment is repeated in ompi/mpi/fortran/use-mpi-f08/buffer_detach.c)
+ *
+ * MPI-3.1 section 3.6, page 45, states that the mpif.h and mpi module
+ * interfaces for MPI_BUFFER_DETACH ignore the buffer argument.
+ * Therefore, for the mpif.h and mpi module interfaces, we use a dummy
+ * variable and leave the value handed in alone.
+ *
+ * The mpi_f08 implementation for MPI_BUFFER_DETACH therefore is a
+ * separate routine in the use-mpi-f08 directory (it's not built in
+ * the mpif-h directory because of all the different combinations of
+ * supporting weak symbols (or not), building the profiling layer (or
+ * not), etc.).
+ */
 void ompi_buffer_detach_f(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
 {
-    /* 
-     * It does not make sense in fortran to return a pointer
-     * here as the user may get a behavior that is unexpected.
-     * Therefore, we use a dummy variable and leave the value
-     * handed in alone.
-     */
     int c_ierr;
     void *dummy;
     OMPI_SINGLE_NAME_DECL(size);
+
     c_ierr = MPI_Buffer_detach(&dummy, OMPI_SINGLE_NAME_CONVERT(size));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -101,6 +101,7 @@ mpi_api_files = \
         bcast_f08.F90 \
         bsend_f08.F90 \
         bsend_init_f08.F90 \
+        buffer_detach.c \
         buffer_attach_f08.F90 \
         buffer_detach_f08.F90 \
         cancel_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "mpi.h"
+#include "ompi/mpi/fortran/base/fint_2_int.h"
+
+/*
+ * This function implemented in this file is only called from Fortran,
+ * so we never bothered to put a prototype for it in any C header
+ * file.  To avoid compiler warnings about no protoype, we prototype
+ * it here.
+ */
+OMPI_DECLSPEC void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size,
+                                          MPI_Fint *ierr);
+
+/* (this comment is repeated in ompi/mpi/fortran/mpif-h/buffer_detach_f.c)
+ *
+ * MPI-3.1 section 3.6, page 45, states that the mpif.h and mpi module
+ * interfaces for MPI_BUFFER_DETACH ignore the buffer argument.
+ * Therefore, for the mpif.h and mpi module interfaces, we use a dummy
+ * variable and leave the value handed in alone.
+ *
+ * The mpi_f08 implementation for MPI_BUFFER_DETACH therefore is a
+ * separate routine in the use-mpi-f08 directory (it's not built in
+ * the mpif-h directory because of all the different combinations of
+ * supporting weak symbols (or not), building the profiling layer (or
+ * not), etc.).
+ *
+ * Note that we only need to build this function once -- the F08
+ * interfaces for MPI_BUFFER_ATTACH and PMPI_BUFFER_ATTACH both
+ * bind(C) to the name ompi_buffer_detach_f08.
+ */
+void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
+{
+    int c_ierr;
+    void *dummy;
+
+    c_ierr = MPI_Buffer_detach(&dummy, size);
+    if (NULL != ierr) {
+        *ierr = OMPI_INT_2_FINT(c_ierr);
+    }
+
+    if (MPI_SUCCESS == c_ierr) {
+        *(void **)buffer = dummy;
+    }
+}

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
@@ -53,13 +53,15 @@ void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
 {
     int c_ierr;
     void *dummy;
+    OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = MPI_Buffer_detach(&dummy, size);
+    c_ierr = MPI_Buffer_detach(&dummy, OMPI_SINGLE_NAME_CONVERT(size));
     if (NULL != ierr) {
         *ierr = OMPI_INT_2_FINT(c_ierr);
     }
 
     if (MPI_SUCCESS == c_ierr) {
+        OMPI_SINGLE_INT_2_FINT(size);
         *(void **)buffer = dummy;
     }
 }


### PR DESCRIPTION
@ggouaillardet was right -- we should have put the ompi_buffer_detach_f08() function in the use-mpi-f08 directory to begin with.  Putting it in the mpif-h directory made it complicated as to whether the function would be built or not (e.g., whether weak symbols were supported or not, whether the profiling layer was disabled or not, ...etc.).

Just put it in the use-mpi-f08 directory and always build it (when the mpi_f08 module is built, of course), and keep it simple.

(cherry picked from commit open-mpi/ompi@8ff60c47cc9b576346dc5c0a0ca214f813f92439)

@ggouaillardet please review
