### PR TITLE
Makefile.am's: if calling OPAL functions, must link to it

### DIFF
--- a/ompi/debuggers/Makefile.am
+++ b/ompi/debuggers/Makefile.am
@@ -43,7 +43,9 @@ headers = \
 # Simple checks to ensure that the DSOs are functional
 
 dlopen_test_SOURCES = dlopen_test.c
-dlopen_test_LDADD = $(top_builddir)/ompi/libmpi.la
+dlopen_test_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 dlopen_test_DEPENDENCIES = $(ompi_predefined_LDADD)
 
 predefined_gap_test_SOURCES = predefined_gap_test.c

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -75,6 +75,7 @@ opal_value_array_DEPENDENCIES = $(opal_value_array_LDADD)
 ompi_rb_tree_SOURCES = ompi_rb_tree.c
 ompi_rb_tree_LDADD = \
         $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)
 

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -21,27 +21,39 @@ check_PROGRAMS = $(TESTS) $(MPI_CHECKS)
 
 ddt_test_SOURCES = ddt_test.c ddt_lib.c ddt_lib.h
 ddt_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_test_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_test_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 ddt_raw_SOURCES = ddt_raw.c ddt_lib.c ddt_lib.h
 ddt_raw_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_raw_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_raw_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 ddt_pack_SOURCES = ddt_pack.c
 ddt_pack_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-ddt_pack_LDADD = $(top_builddir)/ompi/libmpi.la
+ddt_pack_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 checksum_SOURCES = checksum.c
 checksum_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-checksum_LDADD = $(top_builddir)/ompi/libmpi.la
+checksum_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 position_SOURCES = position.c
 position_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-position_LDADD = $(top_builddir)/ompi/libmpi.la
+position_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 position_noncontig_SOURCES = position_noncontig.c
 position_noncontig_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-position_noncontig_LDADD = $(top_builddir)/ompi/libmpi.la
+position_noncontig_LDADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 to_self_SOURCES = to_self.c
 to_self_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)


### PR DESCRIPTION
On some OSs (e.g., Ubuntu 14.04.2 LTS), the linker is configured such that the symbols of library dependencies are not available to the application.  Hence, we need to explicitly list such dependencies when creating the executable.

For this commit, these tests are use OPAL function calls, so we must explicitly link in libopen-pal.so.

(ported from open-mpi/ompi@42b9a966d622c190e65c2f3fbbc998da7b066f6f)

@rhc54 please review
