### PR TITLE
CSCuv67889: usnic: fix an error corner case

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_util.c
+++ b/ompi/mca/btl/usnic/btl_usnic_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,7 +25,9 @@ void opal_btl_usnic_exit(opal_btl_usnic_module_t *module)
     if (NULL == module) {
         /* Find the first module with an error callback */
         for (int i = 0; i < mca_btl_usnic_component.num_modules; ++i) {
-            if (NULL != mca_btl_usnic_component.usnic_active_modules[i]->pml_error_callback) {
+            if (NULL != mca_btl_usnic_component.usnic_active_modules &&
+                NULL != mca_btl_usnic_component.usnic_active_modules[i] &&
+                NULL != mca_btl_usnic_component.usnic_active_modules[i]->pml_error_callback) {
                 module = mca_btl_usnic_component.usnic_active_modules[i];
                 break;
             }


### PR DESCRIPTION
Ensure that we have non-NULL on all levels of pointers, which will save us if there are exitable errors very early during component / module initialization.

(cherry picked from commit open-mpi/ompi@b5c37dbfe2ce6353c756d161c1cd4e75d5f5f127)

@bturrubiates please review
