### PR TITLE
orte/test/system: fix compiler warnings

### DIFF
--- a/orte/test/system/binom.c
+++ b/orte/test/system/binom.c
@@ -30,7 +30,7 @@ static void construct(orte_routed_tree_t *rt)
     rt->vpid = ORTE_VPID_INVALID;
     OBJ_CONSTRUCT(&rt->relatives, opal_bitmap_t);
 }
-static destruct(orte_routed_tree_t *rt)
+static void destruct(orte_routed_tree_t *rt)
 {
     OBJ_DESTRUCT(&rt->relatives);
 }

--- a/orte/test/system/mapper.c
+++ b/orte/test/system/mapper.c
@@ -2,6 +2,7 @@
  */
 
 #include <stdio.h>
+#include <ctype.h>
 
 #include "orte/constants.h"
 

--- a/orte/test/system/opal-evpri-test.c
+++ b/orte/test/system/opal-evpri-test.c
@@ -3,8 +3,8 @@
 #include <signal.h>
 #include <stdbool.h>
 
+#include "opal/runtime/opal.h"
 #include "opal/mca/event/event.h"
-
 #include "orte/mca/state/state_types.h"
 
 #define SIGPRI 0
@@ -62,7 +62,7 @@ main(int argc, char **argv)
     opal_event_t ev1, ev2;
     orte_state_caddy_t *caddy;
 
-    opal_init();
+    opal_init(&argc, &argv);
 
     /* assign some signal traps */
     if (opal_event_signal_set(orte_event_base, &ev1, SIGTERM, cbfunc, &ev1) < 0) {

--- a/orte/test/system/opal_interface.c
+++ b/orte/test/system/opal_interface.c
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
     
     if (OPAL_SUCCESS != mca_base_framework_open(&opal_if_base_framework, 0)) {
         fprintf(stderr, "opal_interface: couldn't get interfaces\n");
-        return;
+        return 1;
     }
 
     for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);

--- a/orte/test/system/radix.c
+++ b/orte/test/system/radix.c
@@ -70,7 +70,7 @@ int down_search(int me, int num_procs,
     }
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     opal_list_t children;
     opal_list_item_t *item;

--- a/orte/test/system/regex.c
+++ b/orte/test/system/regex.c
@@ -15,7 +15,7 @@
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/runtime/runtime.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     int rc;
     char *regex, *save;


### PR DESCRIPTION
Note that the opal_hotel test still doesn't compile; it looks like it needs to be updated to the new requirement to pass an event base.

(cherry picked from commit open-mpi/ompi@60609cbb79a99d6a8ed946e07f699135aa0a2a8d)

@rhc54 Please review.
