### PR TITLE
Makefile.am's: if calling OPAL functions, must link to it

### DIFF
--- a/ompi/debuggers/Makefile.am
+++ b/ompi/debuggers/Makefile.am
@@ -43,7 +43,9 @@ headers = \
 # Simple checks to ensure that the DSOs are functional
 
 dlopen_test_SOURCES = dlopen_test.c
-dlopen_test_LDADD = $(top_builddir)/ompi/libmpi.la
+dlopen_test_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 dlopen_test_DEPENDENCIES = $(ompi_predefined_LDADD)
 
 predefined_gap_test_SOURCES = predefined_gap_test.c

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -41,61 +41,62 @@ TESTS = $(check_PROGRAMS)
 
 opal_bitmap_SOURCES = opal_bitmap.c
 opal_bitmap_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_bitmap_DEPENDENCIES = $(opal_bitmap_LDADD)
 
 opal_list_SOURCES = opal_list.c
 opal_list_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_list_DEPENDENCIES = $(opal_list_LDADD)
 
 opal_tree_SOURCES = opal_tree.c
 opal_tree_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_tree_DEPENDENCIES = $(opal_tree_LDADD)
 
 opal_hash_table_SOURCES = opal_hash_table.c
 opal_hash_table_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_hash_table_DEPENDENCIES = $(opal_hash_table_LDADD)
 
 opal_proc_table_SOURCES = opal_proc_table.c
 opal_proc_table_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_proc_table_DEPENDENCIES = $(opal_proc_table_LDADD)
 
 opal_pointer_array_SOURCES = opal_pointer_array.c
 opal_pointer_array_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_pointer_array_DEPENDENCIES = $(opal_pointer_array_LDADD)
 
 opal_value_array_SOURCES = opal_value_array.c
 opal_value_array_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_value_array_DEPENDENCIES = $(opal_value_array_LDADD)
 
 ompi_rb_tree_SOURCES = ompi_rb_tree.c
 ompi_rb_tree_LDADD = \
         $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)
 
 opal_lifo_SOURCES = opal_lifo.c
 opal_lifo_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 opal_lifo_DEPENDENCIES = $(opal_lifo_LDADD)
 
 opal_fifo_SOURCES = opal_fifo.c
 opal_fifo_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
 

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -23,31 +23,45 @@ check_PROGRAMS = $(TESTS) $(MPI_CHECKS)
 
 unpack_ooo_SOURCES = unpack_ooo.c ddt_lib.c ddt_lib.h
 unpack_ooo_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-unpack_ooo_LDADD = $(top_builddir)/ompi/libmpi.la
+unpack_ooo_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_test_SOURCES = ddt_test.c ddt_lib.c ddt_lib.h
 ddt_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_test_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_test_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_raw_SOURCES = ddt_raw.c ddt_lib.c ddt_lib.h
 ddt_raw_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_raw_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_raw_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_pack_SOURCES = ddt_pack.c
 ddt_pack_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_pack_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_pack_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 checksum_SOURCES = checksum.c
 checksum_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-checksum_LDADD = $(top_builddir)/ompi/libmpi.la
+checksum_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 position_SOURCES = position.c
 position_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-position_LDADD = $(top_builddir)/ompi/libmpi.la
+position_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 position_noncontig_SOURCES = position_noncontig.c
 position_noncontig_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-position_noncontig_LDADD = $(top_builddir)/ompi/libmpi.la
+position_noncontig_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 to_self_SOURCES = to_self.c
 to_self_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
@@ -55,5 +69,5 @@ to_self_LDADD = $(top_builddir)/ompi/libmpi.la
 
 opal_datatype_test_SOURCES = opal_datatype_test.c opal_ddt_lib.c opal_ddt_lib.h
 opal_datatype_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-opal_datatype_test_LDADD = $(top_builddir)/opal/libopen-pal.la
-
+opal_datatype_test_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la


### PR DESCRIPTION
On some OSs (e.g., Ubuntu 14.04.2 LTS), the linker is configured such that the symbols of library dependencies are not available to the application.  Hence, we need to explicitly list such dependencies when creating the executable.

For this commit, these tests are use OPAL function calls, so we must explicitly link in libopen-pal.so.

(cherry picked from commit open-mpi/ompi@42b9a966d622c190e65c2f3fbbc998da7b066f6f)
