### PR TITLE
 Fix MPI_Finalize

### DIFF
--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -446,7 +446,11 @@ static int mca_bml_r2_del_procs(size_t nprocs,
 
     for(p = 0; p < nprocs; p++) { 
         ompi_proc_t *proc = procs[p]; 
-        if(((opal_object_t*)proc)->obj_reference_count == 1) { 
+        /* We much check that there are 2 references to the proc (not 1). The
+         * first reference belongs to ompi/proc the second belongs to the bml
+         * since we retained it. We will release that reference at the end of
+         * the loop below. */
+        if(((opal_object_t*)proc)->obj_reference_count == 2) {
             del_procs[n_del_procs++] = proc; 
         }
     }

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -139,6 +139,11 @@ int ompi_mpi_finalize(void)
      */
     (void)mca_pml_base_bsend_detach(NULL, NULL);
 
+    nprocs = 0;
+    procs = ompi_proc_world(&nprocs);
+    MCA_PML_CALL(del_procs(procs, nprocs));
+    free(procs);
+
 #if OMPI_ENABLE_PROGRESS_THREADS == 0
     opal_progress_set_event_flag(OPAL_EVLOOP_ONCE | OPAL_EVLOOP_NONBLOCK);
 #endif
@@ -281,11 +286,6 @@ int ompi_mpi_finalize(void)
     if (OMPI_SUCCESS != (ret = ompi_comm_finalize())) {
         return ret;
     }
-
-    nprocs = 0;
-    procs = ompi_proc_world(&nprocs);
-    MCA_PML_CALL(del_procs(procs, nprocs));
-    free(procs);
 
     /* free pml resource */ 
     if(OMPI_SUCCESS != (ret = mca_pml_base_finalize())) { 


### PR DESCRIPTION
This has a horrible history associated with it. Apparently, we committed a pull request that would have included a change to ompi_mpi_finalize that fixed an ordering problem - we were incorrectly finalizing the PML before finalizing the communicator system, and the latter causes PSM to send out messages. However, the change was immediately reverted because it caused the USNIC BTL to segfault.

Subsequently, the problem was fixed in the master. Sadly, the completed fix was never brought back to the 1.8 series.

We also found another MPI_Finalize ordering fix that came in later, but was not brought to the 1.8 series. We are including it here just in case it is needed.

The two commits in question:
(cherry picked from commit open-mpi/ompi@faf008f5277a2cb081010f6d284c5d1b9651b4d1)
(cherry picked from commit open-mpi/ompi@dee243c58d0c79faa445b3c12685fc02def27085)

@hjelmn @bosilca Please see if this is okay, and if we missed other things that need to be here.
