### PR TITLE
osc/rdma: fix regression in ompi_osc_rdma_complete

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -339,17 +339,21 @@ ompi_osc_rdma_complete(ompi_win_t *win)
                 return ret;
             }
         }
-        free (ranks);
     }
+
     OPAL_THREAD_LOCK(&module->lock);
 
     /* start all requests */
     ret = ompi_osc_rdma_frag_flush_all(module);
     if (OMPI_SUCCESS != ret) goto cleanup;
 
-    /* zero the fragment counts here to ensure they are zerod */
-    for (i = 0 ; i < group_size ; ++i) {
-        module->epoch_outgoing_frag_count[ranks[i]] = 0;
+    if (0 != group_size) {
+        /* zero the fragment counts here to ensure they are zerod */
+        for (i = 0 ; i < group_size ; ++i) {
+            module->epoch_outgoing_frag_count[ranks[i]] = 0;
+        }
+        free (ranks);
+        ranks = NULL;
     }
 
     /* wait for outgoing requests to complete.  Don't wait for incoming, as
@@ -376,6 +380,7 @@ ompi_osc_rdma_complete(ompi_win_t *win)
 
  cleanup:
     OPAL_THREAD_UNLOCK(&(module->lock));
+    free (ranks);
 
     return ret;
 }


### PR DESCRIPTION
This commit fixes a regression introduced by some 0-size group fixes
introduced in a946b0ec51aff4e944d8c566756c2b9f93729eac.

Closes #397

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
