### PR TITLE
v1.10: VERSION: proposed new .so version numbers

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -82,16 +82,16 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=7:0:6
+libmpi_so_version=12:0:0
 libmpi_cxx_so_version=2:3:1
-libmpi_mpifh_so_version=7:0:5
+libmpi_mpifh_so_version=12:0:0
 libmpi_usempi_tkr_so_version=5:0:4
-libmpi_usempi_ignore_tkr_so_version=1:0:1
-libmpi_usempif08_so_version=6:0:6
-libopen_rte_so_version=7:5:0
-libopen_pal_so_version=8:1:2
+libmpi_usempi_ignore_tkr_so_version=6:0:0
+libmpi_usempif08_so_version=11:0:0
+libopen_rte_so_version=12:0:0
+libopen_pal_so_version=13:0:0
 libmpi_java_so_version=3:0:2
-liboshmem_so_version=3:1:0
+liboshmem_so_version=8:0:0
 
 # "Common" components install standalone libraries that are run-time
 # linked by one or more components.  So they need to be versioned as
@@ -103,10 +103,10 @@ libmca_common_cuda_so_version=1:7:0
 libmca_common_mx_so_version=2:5:0
 libmca_common_sm_so_version=4:4:0
 libmca_common_ugni_so_version=2:1:2
-libmca_common_verbs_so_version=2:3:2
+libmca_common_verbs_so_version=7:0:0
 
 # OPAL layer
-libmca_opal_common_libfabric_so_version=0:0:0
+libmca_opal_common_libfabric_so_version=1:0:0
 
 # OPAL layer
-libmca_opal_common_pmi_so_version=2:3:1
+libmca_opal_common_pmi_so_version=7:0:0


### PR DESCRIPTION
This commit reflects an update in the Libtool version numbers for many of the major shared libraries that Open MPI produces.  These version numbers reflect the first in the v1.10.x series, and are designed to _not_ be backwards compatible with the v1.8.x series.  As such, most of the version numbers simply went from x:y:z to (x+5):0:0.  This accomplishes two things:
1. Makes the new version be non-backwards-compatible (in an ABI sense)
2. Leaves a "gap" in the "c"urrent value for future 1.8.x releases (if we need them)

(this commit currently contains superflous comments so that a reviewer can examine the changes easily -- these comments will be removed before the PR is merged to v1.10)

Fixes open-mpi/ompi#734

@goodell please review
