### PR TITLE
Java GC bugfix

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -620,7 +620,9 @@ public final Request iSend(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iSend(handle, buf, count, type.handle, dest, tag));
+    Request req = new Request(iSend(handle, buf, count, type.handle, dest, tag));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iSend(
@@ -645,7 +647,9 @@ public final Request ibSend(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(ibSend(handle, buf, count, type.handle, dest, tag));
+    Request req = new Request(ibSend(handle, buf, count, type.handle, dest, tag));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long ibSend(
@@ -670,7 +674,9 @@ public final Request isSend(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(isSend(handle, buf, count, type.handle, dest, tag));
+    Request req = new Request(isSend(handle, buf, count, type.handle, dest, tag));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long isSend(
@@ -695,7 +701,9 @@ public final Request irSend(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(irSend(handle, buf, count, type.handle, dest, tag));
+    Request req = new Request(irSend(handle, buf, count, type.handle, dest, tag));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long irSend(
@@ -720,7 +728,9 @@ public final Request iRecv(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iRecv(handle, buf, count, type.handle, source, tag));
+    Request req = new Request(iRecv(handle, buf, count, type.handle, source, tag));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iRecv(
@@ -748,7 +758,9 @@ public final Prequest sendInit(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Prequest(sendInit(handle, buf, count, type.handle, dest, tag));
+    Prequest preq = new Prequest(sendInit(handle, buf, count, type.handle, dest, tag));
+    preq.addSendBufRef(buf);
+    return preq;
 }
 
 private native long sendInit(
@@ -773,7 +785,9 @@ public final Prequest bSendInit(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Prequest(bSendInit(handle, buf, count, type.handle, dest, tag));
+    Prequest preq = new Prequest(bSendInit(handle, buf, count, type.handle, dest, tag));
+    preq.addSendBufRef(buf);
+    return preq;
 }
 
 private native long bSendInit(
@@ -798,7 +812,9 @@ public final Prequest sSendInit(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Prequest(sSendInit(handle, buf, count, type.handle, dest, tag));
+    Prequest preq = new Prequest(sSendInit(handle, buf, count, type.handle, dest, tag));
+    preq.addSendBufRef(buf);
+    return preq;
 }
 
 private native long sSendInit(
@@ -823,7 +839,9 @@ public final Prequest rSendInit(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Prequest(rSendInit(handle, buf, count, type.handle, dest, tag));
+    Prequest preq = new Prequest(rSendInit(handle, buf, count, type.handle, dest, tag));
+    preq.addSendBufRef(buf);
+    return preq;
 }
 
 private native long rSendInit(
@@ -848,7 +866,9 @@ public final Prequest recvInit(Buffer buf, int count,
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Prequest(recvInit(handle, buf, count, type.handle, source, tag));
+    Prequest preq = new Prequest(recvInit(handle, buf, count, type.handle, source, tag));
+    preq.addRecvBufRef(buf);
+    return preq;
 }
 
 private native long recvInit(
@@ -1231,7 +1251,9 @@ public final Request iBcast(Buffer buf, int count, Datatype type, int root)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iBcast(handle, buf, count, type.handle, root));
+    Request req = new Request(iBcast(handle, buf, count, type.handle, root));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iBcast(
@@ -1337,9 +1359,11 @@ public final Request iGather(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iGather(handle, sendbuf, sendcount, sendtype.handle,
-                               recvbuf, recvcount, recvtype.handle, root));
+    Request req = new Request(iGather(handle, sendbuf, sendcount, sendtype.handle,
+            recvbuf, recvcount, recvtype.handle, root));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -1360,9 +1384,10 @@ public final Request iGather(Buffer buf, int count, Datatype type, int root)
 {
     MPI.check();
     assertDirectBuffer(buf);
-
-    return new Request(iGather(handle, null, 0, 0,
-                               buf, count, type.handle, root));
+    Request req = new Request(iGather(handle, null, 0, 0,
+            buf, count, type.handle, root));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iGather(
@@ -1506,10 +1531,12 @@ public final Request iGatherv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iGatherv(
+    Request req = new Request(iGatherv(
             handle, sendbuf, sendcount, sendtype.handle,
             recvbuf, recvcount, displs, recvtype.handle, root));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -1532,9 +1559,10 @@ public final Request iGatherv(Buffer recvbuf, int[] recvcount, int[] displs,
 {
     MPI.check();
     assertDirectBuffer(recvbuf);
-
-    return new Request(iGatherv(handle, null, 0, 0,
+    Request req = new Request(iGatherv(handle, null, 0, 0,
             recvbuf, recvcount, displs, recvtype.handle, root));
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -1556,9 +1584,10 @@ public final Request iGatherv(Buffer sendbuf, int sendcount,
 {
     MPI.check();
     assertDirectBuffer(sendbuf);
-
-    return new Request(iGatherv(handle, sendbuf, sendcount, sendtype.handle,
-                                null, null, null, 0, root));
+    Request req = new Request(iGatherv(handle, sendbuf, sendcount, sendtype.handle,
+            null, null, null, 0, root));
+    req.addSendBufRef(sendbuf);
+    return req;
 }
 
 private native long iGatherv(
@@ -1665,9 +1694,11 @@ public final Request iScatter(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iScatter(handle, sendbuf, sendcount, sendtype.handle,
-                                recvbuf, recvcount, recvtype.handle, root));
+    Request req = new Request(iScatter(handle, sendbuf, sendcount, sendtype.handle,
+            recvbuf, recvcount, recvtype.handle, root));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -1688,9 +1719,10 @@ public final Request iScatter(Buffer buf, int count, Datatype type, int root)
 {
     MPI.check();
     assertDirectBuffer(buf);
-
-    return new Request(iScatter(handle, buf, count, type.handle,
-                                null, 0, 0, root));
+    Request req = new Request(iScatter(handle, buf, count, type.handle,
+            null, 0, 0, root));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iScatter(
@@ -1831,10 +1863,12 @@ public final Request iScatterv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iScatterv(
+    Request req = new Request(iScatterv(
             handle, sendbuf, sendcount, displs, sendtype.handle,
             recvbuf, recvcount, recvtype.handle, root));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -1856,9 +1890,10 @@ public final Request iScatterv(Buffer sendbuf, int[] sendcount, int[] displs,
 {
     MPI.check();
     assertDirectBuffer(sendbuf);
-
-    return new Request(iScatterv(handle, sendbuf, sendcount, displs,
-                                 sendtype.handle, null, 0, 0, root));
+    Request req = new Request(iScatterv(handle, sendbuf, sendcount, displs,
+            sendtype.handle, null, 0, 0, root));
+    req.addSendBufRef(sendbuf);
+    return req;
 }
 
 /**
@@ -1879,9 +1914,10 @@ public final Request iScatterv(Buffer recvbuf, int recvcount,
 {
     MPI.check();
     assertDirectBuffer(recvbuf);
-
-    return new Request(iScatterv(handle, null, null, null, 0,
-                                 recvbuf, recvcount, recvtype.handle, root));
+    Request req = new Request(iScatterv(handle, null, null, null, 0,
+            recvbuf, recvcount, recvtype.handle, root));
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iScatterv(
@@ -1981,9 +2017,11 @@ public final Request iAllGather(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iAllGather(handle, sendbuf, sendcount, sendtype.handle,
-                                  recvbuf, recvcount, recvtype.handle));
+    Request req = new Request(iAllGather(handle, sendbuf, sendcount, sendtype.handle,
+            recvbuf, recvcount, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -2001,7 +2039,9 @@ public final Request iAllGather(Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iAllGather(handle, null, 0, 0, buf, count, type.handle));
+    Request req = new Request(iAllGather(handle, null, 0, 0, buf, count, type.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iAllGather(
@@ -2106,10 +2146,12 @@ public final Request iAllGatherv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iAllGatherv(
+    Request req = new Request(iAllGatherv(
             handle, sendbuf, sendcount, sendtype.handle,
             recvbuf, recvcount, displs, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -2129,9 +2171,10 @@ public final Request iAllGatherv(
 {
     MPI.check();
     assertDirectBuffer(buf);
-
-    return new Request(iAllGatherv(
+    Request req = new Request(iAllGatherv(
             handle, null, 0, 0, buf, count, displs, type.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iAllGatherv(
@@ -2206,9 +2249,11 @@ public final Request iAllToAll(Buffer sendbuf, int sendcount, Datatype sendtype,
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iAllToAll(handle, sendbuf, sendcount, sendtype.handle,
-                                 recvbuf, recvcount, recvtype.handle));
+    Request req = new Request(iAllToAll(handle, sendbuf, sendcount, sendtype.handle,
+            recvbuf, recvcount, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iAllToAll(
@@ -2291,10 +2336,12 @@ public final Request iAllToAllv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iAllToAllv(
+    Request req = new Request(iAllToAllv(
             handle, sendbuf, sendcount, sdispls, sendtype.handle,
             recvbuf, recvcount, rdispls, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iAllToAllv(long comm,
@@ -2368,10 +2415,12 @@ public final Request iNeighborAllGather(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iNeighborAllGather(
+    Request req = new Request(iNeighborAllGather(
             handle, sendbuf, sendcount, sendtype.handle,
             recvbuf, recvcount, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iNeighborAllGather(
@@ -2446,10 +2495,12 @@ public final Request iNeighborAllGatherv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iNeighborAllGatherv(
+    Request req = new Request(iNeighborAllGatherv(
             handle, sendbuf, sendcount, sendtype.handle,
             recvbuf, recvcount, displs, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iNeighborAllGatherv(
@@ -2523,10 +2574,12 @@ public final Request iNeighborAllToAll(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iNeighborAllToAll(
+    Request req = new Request(iNeighborAllToAll(
             handle, sendbuf, sendcount, sendtype.handle,
             recvbuf, recvcount, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iNeighborAllToAll(
@@ -2604,10 +2657,12 @@ public final Request iNeighborAllToAllv(
 {
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iNeighborAllToAllv(
+    Request req = new Request(iNeighborAllToAllv(
             handle, sendbuf, sendcount, sdispls, sendtype.handle,
             recvbuf, recvcount, rdispls, recvtype.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 private native long iNeighborAllToAllv(
@@ -2721,10 +2776,12 @@ public final Request iReduce(Buffer sendbuf, Buffer recvbuf,
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
     op.setDatatype(type);
-
-    return new Request(iReduce(
+    Request req = new Request(iReduce(
             handle, sendbuf, recvbuf, count,
             type.handle, type.baseType, op, op.handle, root));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -2748,10 +2805,11 @@ public final Request iReduce(Buffer buf, int count,
     MPI.check();
     assertDirectBuffer(buf);
     op.setDatatype(type);
-
-    return new Request(iReduce(
+    Request req = new Request(iReduce(
             handle, null, buf, count,
             type.handle, type.baseType, op, op.handle, root));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iReduce(
@@ -2852,9 +2910,11 @@ public final Request iAllReduce(Buffer sendbuf, Buffer recvbuf,
     MPI.check();
     assertDirectBuffer(sendbuf, recvbuf);
     op.setDatatype(type);
-
-    return new Request(iAllReduce(handle, sendbuf, recvbuf, count,
-                                  type.handle, type.baseType, op, op.handle));
+    Request req = new Request(iAllReduce(handle, sendbuf, recvbuf, count,
+            type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -2875,10 +2935,11 @@ public final Request iAllReduce(Buffer buf, int count, Datatype type, Op op)
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(buf);
-
-    return new Request(iAllReduce(
+    Request req = new Request(iAllReduce(
             handle, null, buf, count,
             type.handle, type.baseType, op, op.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iAllReduce(
@@ -2981,10 +3042,12 @@ public final Request iReduceScatter(Buffer sendbuf, Buffer recvbuf,
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iReduceScatter(
+    Request req = new Request(iReduceScatter(
             handle, sendbuf, recvbuf, recvcounts,
             type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -3007,10 +3070,11 @@ public final Request iReduceScatter(
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(buf);
-
-    return new Request(iReduceScatter(
+    Request req = new Request(iReduceScatter(
             handle, null, buf, counts,
             type.handle, type.baseType, op, op.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iReduceScatter(
@@ -3108,10 +3172,12 @@ public final Request iReduceScatterBlock(
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iReduceScatterBlock(
+    Request req = new Request(iReduceScatterBlock(
             handle, sendbuf, recvbuf, recvcount,
             type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -3132,10 +3198,11 @@ public final Request iReduceScatterBlock(
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(buf);
-
-    return new Request(iReduceScatterBlock(
+    Request req = new Request(iReduceScatterBlock(
             handle, null, buf, count, type.handle,
             type.baseType, op, op.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iReduceScatterBlock(

--- a/ompi/mpi/java/java/File.java
+++ b/ompi/mpi/java/java/File.java
@@ -394,7 +394,9 @@ public Request iReadAt(long offset, Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iReadAt(handle, offset, buf, count, type.handle));
+    Request req = new Request(iReadAt(handle, offset, buf, count, type.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iReadAt(
@@ -415,7 +417,9 @@ public Request iWriteAt(long offset, Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iWriteAt(handle, offset, buf, count, type.handle));
+    Request req = new Request(iWriteAt(handle, offset, buf, count, type.handle));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iWriteAt(
@@ -550,7 +554,9 @@ public Request iRead(Buffer buf, int count, Datatype type) throws MPIException
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iRead(handle, buf, count, type.handle));
+    Request req = new Request(iRead(handle, buf, count, type.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iRead(long fh, Buffer buf, int count, long type)
@@ -568,7 +574,9 @@ public Request iWrite(Buffer buf, int count, Datatype type) throws MPIException
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iWrite(handle, buf, count, type.handle));
+    Request req = new Request(iWrite(handle, buf, count, type.handle));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iWrite(long fh, Buffer buf, int count, long type)
@@ -692,7 +700,9 @@ public Request iReadShared(Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iReadShared(handle, buf, count, type.handle));
+    Request req = new Request(iReadShared(handle, buf, count, type.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iReadShared(long fh, Buffer buf, int count, long type)
@@ -711,7 +721,9 @@ public Request iWriteShared(Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(iWriteShared(handle, buf, count, type.handle));
+    Request req = new Request(iWriteShared(handle, buf, count, type.handle));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iWriteShared(long fh, Buffer buf, int count, long type)

--- a/ompi/mpi/java/java/Intracomm.java
+++ b/ompi/mpi/java/java/Intracomm.java
@@ -419,9 +419,11 @@ public final Request iScan(Buffer sendbuf, Buffer recvbuf,
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iScan(handle, sendbuf, recvbuf, count,
-                             type.handle, type.baseType, op, op.handle));
+    Request req = new Request(iScan(handle, sendbuf, recvbuf, count,
+            type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -441,10 +443,11 @@ public final Request iScan(Buffer buf, int count, Datatype type, Op op)
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(buf);
-
-    return new Request(iScan(
+    Request req = new Request(iScan(
             handle, null, buf, count,
             type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(buf);
+    return req;
 }
 
 private native long iScan(
@@ -543,9 +546,11 @@ public final Request iExScan(Buffer sendbuf, Buffer recvbuf,
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(sendbuf, recvbuf);
-
-    return new Request(iExScan(handle, sendbuf, recvbuf, count,
-                               type.handle, type.baseType, op, op.handle));
+    Request req = new Request(iExScan(handle, sendbuf, recvbuf, count,
+            type.handle, type.baseType, op, op.handle));
+    req.addSendBufRef(sendbuf);
+    req.addRecvBufRef(recvbuf);
+    return req;
 }
 
 /**
@@ -565,10 +570,11 @@ public final Request iExScan(Buffer buf, int count, Datatype type, Op op)
     MPI.check();
     op.setDatatype(type);
     assertDirectBuffer(buf);
-
-    return new Request(iExScan(
+    Request req = new Request(iExScan(
             handle, null, buf, count,
             type.handle, type.baseType, op, op.handle));
+    req.addRecvBufRef(buf);
+    return req;
 }
 
 private native long iExScan(

--- a/ompi/mpi/java/java/Message.java
+++ b/ompi/mpi/java/java/Message.java
@@ -149,7 +149,9 @@ public Request imRecv(Buffer buf, int count, Datatype type)
 {
     MPI.check();
     assertDirectBuffer(buf);
-    return new Request(imRecv(handle, buf, count, type.handle));
+    Request req = new Request(imRecv(handle, buf, count, type.handle));
+    req.addRecvBufRef(buf);
+    return req; 
 }
 
 private native long imRecv(long message, Object buf, int count, long type)

--- a/ompi/mpi/java/java/Request.java
+++ b/ompi/mpi/java/java/Request.java
@@ -61,12 +61,16 @@
 
 package mpi;
 
+import java.nio.Buffer;
+
 /**
  * Request object.
  */
 public class Request implements Freeable
 {
 protected long handle;
+protected Buffer sendBuf;
+protected Buffer recvBuf;
 
 static
 {
@@ -108,6 +112,32 @@ public final void cancel() throws MPIException
 }
 
 private native void cancel(long request) throws MPIException;
+
+/**
+ * Adds a receive buffer to this Request object.  This method 
+ * should be called by the internal api whenever a persistent 
+ * request is created and any time a request object, that has 
+ * an associated buffer, is returned from an opperation to protect 
+ * the buffer from getting prematurely garbage collected.
+ * @param buf buffer to add to the array list
+ */
+protected final void addRecvBufRef(Buffer buf)
+{
+	this.recvBuf = buf;
+}
+
+/**
+ * Adds a send buffer to this Request object.  This method 
+ * should be called by the internal api whenever a persistent 
+ * request is created and any time a request object, that has 
+ * an associated buffer, is returned from an opperation to protect 
+ * the buffer from getting prematurely garbage collected.
+ * @param buf buffer to add to the array list
+ */
+protected final void addSendBufRef(Buffer buf)
+{
+	this.sendBuf = buf;
+}
 
 /**
  * Test if request object is null.


### PR DESCRIPTION
This pull request adds two Buffer references to the
Request class. Whenever a request object is created
that has associated buffers, the buffers should be added
to these references so the java garbage collector does
not dispose of the buffers prematurely.

This is a more robust expansion on the idea first proposed by
@ggouaillardet, and further discussed in open-mpi/ompi#369.

Fixes open-mpi/ompi#369

Manual cherry-pick from open-mpi/ompi@d363b5d8326c33b275684a2a097162fc63c0e62e

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
