### PR TITLE
More one sided java bindings.

### DIFF
--- a/ompi/mpi/java/c/mpi_Intracomm.c
+++ b/ompi/mpi/java/c/mpi_Intracomm.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -64,6 +66,15 @@ JNIEXPORT jlong JNICALL Java_mpi_Intracomm_split(
 {
     MPI_Comm newcomm;
     int rc = MPI_Comm_split((MPI_Comm)comm, colour, key, &newcomm);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)newcomm;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Intracomm_splitType(
+        JNIEnv *env, jobject jthis, jlong comm, jint splitType, jint key, jlong info)
+{
+    MPI_Comm newcomm;
+    int rc = MPI_Comm_split_type((MPI_Comm)comm, splitType, key, (MPI_Info)info, &newcomm);
     ompi_java_exceptionCheck(env, rc);
     return (jlong)newcomm;
 }

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -41,6 +41,66 @@ JNIEXPORT jlong JNICALL Java_mpi_Win_createWin(
     return (jlong)win;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_Win_allocateWin(JNIEnv *env, jobject jthis,
+                                                 jint size, jint dispUnit, jlong info, jlong comm, jobject jBase)
+{
+    void *basePtr = (*env)->GetDirectBufferAddress(env, jBase);
+    MPI_Win win;
+    
+    int rc = MPI_Win_allocate((MPI_Aint)size, dispUnit,
+                              (MPI_Info)info, (MPI_Comm)comm, basePtr, &win);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)win;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Win_allocateSharedWin(JNIEnv *env, jobject jthis,
+                                                       jint size, jint dispUnit, jlong info, jlong comm, jobject jBase)
+{
+    void *basePtr = (*env)->GetDirectBufferAddress(env, jBase);
+    MPI_Win win;
+    
+    int rc = MPI_Win_allocate_shared((MPI_Aint)size, dispUnit,
+                                     (MPI_Info)info, (MPI_Comm)comm, basePtr, &win);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)win;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Win_createDynamicWin(
+        JNIEnv *env, jobject jthis,
+        jlong info, jlong comm)
+{
+    MPI_Win win;
+
+    int rc = MPI_Win_create_dynamic(
+                            (MPI_Info)info, (MPI_Comm)comm, &win);
+
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)win;
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_attach(
+        JNIEnv *env, jobject jthis, jlong win, jobject jBase,
+        jint size)
+{
+    void *base = (*env)->GetDirectBufferAddress(env, jBase);
+
+    int rc = MPI_Win_attach((MPI_Win)win, base, (MPI_Aint)size);
+
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_detach(
+        JNIEnv *env, jobject jthis, jlong win, jobject jBase)
+{
+    void *base = (*env)->GetDirectBufferAddress(env, jBase);
+
+    int rc = MPI_Win_detach((MPI_Win)win, base);
+
+    ompi_java_exceptionCheck(env, rc);
+}
+
 JNIEXPORT jlong JNICALL Java_mpi_Win_getGroup(
         JNIEnv *env, jobject jthis, jlong win)
 {
@@ -394,5 +454,17 @@ JNIEXPORT void JNICALL Java_mpi_Win_fetchAndOp(JNIEnv *env, jobject jthis, jlong
     MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
     
     int rc = MPI_Fetch_and_op(orgPtr, resultPtr, dataType, targetRank, targetDisp, op, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flushLocal(JNIEnv *env, jobject jthis, jlong win, jint targetRank)
+{
+    int rc = MPI_Win_flush_local(targetRank, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flushLocalAll(JNIEnv *env, jobject jthis, jlong win)
+{
+    int rc = MPI_Win_flush_local_all((MPI_Win)win);
     ompi_java_exceptionCheck(env, rc);
 }

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -9,6 +9,10 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -63,6 +67,7 @@ import static mpi.MPI.assertDirectBuffer;
  */
 public class Comm implements Freeable
 {
+public final static int TYPE_SHARED = 0;
 protected final static int SELF  = 1;
 protected final static int WORLD = 2;
 protected long handle;

--- a/ompi/mpi/java/java/Intracomm.java
+++ b/ompi/mpi/java/java/Intracomm.java
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -138,6 +140,24 @@ public final Intracomm split(int colour, int key) throws MPIException
 }
 
 private native long split(long comm, int colour, int key) throws MPIException;
+
+/**
+ * Partition the group associated with this communicator and create
+ * a new communicator within each subgroup.
+ * <p>Java binding of the MPI operation {@code MPI_COMM_SPLIT_TYPE}.
+ * @param splitType	type of processes to be grouped together
+ * @param key	    control of rank assignment
+ * @param info		info argument
+ * @return new communicator
+ * @throws MPIException
+ */
+public final Intracomm splitType(int splitType, int key, Info info) throws MPIException
+{
+    MPI.check();
+    return new Intracomm(splitType(handle, splitType, key, info.handle));
+}
+
+private native long splitType(long comm, int colour, int key, long info) throws MPIException;
 
 /**
  * Create a new communicator.

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -26,6 +26,9 @@ import java.nio.*;
 public final class Win implements Freeable
 {
 private long handle;
+public static final int WIN_NULL = 0;
+public static final int FLAVOR_PRIVATE = 0;
+public static final int FLAVOR_SHARED = 1;
 
 /**
  * Java binding of {@code MPI_WIN_CREATE}.
@@ -63,6 +66,69 @@ public Win(Buffer base, int size, int dispUnit, Info info, Comm comm)
 
 private native long createWin(
         Buffer base, int size, int dispUnit, long info, long comm)
+        throws MPIException;
+
+/**
+ * Java binding of {@code MPI_WIN_ALLOCATE} and {@code MPI_WIN_ALLOCATE_SHARED}.
+ * @param size     size of window (buffer elements)
+ * @param dispUnit 	local unit size for displacements (buffer elements)
+ * @param info     	info object
+ * @param comm     	communicator
+ * @param base     	initial address of window
+ * @param flavor	FLAVOR_PRIVATE or FLAVOR_SHARED
+ * @throws MPIException
+ */
+public Win(int size, int dispUnit, Info info, Comm comm, Buffer base, int flavor)
+    throws MPIException
+{
+    if(!base.isDirect())
+        throw new IllegalArgumentException("The buffer must be direct.");
+
+    int baseSize;
+
+    if(base instanceof ByteBuffer)
+        baseSize = 1;
+    else if(base instanceof CharBuffer || base instanceof ShortBuffer)
+        baseSize = 2;
+    else if(base instanceof IntBuffer || base instanceof FloatBuffer)
+        baseSize = 4;
+    else if(base instanceof LongBuffer || base instanceof DoubleBuffer)
+        baseSize = 8;
+    else
+        throw new AssertionError();
+
+    int sizeBytes = size * baseSize,
+        dispBytes = dispUnit * baseSize;
+    
+    if(flavor == 0) {
+    	handle = allocateWin(sizeBytes, dispBytes, info.handle, comm.handle, base);
+    } else if(flavor == 1) {
+    	handle = allocateSharedWin(sizeBytes, dispBytes, info.handle, comm.handle, base);
+    }
+}
+
+private native long allocateWin(
+        int size, int dispUnit, long info, long comm, Buffer base)
+        throws MPIException;
+
+private native long allocateSharedWin(
+        int size, int dispUnit, long info, long comm, Buffer base)
+        throws MPIException;
+
+/**
+ * Java binding of {@code MPI_WIN_CREATE_DYNAMIC}.
+ * @param info     info object
+ * @param comm     communicator
+ * @throws MPIException 
+ */
+public Win(Info info, Comm comm)
+    throws MPIException
+{
+    handle = createDynamicWin(info.handle, comm.handle);
+}
+
+private native long createDynamicWin(
+        long info, long comm)
         throws MPIException;
 
 private int getBaseType(Datatype orgType, Datatype targetType)
@@ -718,11 +784,38 @@ public void fetchAndOp(Buffer origin, Buffer resultAddr, Datatype dataType,
         throw new IllegalArgumentException("The origin must be direct buffer.");
 
     fetchAndOp(handle, origin, resultAddr, dataType.handle, targetRank, 
-    		targetDisp, op, op.handle, getBaseType(dataType, dataType));  //neccessary?
+    		targetDisp, op, op.handle, getBaseType(dataType, dataType));
 }
 
 private native void fetchAndOp(
         long win, Buffer origin, Buffer resultAddr, long targetType, int targetRank, 
         int targetDisp, Op jOp, long hOp, int baseType) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_FLUSH_LOCAL}.
+ * @param targetRank	rank of target window
+ * @throws MPIException 
+ */
+
+public void flushLocal(int targetRank) throws MPIException
+{
+    MPI.check();
+    flushLocal(handle, targetRank);
+}
+
+private native void flushLocal(long win, int targetRank) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_FLUSH_LOCAL_ALL}.
+ * @throws MPIException 
+ */
+
+public void flushLocalAll() throws MPIException
+{
+    MPI.check();
+    flushLocalAll(handle);
+}
+
+private native void flushLocalAll(long win) throws MPIException;
 
 } // Win


### PR DESCRIPTION
Bindings for the MPI_WIN_FLUSH_LOCAL, MPI_WIN_FLUSH_LOCAL_ALL, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, and MPI_COMM_SPLIT_TYPE.  Also added several necessary constants.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

@hppritcha

:bot:milestone:v2.0.0
;bot:label:enhancement
