### PR TITLE
usnic: sync with master

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic.h
+++ b/ompi/mca/btl/usnic/btl_usnic.h
@@ -226,6 +226,9 @@ typedef struct opal_btl_usnic_component_t {
         / API >=v1.1, this is the endpoint.msg_prefix_size (i.e.,
         component.transport_header_len). */
     uint32_t prefix_send_offset;
+
+    /* OPAL async progress event base */
+    opal_event_base_t *opal_evbase;
 } opal_btl_usnic_component_t;
 
 OPAL_MODULE_DECLSPEC extern opal_btl_usnic_component_t mca_btl_usnic_component;

--- a/ompi/mca/btl/usnic/btl_usnic_compat.h
+++ b/ompi/mca/btl/usnic/btl_usnic_compat.h
@@ -31,6 +31,9 @@
 /* Free lists are unified into OPAL free lists */
 #  include "opal/class/opal_free_list.h"
 
+/* Inclue the progress thread stuff */
+#  include "opal/runtime/opal_progress_threads.h"
+
 #  define USNIC_OUT opal_btl_base_framework.framework_output
 /* JMS Really want to be able to get the job size somehow...  But for
    now, so that we can compile, just set it to a constant :-( */
@@ -95,6 +98,8 @@ usnic_compat_proc_name_compare(opal_process_name_t a,
 #  define USNIC_MCW_SIZE ompi_process_info.num_procs
 #  define proc_bound() (ompi_rte_proc_is_bound)
 #  define opal_proc_local_get() ompi_proc_local()
+
+#  define opal_sync_event_base opal_event_base
 
 #  define opal_process_info orte_process_info
 
@@ -185,6 +190,25 @@ usnic_compat_proc_name_compare(opal_process_name_t a,
     return ompi_rte_compare_name_fields(OMPI_RTE_CMP_ALL, &a, &b);
 }
 
+/* Hotels in v1.8 */
+#  include "opal/class/opal_hotel.h"
+
+/*
+ * Performance critical; needs to be inline
+ */
+static inline int
+usnic_compat_opal_hotel_init(opal_hotel_t *hotel, int num_rooms,
+                             opal_event_base_t *evbase,
+                             uint32_t eviction_timeout,
+                             int eviction_event_priority,
+                             opal_hotel_eviction_callback_fn_t evict_callback_fn)
+{
+    return opal_hotel_init(hotel, num_rooms, eviction_timeout,
+                           eviction_event_priority, evict_callback_fn);
+}
+#define opal_hotel_init usnic_compat_opal_hotel_init
+
+
 /*
  * Replicate functions that exist on master
  */
@@ -207,6 +231,17 @@ int usnic_compat_free_list_init(opal_free_list_t *free_list,
                                 void *unused0,
                                 opal_free_list_item_init_fn_t item_init,
                                 void *ctx);
+
+/*
+ * Start the connectivity checker progress thread
+ */
+opal_event_base_t *opal_progress_thread_init(const char *name);
+
+/*
+ * Stop the connectivity checker progress thread
+ */
+int opal_progress_thread_finalize(const char *name);
+
 
 /************************************************************************/
 

--- a/ompi/mca/btl/usnic/btl_usnic_component.c
+++ b/ompi/mca/btl/usnic/btl_usnic_component.c
@@ -650,12 +650,23 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
          against libfabric v1.1.0 (i.e., API v1.1).
 
        So never request API v1.0 -- always request a minimum of
-       v1.1. */
+       v1.1.
+
+       NOTE: The configure.m4 in this component will require libfabric
+       >= v1.1.0 (i.e., it won't accept v1.0.0) because of a critical
+       bug in the usnic provider in libfabric v1.0.0.  However, the
+       compatibility code with libfabric v1.0.0 in the usNIC BTL has
+       been retained, for two reasons:
+
+       1. It's not harmful, nor overly complicated.  So the
+          compatibility code was not ripped out.
+       2. At least some versions of Cisco Open MPI are shipping with
+          an embedded (libfabric v1.0.0+critical bug fix).
+
+       Someday, #2 may no longer be true, and we may therefore rip out
+       the libfabric v1.0.0 compatibility code. */
     uint32_t libfabric_api;
-    libfabric_api = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
-    if (libfabric_api == FI_VERSION(1, 0)) {
-        libfabric_api = FI_VERSION(1, 1);
-    }
+    libfabric_api = FI_VERSION(1, 1);
     ret = fi_getinfo(libfabric_api, NULL, 0, 0, &hints, &info_list);
     if (0 != ret) {
         opal_output_verbose(5, USNIC_OUT,

--- a/ompi/mca/btl/usnic/btl_usnic_endpoint.c
+++ b/ompi/mca/btl/usnic/btl_usnic_endpoint.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2007      The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,6 +87,7 @@ static void endpoint_construct(mca_btl_base_endpoint_t* endpoint)
     OBJ_CONSTRUCT(&endpoint->endpoint_hotel, opal_hotel_t);
     opal_hotel_init(&endpoint->endpoint_hotel,
                     WINDOW_SIZE,
+                    opal_sync_event_base,
                     mca_btl_usnic_component.retrans_timeout,
                     0,
                     opal_btl_usnic_ack_timeout);

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1609,6 +1609,7 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
     channel->fastsend_wqe_thresh = sd_num - 10;
 
     channel->credits = sd_num;
+    channel->rx_post_cnt = 0;
 
     /* We did math up in component_init() to know that there should be
        enough CQs available.  So if create_cq() fails, then either the
@@ -2100,8 +2101,9 @@ static void init_async_event(opal_btl_usnic_module_t *module)
         return;
     }
 
-    /* Get the fd to receive events on this device */
-    opal_event_set(opal_event_base, &(module->device_async_event), fd,
+    /* Get the fd to receive events on this device.  Keep this in the
+       sync event base (not the async event base) */
+    opal_event_set(opal_sync_event_base, &(module->device_async_event), fd,
                    OPAL_EV_READ | OPAL_EV_PERSIST,
                    module_async_event_callback, module);
     opal_event_add(&(module->device_async_event), NULL);

--- a/ompi/mca/btl/usnic/btl_usnic_stats.c
+++ b/ompi/mca/btl/usnic/btl_usnic_stats.c
@@ -212,7 +212,8 @@ int opal_btl_usnic_stats_init(opal_btl_usnic_module_t *module)
         module->stats.timeout.tv_sec = mca_btl_usnic_component.stats_frequency;
         module->stats.timeout.tv_usec = 0;
 
-        opal_event_set(opal_event_base, &(module->stats.timer_event),
+        opal_event_set(mca_btl_usnic_component.opal_evbase,
+                       &(module->stats.timer_event),
                        -1, EV_TIMEOUT | EV_PERSIST,
                        &usnic_stats_callback, module);
         opal_event_add(&(module->stats.timer_event),


### PR DESCRIPTION
Sync with the latest master usnic BTL, including the OPAL async progress thread, the new opal_sync_event_base name, and fixing a race between the connectivity checker agent shutting down before all clients could connect.
