### PR TITLE
Topic/fix breakage from pr 430

### DIFF
--- a/ompi/mca/crcp/bkmrk/crcp_bkmrk_pml.c
+++ b/ompi/mca/crcp/bkmrk/crcp_bkmrk_pml.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -32,7 +33,6 @@
 
 #include "opal/util/opal_environ.h"
 #include "ompi/mca/mca.h"
-#include "opal/mca/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 
 #include "ompi/request/request.h"
@@ -4440,7 +4440,7 @@ static int ft_event_exchange_bookmarks(void)
     /* Wait for all bookmarks to arrive */
     START_TIMER(CRCP_TIMER_CKPT_EX_WAIT);
     while( total_recv_bookmarks > 0 ) {
-        opal_event_loop(opal_event_base, OPAL_EVLOOP_NONBLOCK);
+        opal_event_loop(opal_sync_event_base, OPAL_EVLOOP_NONBLOCK);
     }
     total_recv_bookmarks = 0;
     END_TIMER(CRCP_TIMER_CKPT_EX_WAIT);
@@ -5227,7 +5227,7 @@ static int wait_quiesce_drain_ack(void)
             }
         }
 
-        opal_event_loop(opal_event_base, OPAL_EVLOOP_NONBLOCK);
+        opal_event_loop(opal_sync_event_base, OPAL_EVLOOP_NONBLOCK);
     }
         
     /* Clear the ack queue if it isn't already clear (it should already be) */

--- a/opal/class/opal_hotel.c
+++ b/opal/class/opal_hotel.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -33,6 +34,7 @@ static void local_eviction_callback(int fd, short flags, void *arg)
 
 
 int opal_hotel_init(opal_hotel_t *h, int num_rooms,
+                    opal_event_base_t *evbase,
                     uint32_t eviction_timeout,
                     int eviction_event_priority,
                     opal_hotel_eviction_callback_fn_t evict_callback_fn)
@@ -46,6 +48,7 @@ int opal_hotel_init(opal_hotel_t *h, int num_rooms,
     }
 
     h->num_rooms = num_rooms;
+    h->evbase = evbase;
     h->eviction_timeout.tv_usec = eviction_timeout % 1000000;
     h->eviction_timeout.tv_sec = eviction_timeout / 1000000;
     h->evict_callback_fn = evict_callback_fn;
@@ -69,14 +72,16 @@ int opal_hotel_init(opal_hotel_t *h, int num_rooms,
         h->eviction_args[i].room_num = i;
 
         /* Create this room's event (but don't add it) */
-        opal_event_set(opal_event_base,
-                       &(h->rooms[i].eviction_timer_event),
-                       -1, 0, local_eviction_callback,
-                       &(h->eviction_args[i]));
+        if (NULL != h->evbase) {
+            opal_event_set(h->evbase,
+                           &(h->rooms[i].eviction_timer_event),
+                           -1, 0, local_eviction_callback,
+                           &(h->eviction_args[i]));
 
-        /* Set the priority so it gets serviced properly */
-        opal_event_set_priority(&(h->rooms[i].eviction_timer_event),
-                                eviction_event_priority);
+            /* Set the priority so it gets serviced properly */
+            opal_event_set_priority(&(h->rooms[i].eviction_timer_event),
+                                    eviction_event_priority);
+        }
     }
 
     return OPAL_SUCCESS;
@@ -85,6 +90,7 @@ int opal_hotel_init(opal_hotel_t *h, int num_rooms,
 static void constructor(opal_hotel_t *h)
 {
     h->num_rooms = 0;
+    h->evbase = NULL;
     h->eviction_timeout.tv_sec = 0;
     h->eviction_timeout.tv_usec = 0;
     h->evict_callback_fn = NULL;
@@ -99,9 +105,11 @@ static void destructor(opal_hotel_t *h)
     int i;
 
     /* Go through all occupied rooms and destroy their events */
-    for (i = 0; i < h->num_rooms; ++i) {
-        if (NULL != h->rooms[i].occupant) {
-            opal_event_del(&(h->rooms[i].eviction_timer_event));
+    if (NULL != h->evbase) {
+        for (i = 0; i < h->num_rooms; ++i) {
+            if (NULL != h->rooms[i].occupant) {
+                opal_event_del(&(h->rooms[i].eviction_timer_event));
+            }
         }
     }
 

--- a/opal/mca/btl/openib/btl_openib_fd.c
+++ b/opal/mca/btl/openib/btl_openib_fd.c
@@ -175,7 +175,7 @@ static int service_pipe_cmd_add_fd(bool use_libevent, cmd_t *cmd)
     if (use_libevent) {
         /* Make an event for this fd */
         ri->ri_event_used = true;
-        opal_event_set(opal_event_base, &ri->ri_event, ri->ri_fd,
+        opal_event_set(opal_sync_event_base, &ri->ri_event, ri->ri_fd,
                        ri->ri_flags | OPAL_EV_PERSIST, service_fd_callback,
                        ri);
         opal_event_add(&ri->ri_event, 0);
@@ -501,7 +501,7 @@ int opal_btl_openib_fd_init(void)
 
         /* Create a libevent event that is used in the main thread
            to watch its pipe */
-        opal_event_set(opal_event_base, &main_thread_event, pipe_to_main_thread[0],
+        opal_event_set(opal_sync_event_base, &main_thread_event, pipe_to_main_thread[0],
                        OPAL_EV_READ | OPAL_EV_PERSIST,
                        main_thread_event_callback, NULL);
         opal_event_add(&main_thread_event, 0);

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -2212,7 +2212,7 @@ static void udcm_sent_message_constructor (udcm_message_sent_t *message)
 {
     memset ((char *)message + sizeof (message->super), 0,
             sizeof (*message) - sizeof (message->super));
-    opal_event_evtimer_set(opal_event_base, &message->event, udcm_send_timeout, message);
+    opal_event_evtimer_set(opal_sync_event_base, &message->event, udcm_send_timeout, message);
 }
 
 static void udcm_sent_message_destructor (udcm_message_sent_t *message)

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -818,7 +818,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     /* register listen port */
 #if OPAL_ENABLE_IPV6
     if (AF_INET6 == af_family) {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp6_recv_event,
+        opal_event_set(opal_sync_event_base, &mca_btl_tcp_component.tcp6_recv_event,
                         mca_btl_tcp_component.tcp6_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -827,7 +827,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     } else
 #endif
     {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp_recv_event,
+        opal_event_set(opal_sync_event_base, &mca_btl_tcp_component.tcp_recv_event,
                         mca_btl_tcp_component.tcp_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -1049,7 +1049,7 @@ static void mca_btl_tcp_component_accept_handler( int incoming_sd,
 
         /* wait for receipt of peers process identifier to complete this connection */
         event = OBJ_NEW(mca_btl_tcp_event_t);
-        opal_event_set(opal_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
+        opal_event_set(opal_sync_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
         opal_event_add(&event->event, 0);
     }
 }

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -311,7 +311,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
     btl_endpoint->endpoint_cache_pos = btl_endpoint->endpoint_cache;
 #endif  /* MCA_BTL_TCP_ENDPOINT_CACHE */
 
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_recv_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_recv_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_READ|OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_recv_handler,
@@ -322,7 +322,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
      * will be fired only once, and when the endpoint is marked as
      * CONNECTED the event should be recreated with the correct flags.
      */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE,
                     mca_btl_tcp_endpoint_send_handler,
@@ -511,7 +511,7 @@ void mca_btl_tcp_endpoint_accept(mca_btl_base_endpoint_t* btl_endpoint,
     assert(btl_endpoint->endpoint_sd_next == -1);
     btl_endpoint->endpoint_sd_next = sd;
 
-    opal_event_evtimer_set(opal_event_base, &btl_endpoint->endpoint_accept_event,
+    opal_event_evtimer_set(opal_sync_event_base, &btl_endpoint->endpoint_accept_event,
                            mca_btl_tcp_endpoint_complete_accept, btl_endpoint);
     opal_event_add(&btl_endpoint->endpoint_accept_event, &now);
 }
@@ -572,7 +572,7 @@ static void mca_btl_tcp_endpoint_connected(mca_btl_base_endpoint_t* btl_endpoint
     MCA_BTL_TCP_ENDPOINT_DUMP(1, btl_endpoint, true, "READY [endpoint_connected]");
 
     /* Create the send event in a persistent manner. */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE | OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_send_handler,

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -1018,7 +1018,7 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
     }
 
     /* start timer to guarantee synthetic clock advances */
-    opal_event_set(opal_event_base, &usnic_clock_timer_event,
+    opal_event_set(opal_sync_event_base, &usnic_clock_timer_event,
                    -1, 0, usnic_clock_callback,
                    &usnic_clock_timeout);
     usnic_clock_timer_event_set = true;

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.c
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2007      The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.c
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.c
@@ -86,6 +86,7 @@ static void endpoint_construct(mca_btl_base_endpoint_t* endpoint)
     OBJ_CONSTRUCT(&endpoint->endpoint_hotel, opal_hotel_t);
     opal_hotel_init(&endpoint->endpoint_hotel,
                     WINDOW_SIZE,
+                    opal_sync_event_base,
                     mca_btl_usnic_component.retrans_timeout,
                     0,
                     opal_btl_usnic_ack_timeout);

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -2102,7 +2102,7 @@ static void init_async_event(opal_btl_usnic_module_t *module)
     }
 
     /* Get the fd to receive events on this device */
-    opal_event_set(opal_event_base, &(module->device_async_event), fd,
+    opal_event_set(opal_sync_event_base, &(module->device_async_event), fd,
                    OPAL_EV_READ | OPAL_EV_PERSIST,
                    module_async_event_callback, module);
     opal_event_add(&(module->device_async_event), NULL);

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -212,7 +212,7 @@ int opal_btl_usnic_stats_init(opal_btl_usnic_module_t *module)
         module->stats.timeout.tv_sec = mca_btl_usnic_component.stats_frequency;
         module->stats.timeout.tv_usec = 0;
 
-        opal_event_set(opal_event_base, &(module->stats.timer_event),
+        opal_event_set(opal_sync_event_base, &(module->stats.timer_event),
                        -1, EV_TIMEOUT | EV_PERSIST,
                        &usnic_stats_callback, module);
         opal_event_add(&(module->stats.timer_event),

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -85,13 +85,13 @@ static int opal_event_base_open(mca_base_open_flag_t flags)
     opal_event_use_threads();
 
     /* get our event base */
-    if (NULL == (opal_event_base = opal_event_base_create())) {
+    if (NULL == (opal_sync_event_base = opal_event_base_create())) {
         return OPAL_ERROR;
     }
 
     /* set the number of priorities */
     if (0 < OPAL_EVENT_NUM_PRI) {
-        opal_event_base_priority_init(opal_event_base, OPAL_EVENT_NUM_PRI);
+        opal_event_base_priority_init(opal_sync_event_base, OPAL_EVENT_NUM_PRI);
     }
 
     return rc;

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -64,7 +64,8 @@ static int opal_event_base_close(void)
 /*
  * Globals
  */
-opal_event_base_t *opal_event_base=NULL;
+opal_event_base_t *opal_sync_event_base=NULL;
+opal_event_base_t *opal_async_event_base=NULL;
 
 static int opal_event_base_open(mca_base_open_flag_t flags)
 {

--- a/opal/mca/event/event.h
+++ b/opal/mca/event/event.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -27,7 +27,8 @@ BEGIN_C_DECLS
 typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
-OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -1,6 +1,11 @@
 /*
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+<<<<<<< HEAD
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved. 
+=======
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
+>>>>>>> 683efcb8... Rename the current opal_event_base to opal_sync_event_base in preparation for adding an async progress thread to opal. No functional changes made here - just a simple rename.
  *
  * $COPYRIGHT$
  * 

--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -67,7 +67,8 @@ BEGIN_C_DECLS
 typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
-OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/pmix/native/pmix_native.c
+++ b/opal/mca/pmix/native/pmix_native.c
@@ -193,7 +193,7 @@ static int native_init(void)
         opal_argv_free(uri);
 
         /* create an event base and progress thread for us */
-        if (NULL == (mca_pmix_native_component.evbase = opal_start_progress_thread("pmix_native", true))) {
+        if (NULL == (mca_pmix_native_component.evbase = opal_start_progress_thread("opal_async", true))) {
             return OPAL_ERROR;
         }
     }
@@ -255,7 +255,7 @@ static int native_fini(void)
     }
 
     if (NULL != mca_pmix_native_component.evbase) {
-        opal_stop_progress_thread("pmix_native", true);
+        opal_stop_progress_thread("opal_async", true);
         mca_pmix_native_component.evbase = NULL;
     }
 

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -815,7 +815,7 @@ int opal_cr_coord(int state)
          * Otherwise it may/will use stale file descriptors which will disrupt
          * the intended users of the soon-to-be newly assigned file descriptors.
          */
-        opal_event_reinit(opal_event_base);
+        opal_event_reinit(opal_sync_event_base);
 
         /*
          * Flush if() functionality, since it caches system specific info.

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -168,7 +168,7 @@ opal_progress(void)
                 event_progress_last_time = (num_event_users > 0) ? 
                     now - event_progress_delta : now;
 
-                events += opal_event_loop(opal_event_base, opal_progress_event_flag);
+                events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
 
 #else /* OPAL_PROGRESS_USE_TIMERS */
@@ -177,7 +177,7 @@ opal_progress(void)
         if (OPAL_THREAD_ADD32(&event_progress_counter, -1) <= 0 ) {
                 event_progress_counter = 
                     (num_event_users > 0) ? 0 : event_progress_delta;
-                events += opal_event_loop(opal_event_base, opal_progress_event_flag);
+                events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
 #endif /* OPAL_PROGRESS_USE_TIMERS */
 

--- a/orte/mca/ess/base/ess_base_std_app.c
+++ b/orte/mca/ess/base/ess_base_std_app.c
@@ -114,8 +114,9 @@ int orte_ess_base_app_setup(bool db_restrict_local)
         opal_proc_local_set(&orte_process_info.super);
     }
 
-    /* get a separate orte event base */
-    orte_event_base = opal_start_progress_thread("orte", true);
+    /* get an async event base - we use the opal_async one so
+     * we don't startup extra threads if not needed */
+    orte_event_base = opal_start_progress_thread("opal_async", true);
     progress_thread_running = true;
     /* open and setup the state machine */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_state_base_framework, 0))) {
@@ -337,13 +338,6 @@ int orte_ess_base_app_finalize(void)
 {
     orte_cr_finalize();
 
-    /* release the event base so we stop all potential
-     * race conditions in the messaging teardown */
-    if (progress_thread_running) {
-        opal_stop_progress_thread("orte", false);
-        progress_thread_running = false;
-    }
-
 #if OPAL_ENABLE_FT_CR == 1
     (void) mca_base_framework_close(&orte_snapc_base_framework);
     (void) mca_base_framework_close(&orte_sstore_base_framework);
@@ -365,8 +359,12 @@ int orte_ess_base_app_finalize(void)
 
     orte_session_dir_finalize(ORTE_PROC_MY_NAME);
 
-    /* free the event base to cleanup memory */
-    opal_stop_progress_thread("orte", true);
+    /* release the event base */
+    if (progress_thread_running) {
+        opal_stop_progress_thread("opal_async", true);
+        progress_thread_running = false;
+    }
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/qos/ack/qos_ack_component.c
+++ b/orte/mca/qos/ack/qos_ack_component.c
@@ -188,7 +188,7 @@ static int ack_open (void *qos_channel, opal_buffer_t * buf)  {
     eviction_timeout = (ack_chan->timeout_secs + QOS_ACK_WINDOW_TIMEOUT_IN_SECS) * 100000;
     /* init outstanding msg hotel */
     opal_hotel_init (&ack_chan->outstanding_msgs, QOS_ACK_MAX_OUTSTANDING_MSGS,
-                       eviction_timeout, 0,
+                       orte_event_base, eviction_timeout, 0,
                        orte_qos_ack_msg_ack_timeout_callback);
     OPAL_OUTPUT_VERBOSE((1, orte_qos_base_framework.framework_output,
                          "%s ack_open channel = %p init hotel timeout =%d",
@@ -466,7 +466,7 @@ static int ack_init_recv (void *channel, opal_list_t *attributes) {
     eviction_timeout = (ack_chan->timeout_secs + QOS_ACK_WINDOW_TIMEOUT_IN_SECS) * 100000;
     /* init outstanding msg hotel */
     opal_hotel_init (&ack_chan->outstanding_msgs, QOS_ACK_MAX_OUTSTANDING_MSGS,
-                     eviction_timeout, 0,
+                     orte_event_base, eviction_timeout, 0,
                      orte_qos_ack_recv_msg_timeout_callback);
     OPAL_OUTPUT_VERBOSE((1, orte_qos_base_framework.framework_output,
                          "%s ack_open channel = %p init hotel timeout =%d",

--- a/orte/runtime/orte_init.c
+++ b/orte/runtime/orte_init.c
@@ -226,7 +226,7 @@ int orte_init(int* pargc, char*** pargv, orte_proc_type_t flags)
          * start their progress thread in ess_base_std_app.c
          * at the appropriate point
          */
-        orte_event_base = opal_event_base;
+        orte_event_base = opal_sync_event_base;
     }
 
     /* initialize the RTE for this environment */

--- a/orte/tools/orte-server/orte-server.c
+++ b/orte/tools/orte-server/orte-server.c
@@ -240,10 +240,10 @@ int main(int argc, char *argv[])
     /* Set signal handlers to catch kill signals so we can properly clean up
      * after ourselves. 
      */
-    opal_event_set(opal_event_base, &term_handler, SIGTERM, OPAL_EV_SIGNAL,
+    opal_event_set(orte_event_base, &term_handler, SIGTERM, OPAL_EV_SIGNAL,
                    shutdown_callback, NULL);
     opal_event_add(&term_handler, NULL);
-    opal_event_set(opal_event_base, &int_handler, SIGINT, OPAL_EV_SIGNAL,
+    opal_event_set(orte_event_base, &int_handler, SIGINT, OPAL_EV_SIGNAL,
                    shutdown_callback, NULL);
     opal_event_add(&int_handler, NULL);
 


### PR DESCRIPTION
Turns out just putting in PR 430 without putting in some other commits that it was associated with broke things at finalize for certain job launch (non mpirun) scenarios.

Cherry pick of open-mpi/ompi@61fb067f1, open-mpi/ompi@683efcb85, open-mpi/opmi@219c4dfba

@jsquyres 
@rhc54 
