### PR TITLE
mtl/ofi: Require proper ordering by OFI provider.

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -127,6 +127,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
      * ep_type:  reliable datagram operation
      * caps:     Capabilities required from the provider.
      *           Tag matching is specified to implement MPI semantics.
+     * msg_order: Guarantee that messages with same tag are ordered.
      */
     hints = fi_allocinfo();
     if (!hints) {
@@ -135,9 +136,11 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                             __FILE__, __LINE__);
         goto error;
     }
-    hints->mode             = FI_CONTEXT;
-    hints->ep_attr->type    = FI_EP_RDM;      /* Reliable datagram         */
-    hints->caps             = FI_TAGGED;      /* Tag matching interface    */
+    hints->mode               = FI_CONTEXT;
+    hints->ep_attr->type      = FI_EP_RDM;      /* Reliable datagram         */
+    hints->caps               = FI_TAGGED;      /* Tag matching interface    */
+    hints->tx_attr->msg_order = FI_ORDER_SAS;
+    hints->rx_attr->msg_order = FI_ORDER_SAS;
 
     /**
      * Refine filter for additional capabilities


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@98b300e1bbe11e298a804084be33e47bc795a4c0)

Submitted by @yburette, approved by @jsquyres
