### PR TITLE
Fix hetero operations. An error in the hwloc utilities only allocated…

### DIFF
--- a/orte/mca/ras/simulator/ras_sim.h
+++ b/orte/mca/ras/simulator/ras_sim.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -22,6 +23,7 @@ struct orte_ras_sim_component_t {
     char * slots;
     char * slots_max;
     char *topofiles;
+    char *topologies;
     bool have_cpubind;
     bool have_membind;
 };

--- a/orte/mca/ras/simulator/ras_sim_component.c
+++ b/orte/mca/ras/simulator/ras_sim_component.c
@@ -9,6 +9,9 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -97,6 +100,13 @@ static int ras_sim_register(void)
                                             OPAL_INFO_LVL_9,
                                             MCA_BASE_VAR_SCOPE_READONLY,
                                             &mca_ras_simulator_component.topofiles);
+    mca_ras_simulator_component.topologies = NULL;
+    (void) mca_base_component_var_register (component, "topologies",
+                                            "Comma-separated list of topology descriptions for simulated nodes",
+                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                            OPAL_INFO_LVL_9,
+                                            MCA_BASE_VAR_SCOPE_READONLY,
+                                            &mca_ras_simulator_component.topologies);
     mca_ras_simulator_component.have_cpubind = true;
     (void) mca_base_component_var_register (component, "have_cpubind",
                                             "Topology supports binding to cpus",

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -12,7 +12,9 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -94,7 +94,16 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
         nprocs = 0;
         for (i=0; i < jdata->apps->size; i++) {
             if (NULL != (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
-                nprocs += app->num_procs;
+                if (0 == app->num_procs) {
+                    opal_list_t nodes;
+                    orte_std_cntr_t slots;
+                    OBJ_CONSTRUCT(&nodes, opal_list_t);
+                    orte_rmaps_base_get_target_nodes(&nodes, &slots, app, ORTE_MAPPING_BYNODE, true, true);
+                    OPAL_LIST_DESTRUCT(&nodes);
+                    nprocs += slots;
+                } else {
+                    nprocs += app->num_procs;
+                }
             }
         }
         opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
@@ -114,20 +123,20 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                      * to byslot if nothing else was specified by the user.
                      */
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using byslot");
+                                        "mca:rmaps[%d] mapping not given - using byslot", __LINE__);
                     ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYSLOT);
                 } else if (opal_hwloc_use_hwthreads_as_cpus) {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using byhwthread");
+                                        "mca:rmaps[%d] mapping not given - using byhwthread", __LINE__);
                     ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYHWTHREAD);
                 } else {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using bycore");
+                                        "mca:rmaps[%d] mapping not given - using bycore", __LINE__);
                     ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYCORE);
                 }
             } else {
                 opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                    "mca:rmaps mapping not given - using bysocket");
+                                    "mca:rmaps[%d] mapping not given - using bysocket", __LINE__);
                 ORTE_SET_MAPPING_POLICY(map->mapping, ORTE_MAPPING_BYSOCKET);
             }
 #else
@@ -191,20 +200,20 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                      * to byslot if nothing else was specified by the user.
                      */
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using byslot");
+                                        "mca:rmaps[%d] mapping not given - using byslot", __LINE__);
                     ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYSLOT);
                 } else if (opal_hwloc_use_hwthreads_as_cpus) {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using byhwthread");
+                                        "mca:rmaps[%d] mapping not given - using byhwthread", __LINE__);
                     ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYHWTHREAD);
                 } else {
                     opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                        "mca:rmaps mapping not given - using bycore");
+                                        "mca:rmaps[%d] mapping not given - using bycore", __LINE__);
                     ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYCORE);
                 }
             } else {
                 opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
-                                    "mca:rmaps mapping not set by user - using bysocket");
+                                    "mca:rmaps[%d] mapping not set by user - using bysocket", __LINE__);
                 ORTE_SET_MAPPING_POLICY(jdata->map->mapping, ORTE_MAPPING_BYSOCKET);
             }
 #else
@@ -249,24 +258,38 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
             jdata->map->binding = opal_hwloc_binding_policy;
         } else {
             orte_mapping_policy_t mpol;
-            mpol = ORTE_GET_MAPPING_POLICY(orte_rmaps_base.mapping);
+            mpol = ORTE_GET_MAPPING_POLICY(jdata->map->mapping);
             /* if the user explicitly mapped-by some object, then we default
              * to binding to that object */
             if (ORTE_MAPPING_POLICY_IS_SET(jdata->map->mapping) &&
                 ORTE_MAPPING_BYBOARD < mpol && mpol < ORTE_MAPPING_BYSLOT) {
                 if (ORTE_MAPPING_BYHWTHREAD == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using byhwthread", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_HWTHREAD);
                 } else if (ORTE_MAPPING_BYCORE == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bycore", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
                 } else if (ORTE_MAPPING_BYL1CACHE == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using byl1cache", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_L1CACHE);
                 } else if (ORTE_MAPPING_BYL2CACHE == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using byl2cache", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_L2CACHE);
                 } else if (ORTE_MAPPING_BYL3CACHE == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using byl3cache", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_L3CACHE);
                 } else if (ORTE_MAPPING_BYSOCKET == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bysocket", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_SOCKET);
                 } else if (ORTE_MAPPING_BYNUMA == mpol) {
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bynuma", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 }
             } else if (ORTE_MAPPING_BYNODE == mpol || ORTE_MAPPING_BYBOARD == mpol) {
@@ -277,13 +300,19 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 if (1 < orte_rmaps_base.cpus_per_rank) {
                     /* assigning multiple cpus to a rank implies threading,
                      * so we only bind to the NUMA level */
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bynuma", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 } else {
                     if (opal_hwloc_use_hwthreads_as_cpus) {
                         /* if we are using hwthread cpus, then bind to those */
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using byhwthread", __LINE__);
                         OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_HWTHREAD);
                     } else {
                         /* for performance, bind to core */
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bycore", __LINE__);
                         OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_CORE);
                     }
                 }
@@ -291,9 +320,13 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 if (1 < orte_rmaps_base.cpus_per_rank) {
                     /* assigning multiple cpus to a rank implies threading,
                      * so we only bind to the NUMA level */
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bynuma", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NUMA);
                 } else {
                     /* for performance, bind to socket */
+                    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                                        "mca:rmaps[%d] binding not given - using bysocket", __LINE__);
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_SOCKET);
                 }
             }

--- a/orte/runtime/data_type_support/orte_dt_print_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_print_fns.c
@@ -495,7 +495,7 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
 
         if (NULL != src->locale) {
             if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(locale, sizeof(locale), src->node->topology, src->locale->cpuset)) {
-                strcpy(locale, "UNKNOWN");
+                strcpy(locale, "NODE");
             }
         } else {
             strcpy(locale, "UNKNOWN");


### PR DESCRIPTION
… memory for the first display of a binding map, and then assumed that all nodes had the same number of cores in them. This resulted in memory corruption whenever someone displayed a binding pattern for a hetero cluster, and a smaller node was first in line.

(cherry picked from commit open-mpi/ompi@ed93154e43ed7c7fdf09205c42922e1790a8a67c)

Add a bunch of debug, and correct an error that caused us to use the wrong mapping policy when determining the default binding policy

(cherry picked from commit open-mpi/ompi@7455802a36013053cedf31b299dd1acbf584dbf6)

@jsquyres lucky you :-)
