### PR TITLE
v2.x function fixes

### DIFF
--- a/ompi/mca/coll/libnbc/libdict/dict_private.h
+++ b/ompi/mca/coll/libnbc/libdict/dict_private.h
@@ -47,7 +47,7 @@ typedef int			 (*icompare_func)	__P((void *, void *itor2));
 #  define ASSERT(expr)														\
 	if (!(expr))															\
 		fprintf(stderr, "\n%s:%d (%s) assertion failed: `%s'\n",			\
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr),			\
+				__FILE__, __LINE__, __func__, #expr),			\
 		abort()
 # else
 #  define ASSERT(expr)														\

--- a/oshmem/mca/atomic/base/base.h
+++ b/oshmem/mca/atomic/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -42,14 +43,14 @@ OSHMEM_DECLSPEC extern mca_base_framework_t oshmem_atomic_base_framework;
 #ifdef OPAL_ENABLE_DEBUG
 #define ATOMIC_VERBOSE(level, ...) \
     oshmem_output_verbose(level, oshmem_atomic_base_framework.framework_output, \
-        "%s:%d - %s()", __ATOMIC_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "%s:%d - %s()", __ATOMIC_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define ATOMIC_VERBOSE(level, ...)
 #endif
 
 #define ATOMIC_ERROR(...) \
     oshmem_output(oshmem_atomic_base_framework.framework_output, \
-        "Error %s:%d - %s()", __ATOMIC_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error %s:%d - %s()", __ATOMIC_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 END_C_DECLS
 

--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -133,18 +134,18 @@ OSHMEM_DECLSPEC extern mca_base_framework_t oshmem_memheap_base_framework;
 #ifdef OPAL_ENABLE_DEBUG
 #define MEMHEAP_VERBOSE(level, ...) \
     oshmem_output_verbose(level, oshmem_memheap_base_framework.framework_output, \
-        "%s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "%s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define MEMHEAP_VERBOSE(level, ...)
 #endif
 
 #define MEMHEAP_ERROR(...) \
     oshmem_output(oshmem_memheap_base_framework.framework_output, \
-        "Error %s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error %s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #define MEMHEAP_WARN(...) \
     oshmem_output_verbose(0, oshmem_memheap_base_framework.framework_output, \
-        "Warning %s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Warning %s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 END_C_DECLS
 

--- a/oshmem/mca/scoll/base/base.h
+++ b/oshmem/mca/scoll/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -54,14 +55,14 @@ OSHMEM_DECLSPEC extern mca_base_framework_t oshmem_scoll_base_framework;
 #ifdef OPAL_ENABLE_DEBUG
 #define SCOLL_VERBOSE(level, ...) \
     oshmem_output_verbose(level, oshmem_scoll_base_framework.framework_output, \
-       "%s:%d - %s()", __SCOLL_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+       "%s:%d - %s()", __SCOLL_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define SCOLL_VERBOSE(...)
 #endif
 
 #define SCOLL_ERROR(...) \
     oshmem_output(oshmem_scoll_base_framework.framework_output, \
-        "Error %s:%d - %s()",  __SCOLL_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error %s:%d - %s()",  __SCOLL_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 END_C_DECLS
 

--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -83,18 +84,18 @@ OSHMEM_DECLSPEC extern mca_base_framework_t oshmem_spml_base_framework;
 #ifdef OPAL_ENABLE_DEBUG
 #define SPML_VERBOSE(level, ...) \
     oshmem_output_verbose(level, oshmem_spml_base_framework.framework_output, \
-        "%s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "%s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define SPML_VERBOSE(level, ...)
 #endif
 
 #define SPML_ERROR(...) \
     oshmem_output(oshmem_spml_base_framework.framework_output, \
-        "Error %s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error %s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #define SPML_WARNING(...) \
     oshmem_output_verbose(0, oshmem_spml_base_framework.framework_output, \
-        "Warning %s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Warning %s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 END_C_DECLS
 

--- a/oshmem/mca/sshmem/base/base.h
+++ b/oshmem/mca/sshmem/base/base.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -133,18 +134,18 @@ OSHMEM_DECLSPEC extern mca_base_framework_t oshmem_sshmem_base_framework;
 #if OPAL_ENABLE_DEBUG
 #define SSHMEM_VERBOSE(level, ...) \
     oshmem_output_verbose(level, oshmem_sshmem_base_framework.framework_output, \
-        "%s:%d - %s()", __SSHMEM_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "%s:%d - %s()", __SSHMEM_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define SSHMEM_VERBOSE(level, ...)
 #endif
 
 #define SSHMEM_ERROR(...) \
     oshmem_output(oshmem_sshmem_base_framework.framework_output, \
-        "Error %s:%d - %s()", __SSHMEM_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error %s:%d - %s()", __SSHMEM_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #define SSHMEM_WARN(...) \
     oshmem_output_verbose(0, oshmem_sshmem_base_framework.framework_output, \
-        "Warning %s:%d - %s()", __SSHMEM_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Warning %s:%d - %s()", __SSHMEM_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 
 /*

--- a/oshmem/shmem/shmem_api_logger.h
+++ b/oshmem/shmem/shmem_api_logger.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -29,13 +30,13 @@ OSHMEM_DECLSPEC extern int shmem_api_logger_output;
 #ifdef OPAL_ENABLE_DEBUG
 #define SHMEM_API_VERBOSE(level, ...) \
     oshmem_output_verbose(level, shmem_api_logger_output, \
-        "%s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "%s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 #else
 #define SHMEM_API_VERBOSE(level, ...)
 #endif
 
 #define SHMEM_API_ERROR(...) \
     oshmem_output(shmem_api_logger_output, \
-        "Error: %s:%d - %s()", __SPML_FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+        "Error: %s:%d - %s()", __SPML_FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #endif /*SHMEM_API_LOGGER_H*/


### PR DESCRIPTION
Same as open-mpi/ompi#774, but without the treematch fix (because treematch isn't yet on v2.x).

@rolfv since you clearly looked at open-mpi/ompi#774, please review :smile: 
