### PR TITLE
Bring cuda mpiext over to 2.x. They are ready.

### DIFF
--- a/ompi/mpiext/cuda/Makefile.am
+++ b/ompi/mpiext/cuda/Makefile.am
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This Makefile is not traversed during a normal "make all" in an OMPI
+# build.  It *is* traversed during "make dist", however.  So you can
+# put EXTRA_DIST targets in here.
+#
+# You can also use this as a convenience for building this MPI
+# extension (i.e., "make all" in this directory to invoke "make all"
+# in all the subdirectories).
+
+SUBDIRS = c
+
+EXTRA_DIST = README.txt

--- a/ompi/mpiext/cuda/README.txt
+++ b/ompi/mpiext/cuda/README.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2015      NVIDIA, Inc.  All rights reserved.
+
+$COPYRIGHT$
+
+Rolf vandeVaart
+
+
+This extension provides a macro for compile time check of CUDA aware support. 
+It also provides a function for runtime check of CUDA aware support.
+
+See MPIX_Query_cuda_support(3) for more details.

--- a/ompi/mpiext/cuda/c/MPIX_Query_cuda_support.3in
+++ b/ompi/mpiext/cuda/c/MPIX_Query_cuda_support.3in
@@ -1,0 +1,34 @@
+.\" Copyright 2007-2010 Oracle and/or its affiliates.  All rights reserved.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2015 NVIDIA, Inc. All rights reserved.
+.TH MPIx_CUDA_SUPPORT 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPIX_Query_cuda_support\fP \- Returns 1 if there is CUDA aware support and 0 if there is not.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+#include <mpi-ext.h>
+
+int MPIX_Query_cuda_support(void)
+.fi
+.SH Fortran Syntax
+There is no Fortran binding for this function.
+.
+.SH C++ Syntax
+There is no C++ binding for this function.
+.
+.SH DESCRIPTION
+.ft R
+
+.SH Examples
+.ft R
+
+.SH See Also
+.ft R
+.nf
+
+.fi

--- a/ompi/mpiext/cuda/c/Makefile.am
+++ b/ompi/mpiext/cuda/c/Makefile.am
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This file builds the C bindings for MPI extensions.  It must be
+# present in all MPI extensions.
+
+# We must set these #defines so that the inner OMPI MPI prototype
+# header files do the Right Thing.
+AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
+
+include $(top_srcdir)/Makefile.ompi-rules
+
+# Convenience libtool library that will be slurped up into libmpi.la.
+noinst_LTLIBRARIES = libmpiext_cuda_c.la
+
+# This is where the top-level header file (that is included in
+# <mpi-ext.h>) must be installed.
+ompidir = $(ompiincludedir)/ompi/mpiext/cuda/c
+
+# This is the header file that is installed.
+ompi_HEADERS = mpiext_cuda_c.h
+
+# Sources for the convenience libtool library.  Other than the one
+# header file, all source files in the extension have no file naming
+# conventions.
+libmpiext_cuda_c_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_cuda.c
+libmpiext_cuda_c_la_LDFLAGS = -module -avoid-version
+
+# Man page installation
+nodist_man_MANS = MPIX_Query_cuda_support.3
+
+# Man page sources
+EXTRA_DIST = $(nodist_man_MANS:.3=.3in)
+
+distclean-local:
+	rm -f $(nodist_man_MANS)

--- a/ompi/mpiext/cuda/c/mpiext_cuda.c
+++ b/ompi/mpiext/cuda/c/mpiext_cuda.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "ompi_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "opal/constants.h"
+#include "ompi/mpiext/cuda/c/mpiext_cuda_c.h"
+
+/* The fact that this code is configured and compiled means that we have CUDA aware
+   support.  We may expand on this API to return more features in the future. */
+int MPIX_Query_cuda_support(void)
+{
+    return OPAL_SUCCESS;
+}

--- a/ompi/mpiext/cuda/c/mpiext_cuda_c.h
+++ b/ompi/mpiext/cuda/c/mpiext_cuda_c.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      NVIDIA, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define MPIX_CUDA_AWARE_SUPPORT 1
+OMPI_DECLSPEC int MPIX_Query_cuda_support(void);

--- a/ompi/mpiext/cuda/configure.m4
+++ b/ompi/mpiext/cuda/configure.m4
@@ -1,0 +1,42 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2010 The Trustees of Indiana University.
+#                         All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015      NVIDIA, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_MPIEXT_cuda_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([OMPI_MPIEXT_cuda_CONFIG],[
+    AC_CONFIG_FILES([ompi/mpiext/cuda/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/cuda/c/Makefile])
+
+    OPAL_VAR_SCOPE_PUSH([ompi_mpi_ext_cuda_happy])
+
+    # If we don't want CUDA, don't compile this extention
+    AS_IF([test "$ENABLE_cuda" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [ompi_mpi_ext_cuda_happy=1],
+          [ompi_mpi_ext_cuda_happy=0])
+
+    AS_IF([test "$ompi_mpi_ext_cuda_happy" = "1" && \
+           test "$CUDA_SUPPORT" = "1"],
+          [$1],
+          [ # Error if the user specifically asked for this extension,
+            # but we can't build it.
+           AS_IF([test "$ENABLE_cuda" = "1"],
+                 [AC_MSG_WARN([Requested "cuda" MPI extension, but cannot build it])
+                  AC_MSG_WARN([because cuda support is not enabled.])
+                  AC_MSG_WARN([Try again with --with-cuda])
+                  AC_MSG_ERROR([Cannot continue])])
+           $2])
+
+    OPAL_VAR_SCOPE_POP
+])


### PR DESCRIPTION
I have tweaked the CUDA MPI extensions in the master and they are ready to be brought to 2.x.  This is basically a copy from master into 2.x.

Since @rhc54 was an original author, maybe he would like to check his modified work.
