### PR TITLE
This is a combination of 2 commits related to fixing CUDA-aware extensions

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -456,7 +456,7 @@ AC_DEFUN([EXT_PROCESS_COMPONENT],[
 
     AC_MSG_CHECKING([if MPI Extension $component has C bindings])
 
-    AS_IF([test ! -e "$test_header"],
+    AS_IF([test ! -e "$test_header" && test ! -e "$test_header.in"],
           [ # There *must* be C bindings
            AC_MSG_RESULT([no])
            AC_MSG_WARN([C bindings for MPI extensions are required])

--- a/ompi/mpiext/cuda/c/mpiext_cuda_c.h.in
+++ b/ompi/mpiext/cuda/c/mpiext_cuda_c.h.in
@@ -12,5 +12,5 @@
  *
  */
 
-#define MPIX_CUDA_AWARE_SUPPORT 1
+#define MPIX_CUDA_AWARE_SUPPORT @MPIX_CUDA_AWARE_SUPPORT@
 OMPI_DECLSPEC int MPIX_Query_cuda_support(void);

--- a/ompi/mpiext/cuda/configure.m4
+++ b/ompi/mpiext/cuda/configure.m4
@@ -17,6 +17,10 @@
 AC_DEFUN([OMPI_MPIEXT_cuda_CONFIG],[
     AC_CONFIG_FILES([ompi/mpiext/cuda/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/cuda/c/Makefile])
+    AC_CONFIG_HEADER([ompi/mpiext/cuda/c/mpiext_cuda_c.h])
+
+    AC_DEFINE_UNQUOTED([MPIX_CUDA_AWARE_SUPPORT],[$CUDA_SUPPORT],
+                       [Macro that is set to 1 when CUDA-aware support is configured in and 0 when it is not])
 
     # We compile this whether CUDA support was requested or not. It allows
     # us to to detect if we have CUDA support.


### PR DESCRIPTION
Fix macro return value when not CUDA-aware
(cherry picked from commit open-mpi/ompi@0e87478e4023dd50283c1b4919c725c0a8183bb2)

ompi_ext.m4: allow extensions to have config.h.in
Previously, extensions were required to have a config.h for their C
bindings.  This commit allows them to have a config.h.in, in case
their C bindings header file is generated.
(cherry picked from commit open-mpi/ompi@6a7d5271c431aec20750460ba906c9de21a265bd)

Once again, I elect @jsquyres to review.  I included your earlier change to look at *.in files in this as well Jeff or else I cannot bring my stuff over.
