### PR TITLE
One word change from none to all - new default

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -38,7 +38,7 @@ AC_DEFUN([OMPI_EXT],[
     #
     AC_ARG_ENABLE(mpi-ext,
         AC_HELP_STRING([--enable-mpi-ext[=LIST]],
-                       [Comma-separated list of extensions that should be built.  Possible values: ompi_mpiext_list.  Example: "--enable-mpi-ext=foo,bar" will enable building the MPI extensions "foo" and "bar".  If LIST is empty or the special value "all", then all available MPI extensions will be built (default: none).]))
+                       [Comma-separated list of extensions that should be built.  Possible values: ompi_mpiext_list.  Example: "--enable-mpi-ext=foo,bar" will enable building the MPI extensions "foo" and "bar".  If LIST is empty or the special value "all", then all available MPI extensions will be built (default: all).]))
 
     # print some nice messages about what we're about to do...
     AC_MSG_CHECKING([for available MPI Extensions])


### PR DESCRIPTION
Jeff has already looked at in master but maybe one more time.

(cherry picked from commit open-mpi/ompi@f1fff56d743827b4fe2f1699fed8f52853dcc7e3)
