### PR TITLE
Initialize variable to make clang happy

### DIFF
--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -66,7 +66,7 @@ static void set(orte_job_t *jobdat,
     hwloc_obj_t root;
     opal_hwloc_topo_data_t *sum;
     orte_app_context_t *context;
-    int rc;
+    int rc=ORTE_ERROR;
     char *msg, *param;
     char *cpu_bitmap;
 


### PR DESCRIPTION
cherry-pick of open-mpi/ompi@014a6a59

@rhc54 

noticed with --enable-picky as prep work for removing crcp from v2.x
