### PR TITLE
Java binding for MPI_REQUEST_GET_STATUS

### DIFF
--- a/ompi/mpi/java/c/mpi_Request.c
+++ b/ompi/mpi/java/c/mpi_Request.c
@@ -171,6 +171,18 @@ JNIEXPORT jobject JNICALL Java_mpi_Request_testStatus(
     return flag ? ompi_java_status_new(env, &status) : NULL;
 }
 
+JNIEXPORT jobject JNICALL Java_mpi_Request_getStatus(
+        JNIEnv *env, jobject jthis, jlong handle)
+{
+    MPI_Request req = (MPI_Request)handle;
+    int flag;
+    MPI_Status status;
+    int rc = MPI_Request_get_status(req, &flag, &status);
+    ompi_java_exceptionCheck(env, rc);
+    (*env)->SetLongField(env, jthis, ompi_java.ReqHandle, (jlong)req);
+    return flag ? ompi_java_status_new(env, &status) : NULL;
+}
+
 JNIEXPORT jboolean JNICALL Java_mpi_Request_test(
         JNIEnv *env, jobject jthis, jlong handle)
 {

--- a/ompi/mpi/java/java/Request.java
+++ b/ompi/mpi/java/java/Request.java
@@ -170,6 +170,23 @@ public class Request implements Freeable
 	private native Status testStatus(long request) throws MPIException;
 
 	/**
+	 * Returns a status object if the operation identified by the request
+	 * is complete, or a null reference otherwise.
+	 * <p>Java binding of the MPI operation {@code MPI_REQUEST_GET_STATUS}.
+	 * <p>After the call, if the operation is complete (ie, if the return
+	 * value is non-null), the request object remains active.
+	 * @return status object
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public final Status getStatus() throws MPIException
+	{
+		MPI.check();
+		return getStatus(handle);
+	}
+
+	private native Status getStatus(long request) throws MPIException;
+	
+	/**
 	 * Returns true if the operation identified by the request
 	 * is complete, or false otherwise.
 	 * <p>Java binding of the MPI operation {@code MPI_TEST}.


### PR DESCRIPTION
This adds the java binding for MPI_REQUEST_GET_STATUS.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

@hppritcha @jsquyres

:bot:milestone:v2.0.0
;bot:label:enhancement
