### PR TITLE
fortran: update comment in sentinels-checking macros

### DIFF
--- a/ompi/mpi/fortran/base/constants.h
+++ b/ompi/mpi/fortran/base/constants.h
@@ -131,9 +131,9 @@ DECL(int *, MPI_FORTRAN_STATUSES_IGNORE, mpi_fortran_statuses_ignore,
  * Generation 2 / v1.8.x, where x>=8: OMPI_IS_FORTRAN_foo() will
  * *always* check all four symbols.
  *
- * Generation 3 / starting with v1.10.0: OMPI_IS_FORTRAN_foo() will
- * check just the one symbol that is relevant for your
- * compiler/platform (based on what configure figured out).
+ * Generation 3 / starting with v2.x: OMPI_IS_FORTRAN_foo() will check
+ * just the one symbol that is relevant for your compiler/platform
+ * (based on what configure figured out).
  *
  *********
  *


### PR DESCRIPTION
We've decided to extend "Gen2" implementation to the v1.10.x series, too, so update the comment to reflect that.

This is a documentation fix that is required after reverting #437 and applying #442 to the v1.10 branch.  It was pre-RM-approved by @rhc54.
