### PR TITLE
Additional java bindings for the Comm class

### DIFF
--- a/ompi/mpi/java/c/mpi_Comm.c
+++ b/ompi/mpi/java/c/mpi_Comm.c
@@ -214,6 +214,15 @@ JNIEXPORT jlongArray JNICALL Java_mpi_Comm_iDup(
     return jcr;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_Comm_dupWithInfo(
+        JNIEnv *env, jobject jthis, jlong comm, jlong info)
+{
+    MPI_Comm newcomm;
+    int rc = MPI_Comm_dup_with_info((MPI_Comm)comm, (MPI_Info)info, &newcomm);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)newcomm;
+}
+
 JNIEXPORT jint JNICALL Java_mpi_Comm_getSize(
         JNIEnv *env, jobject jthis, jlong comm)
 {

--- a/ompi/mpi/java/c/mpi_Intracomm.c
+++ b/ompi/mpi/java/c/mpi_Intracomm.c
@@ -88,6 +88,15 @@ JNIEXPORT jlong JNICALL Java_mpi_Intracomm_create(
     return (jlong)newcomm;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_Intracomm_createGroup(
+        JNIEnv *env, jobject jthis, jlong comm, jlong group, int tag)
+{
+    MPI_Comm newcomm;
+    int rc = MPI_Comm_create_group((MPI_Comm)comm, (MPI_Group)group, tag, &newcomm);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)newcomm;
+}
+
 JNIEXPORT jlong JNICALL Java_mpi_Intracomm_createCart(
         JNIEnv *env, jobject jthis, jlong comm,
         jintArray dims, jbooleanArray periods, jboolean reorder)

--- a/ompi/mpi/java/java/CartComm.java
+++ b/ompi/mpi/java/java/CartComm.java
@@ -115,6 +115,19 @@ public final class CartComm extends Intracomm
 	}
 
 	/**
+	* Duplicates this communicator with the info object used in the call.
+	* <p>Java binding of {@code MPI_COMM_DUP_WITH_INFO}.
+	* @param info	info object to associate with the new communicator
+	* @return copy of this communicator
+	* @throws MPIException Signals that an MPI exception of some sort has occurred.
+	*/
+	@Override public CartComm dupWithInfo(Info info) throws MPIException
+	{
+	    MPI.check();
+	    return new CartComm(dupWithInfo(handle, info.handle));
+	}
+	
+	/**
 	 * Returns cartesian topology information.
 	 * <p>Java binding of the MPI operations {@code MPI_CARTDIM_GET} and
 	 * {@code MPI_CART_GET}.

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -152,7 +152,22 @@ public class Comm implements Freeable
 	}
 
 	protected final native long[] iDup(long comm) throws MPIException;
+	
+	/**
+	 * Duplicates this communicator with the info object used in the call.
+	 * <p>Java binding of {@code MPI_COMM_DUP_WITH_INFO}.
+	 * @param info	info object to associate with the new communicator
+	 * @return copy of this communicator
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Comm dupWithInfo(Info info) throws MPIException
+	{
+	    MPI.check();
+	    return new Comm(dupWithInfo(handle, info.handle));
+	}
 
+	protected final native long dupWithInfo(long comm, long info) throws MPIException;
+	
 	/**
 	 * Returns the associated request to this communicator if it was
 	 * created using {@link #iDup}.

--- a/ompi/mpi/java/java/GraphComm.java
+++ b/ompi/mpi/java/java/GraphComm.java
@@ -115,6 +115,19 @@ public final class GraphComm extends Intracomm
 	}
 
 	/**
+	* Duplicates this communicator with the info object used in the call.
+	* <p>Java binding of {@code MPI_COMM_DUP_WITH_INFO}.
+	* @param info	info object to associate with the new communicator
+	* @return copy of this communicator
+	* @throws MPIException Signals that an MPI exception of some sort has occurred.
+	*/
+	@Override public GraphComm dupWithInfo(Info info) throws MPIException
+	{
+	    MPI.check();
+	    return new GraphComm(dupWithInfo(handle, info.handle));
+	}
+	
+	/**
 	 * Returns graph topology information.
 	 * <p>Java binding of the MPI operations {@code MPI_GRAPHDIMS_GET}
 	 * and {@code MPI_GRAPH_GET}.

--- a/ompi/mpi/java/java/Intercomm.java
+++ b/ompi/mpi/java/java/Intercomm.java
@@ -106,7 +106,20 @@ public final class Intercomm extends Comm
 		MPI.check();
 		return new Intercomm(iDup(handle));
 	}
-
+	
+	/**
+	* Duplicates this communicator with the info object used in the call.
+	* <p>Java binding of {@code MPI_COMM_DUP_WITH_INFO}.
+	* @param info	info object to associate with the new communicator
+	* @return copy of this communicator
+	* @throws MPIException Signals that an MPI exception of some sort has occurred.
+	*/
+	@Override public Intercomm dupWithInfo(Info info) throws MPIException
+	{
+	    MPI.check();
+	    return new Intercomm(dupWithInfo(handle, info.handle));
+	}
+	
 	// Inter-Communication
 
 	/**

--- a/ompi/mpi/java/java/Intracomm.java
+++ b/ompi/mpi/java/java/Intracomm.java
@@ -123,7 +123,20 @@ public class Intracomm extends Comm
 		MPI.check();
 		return new Intracomm(iDup(handle));
 	}
-
+	
+	/**
+	 * Duplicates this communicator with the info object used in the call.
+	 * <p>Java binding of {@code MPI_COMM_DUP_WITH_INFO}.
+	 * @param info	info object to associate with the new communicator
+	 * @return copy of this communicator
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	@Override public Intracomm dupWithInfo(Info info) throws MPIException
+	{
+	    MPI.check();
+	    return new Intracomm(dupWithInfo(handle, info.handle));
+	}
+	
 	/**
 	 * Partition the group associated with this communicator and create
 	 * a new communicator within each subgroup.
@@ -173,7 +186,23 @@ public class Intracomm extends Comm
 	}
 
 	private native long create(long comm, long group);
+	
+	/**
+	 * Create a new intracommunicator for the given group.
+	 * <p>Java binding of the MPI operation {@code MPI_COMM_CREATE_GROUP}.
+	 * @param group group which is a subset of the group of this communicator
+	 * @param tag	an integer tag
+	 * @return new communicator
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public final Intracomm createGroup(Group group, int tag) throws MPIException
+	{
+	    MPI.check();
+	    return new Intracomm(createGroup(handle, group.handle, tag));
+	}
 
+	private native long createGroup(long comm, long group, int tag);
+	
 	// Topology Constructors
 
 	/**


### PR DESCRIPTION
Added bindings for MPI_COMM_CREATE_GROUP and MPI_COMM_DUP_WITH_INFO.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

@hppritcha @jsquyres

:bot:milestone:v2.0.0
;bot:label:enhancement
