### PR TITLE
Make the async copy the default.

### DIFF
--- a/ompi/mca/common/cuda/common_cuda.c
+++ b/ompi/mca/common/cuda/common_cuda.c
@@ -317,7 +317,7 @@ int mca_common_cuda_stage_one_init(void)
 #endif /* OPAL_CUDA_SUPPORT_41 */
 
     /* Use this flag to test cuMemcpyAsync vs cuMemcpy */
-    mca_common_cuda_cumemcpy_async = 0;
+    mca_common_cuda_cumemcpy_async = 1;
     (void) mca_base_var_register("ompi", "mpi", "common_cuda", "cumemcpy_async",
                                  "Set to 0 to force CUDA cuMemcpy instead of cuMemcpyAsync/cuStreamSynchronize",
                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,


### PR DESCRIPTION
This is a one character change that makes the async copy the default.  This has been the default in the master version for almost a year so it is time to put it in the 1.10 series also.
@jsquyres Can you review?
@rhc54 I need this in 1.10 FYI
