### PR TITLE
Revert "fortran: optimize testall and waitall when MPI_STATUSES_IGNOR…

### DIFF
--- a/ompi/mpi/fortran/mpif-h/testall_f.c
+++ b/ompi/mpi/fortran/mpif-h/testall_f.c
@@ -10,8 +10,6 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -109,10 +107,11 @@ void ompi_testall_f(MPI_Fint *count, MPI_Fint *array_of_requests, ompi_fortran_l
 
     /* All Fortran Compilers have FALSE == 0, so just check for any
        nonzero value (because TRUE is not always == 1) */
-    if (MPI_SUCCESS == c_ierr && !OMPI_IS_FORTRAN_STATUSES_IGNORE(array_of_statuses) && *flag) {
+    if (MPI_SUCCESS == c_ierr && *flag) {
         for (i = 0; i < OMPI_FINT_2_INT(*count); ++i) {
             array_of_requests[i] = c_req[i]->req_f_to_c_index;
-            if (!OMPI_IS_FORTRAN_STATUS_IGNORE(&array_of_statuses[i])) {
+            if (!OMPI_IS_FORTRAN_STATUSES_IGNORE(array_of_statuses) &&
+                !OMPI_IS_FORTRAN_STATUS_IGNORE(&array_of_statuses[i])) {
                 MPI_Status_c2f(&c_status[i], &array_of_statuses[i * (sizeof(MPI_Status) / sizeof(int))]);
             }
         }

--- a/ompi/mpi/fortran/mpif-h/waitall_f.c
+++ b/ompi/mpi/fortran/mpif-h/waitall_f.c
@@ -5,17 +5,15 @@
  * Copyright (c) 2004-2005 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
- *
+ * 
  * Additional copyrights may follow
- *
+ * 
  * $HEADER$
  */
 
@@ -104,11 +102,12 @@ void ompi_waitall_f(MPI_Fint *count, MPI_Fint *array_of_requests,
     c_ierr = MPI_Waitall(OMPI_FINT_2_INT(*count), c_req, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    if (MPI_SUCCESS == c_ierr && !OMPI_IS_FORTRAN_STATUSES_IGNORE(array_of_statuses)) {
+    if (MPI_SUCCESS == c_ierr) {
         for (i = 0; i < OMPI_FINT_2_INT(*count); ++i) {
             array_of_requests[i] = c_req[i]->req_f_to_c_index;
-            if (!OMPI_IS_FORTRAN_STATUS_IGNORE(&array_of_statuses[i])) {
-                MPI_Status_c2f( &c_status[i], &array_of_statuses[i * (sizeof(MPI_Status) / sizeof(int))]);
+            if (!OMPI_IS_FORTRAN_STATUSES_IGNORE(array_of_statuses) &&
+                !OMPI_IS_FORTRAN_STATUS_IGNORE(&array_of_statuses[i])) {
+                MPI_Status_c2f( &c_status[i], &array_of_statuses[i * (sizeof(MPI_Status) / sizeof(int))]); 
             }
         }
     }


### PR DESCRIPTION
…E is used"

This reverts commit 8d58e5847f6854a4dd6c8d9dd4fe76bec5ba2a82.

(cherry-picked from commit open-mpi/ompi@2fa8f4d53ac973519fe6081f245abe0952fed26d)
