### PR TITLE
fortran sizeof: ensure mpi_sizeof*f90 is not empty

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -227,16 +227,24 @@ sub output_file {
 ! compiler to build Open MPI.\n\n";
 
         if ($want_bodies) {
+            my $name = "ompi_sad_panda";
+            $name = "pompi_sad_panda"
+                if ($pmpi_arg);
             print OUT "!
 ! Dummy subroutine, just so that there is *some* Fortran in this file
-! (some compilers are unhappy if there are no Fortran statements in this
+! (this is defensive programming: since the Fortran compiler doesn't
+! support enough mojo, configure should set some AM_CONDITIONALs such
+! that this file should not end up being compiled, but just in case
+! that logic changes someday and this file *does* end up getting
+! compiled, make sure that it's not entirely empty because some
+! compilers are unhappy if there are no Fortran statements in this
 ! file).
-subroutine ompi_sad_panda()
+subroutine $name()
   implicit none
 
   print *, 'Open MPI is a sad panda because your Fortran compiler'
   print *, 'does not support enough Fortran mojo for MPI_SIZEOF'
-end subroutine ompi_sad_panda\n\n";
+end subroutine $name\n\n";
         }
     }
 

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -218,12 +218,26 @@ sub output_file {
 ! Specifically: we need support for the INTERFACE keyword,
 ! ISO_FORTRAN_ENV, and the STORAGE_SIZE() intrinsic on all types.
 ! Apparently, this compiler does not support both of those things, so
-! this file will be blank (i.e., we didn't bother generating the
-! necessary stuff for MPI_SIZEOF because the compiler doesn't support
+! this file will be (effecitvely) blank (i.e., we didn't bother
+! generating the necessary stuff for MPI_SIZEOF because the compiler
+! doesn't support
 ! it).
 !
 ! If you want support for MPI_SIZEOF, please use a different Fortran
 ! compiler to build Open MPI.\n\n";
+
+        if ($want_bodies) {
+            print OUT "!
+! Dummy subroutine, just so that there is *some* Fortran in this file
+! (some compilers are unhappy if there are no Fortran statements in this
+! file).
+subroutine ompi_sad_panda()
+  implicit none
+
+  print *, 'Open MPI is a sad panda because your Fortran compiler'
+  print *, 'does not support enough Fortran mojo for MPI_SIZEOF'
+end subroutine ompi_sad_panda\n\n";
+        }
     }
 
     close(OUT);

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -227,9 +227,7 @@ sub output_file {
 ! compiler to build Open MPI.\n\n";
 
         if ($want_bodies) {
-            my $name = "ompi_sad_panda";
-            $name = "pompi_sad_panda"
-                if ($pmpi_arg);
+            my $name =  $pmpi_arg ? "pompi_sad_panda" : "ompi_sad_panda";
             print OUT "!
 ! Dummy subroutine, just so that there is *some* Fortran in this file
 ! (this is defensive programming: since the Fortran compiler doesn't

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Inria.  All rights reserved.
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
@@ -25,6 +25,9 @@
 #
 
 include $(top_srcdir)/Makefile.ompi-rules
+
+CLEANFILES=
+libmpi_mpifh_pmpi_la_LIBADD =
 
 #
 # OMPI_PROFILING_DEFINES flag is enabled when we want our MPI_* symbols
@@ -430,7 +433,19 @@ $(linked_files):
 
 # psizeof_f.f90 is generated based on some results from configure tests.
 CLEANFILES += psizeof_f.f90
+
+# Build the MPI_SIZEOF code in a separate convenience library (see
+# lengthy comment in ompi/mpi/fortran/mpif-h/Makefile.am for an
+# explanation why).
+#if BUILD_FORTRAN_SIZEOF
+noinst_LTLIBRARIES += libmpi_mpifh_psizeof.la
+# Do not dist this file; it is generated
+nodist_libmpi_mpifh_psizeof_la_SOURCES = psizeof_f.f90
+libmpi_mpifh_pmpi_la_LIBADD += libmpi_mpifh_psizeof.la
+#endif
+
 sizeof_pl=$(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+
 psizeof_f.f90: $(top_builddir)/config.status
 psizeof_f.f90: $(sizeof_pl)
 psizeof_f.f90:
@@ -445,7 +460,6 @@ psizeof_f.f90:
 # The library itself
 #
 nodist_libmpi_mpifh_pmpi_la_SOURCES = \
-        psizeof_f.f90 \
         $(linked_files)
 
 # Conditionally install the header files


### PR DESCRIPTION
Per http://www.open-mpi.org/community/lists/devel/2015/08/17775.php, some compilers don't like it when there's a .f90 file that only contains comments (and no actual Fortran code).  So if OMPI determines that the Fortran compiler does not support enough Fortran mojo to support MPI_SIZEOF, generate at least one dummy Fortran subroutine that can be compiled in an otherwise barren Fortran landscape that is devoid of life and hope.

(cherry picked from commit open-mpi/ompi@d5763a8288c994e1d55a333d45f1a85d64341aff)

Thanks to @PHHargrove for raising the issue.
