### PR TITLE
opal_bit_ops: s/ompi_config/opal_config/

### DIFF
--- a/test/util/opal_bit_ops.c
+++ b/test/util/opal_bit_ops.c
@@ -16,7 +16,7 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
+#include "opal_config.h"
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
OPAL tests should use OPAL headers, not OMPI headers.  This makes sure that "./autogen.pl --no-ompi; ./configure; make distcheck" still works.

@rhc54 please review; it's trivial
