### PR TITLE
mca/topo: suppress picky warning

### DIFF
--- a/ompi/mca/topo/base/topo_base_lazy_init.c
+++ b/ompi/mca/topo/base/topo_base_lazy_init.c
@@ -43,7 +43,7 @@ int mca_topo_base_lazy_init(void)
          * Register and open all available components, giving them a chance to access the MCA parameters.
          */
 
-        err = mca_base_framework_open (&ompi_topo_base_framework, MCA_BASE_REGISTER_DEFAULT);
+        err = mca_base_framework_open (&ompi_topo_base_framework, MCA_BASE_OPEN_DEFAULT);
         if (OMPI_SUCCESS != err) {
             return err;
         }


### PR DESCRIPTION
When configured with --enable-picky

topo_base_lazy_init.c compiles with a warning:

  CC       base/topo_base_lazy_init.lo
base/topo_base_lazy_init.c:46:67: warning: implicit conversion from enumeration type 'enum mca_base_register_flag_t' to different enumeration type 'mca_base_open_flag_t' (aka 'enum mca_base_open_flag_t') [-Wenum-conversion]
        err = mca_base_framework_open (&ompi_topo_base_framework, MCA_BASE_REGISTER_DEFAULT);

This commit fixes this implicit conversion problem.

cherry-pick of open-mpi/ompi@10aac80

Signed-off-by: Howard Pritchard howardp@lanl.gov
