### PR TITLE
mailmap: add entries to the git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,8 @@
 
 Dave Goodell <dgoodell@cisco.com> <dgoodell@open-mpi-git-mirror.example.com>
 Jeff Squyres <jsquyres@cisco.com> <jsquyres@open-mpi-git-mirror.example.com>
+# Jeff accidentally stomped on his $HOME/.gitconfig for a short while:
+Jeff Squyres <jsquyres@cisco.com> --quiet <--quiet>
 Reese Faucette <rfaucett@cisco.com> <rfaucett@open-mpi-git-mirror.example.com>
 Bill D'Amico <bdamico@cisco.com> <damico@open-mpi-git-mirror.example.com>
 Adrian Reber <adrian.reber@hs-esslingen.de> <adrian@open-mpi-git-mirror.example.com>


### PR DESCRIPTION
I borked my $HOME/.gitconfig for a few commits, resulting in several commits on Aug 20, 2015 being authored by "--quiet <--quiet>".  This .mailmap entry will correctly list those commits as being mine when
you use "git shortlog" or "git log --use-mailmap".

(cherry picked from commit open-mpi/ompi@7a7d4f2ceee7e30a732fdc69313c00571f29678c)

@hppritcha please review / approve
