### PR TITLE
v1.8 asm fix

### DIFF
--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -174,10 +174,10 @@ static inline int32_t opal_atomic_swap_32( volatile int32_t *addr,
     return oldval;
 }
 
-#endif /* OPAL_GCC_INLINE_ASSEMBLY */
+#endif /* OMPI_GCC_INLINE_ASSEMBLY */
 
 
-#if OPAL_GCC_INLINE_ASSEMBLY
+#if OMPI_GCC_INLINE_ASSEMBLY
 
 /**
  * atomic_add - add integer to atomic variable


### PR DESCRIPTION
@rhc54 This fixes an error in ia32 builds introduced by an error in a cherry-pick. Close this if you do not want to bother with a 1.8.9.

Will apply a similar fix to 1.10
