### PR TITLE
fortran: (try to) align C objects used by Fortran

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -489,6 +489,7 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
                [OMPI_FORTRAN_HAVE_ASYNCHRONOUS=0])])
 
     OMPI_FORTRAN_F08_HANDLE_SIZE=4
+    OMPI_FORTRAN_F08_HANDLE_ALIGNMENT=4
     AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS && \
            test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS],
           [ # How big are derived types with a single INTEGER?
@@ -497,6 +498,9 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
 end type test_mpi_handle], 
                                    [type(test_mpi_handle)], 
                                    [OMPI_FORTRAN_F08_HANDLE_SIZE])
+           OMPI_FORTRAN_F08_GET_HANDLE_ALIGNMENT(
+                                   [type(test_mpi_handle)],
+                                   [OMPI_FORTRAN_F08_HANDLE_ALIGNMENT])
           ])
 
     OMPI_FORTRAN_NEED_WRAPPER_ROUTINES=1
@@ -714,6 +718,10 @@ end type test_mpi_handle],
     AC_DEFINE_UNQUOTED(OMPI_FORTRAN_F08_HANDLE_SIZE, 
                        $OMPI_FORTRAN_F08_HANDLE_SIZE,
                        [How many bytes the mpi_f08 TYPE(MPI_<foo>) handles will be])
+
+    AC_DEFINE_UNQUOTED(OMPI_FORTRAN_F08_HANDLE_ALIGNMENT,
+                       $OMPI_FORTRAN_F08_HANDLE_ALIGNMENT,
+                       [How many bytes the mpi_f08 TYPE(MPI_<foo>) handles will be aligned to])
 
     # These go into ompi/info/param.c
     AC_DEFINE_UNQUOTED(OMPI_FORTRAN_HAVE_F08_ASSUMED_RANK,

--- a/ompi/mpi/fortran/use-mpi-f08/constants.c
+++ b/ompi/mpi/fortran/use-mpi-f08/constants.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -20,76 +22,82 @@
  */
 typedef MPI_Fint ompi_fortran_08_handle_t[OMPI_FORTRAN_F08_HANDLE_SIZE / sizeof(MPI_Fint)];
 
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_comm_world       = {OMPI_MPI_COMM_WORLD};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_comm_self        = {OMPI_MPI_COMM_SELF};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_group_empty      = {OMPI_MPI_GROUP_EMPTY};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_errors_are_fatal = {OMPI_MPI_ERRORS_ARE_FATAL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_errors_return    = {OMPI_MPI_ERRORS_RETURN};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_message_no_proc  = {OMPI_MPI_MESSAGE_NO_PROC};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_info_env         = {OMPI_MPI_INFO_ENV};
+#if OMPI_FORTRAN_F08_HANDLE_ALIGNMENT > OMPI_FORTRAN_F08_HANDLE_SIZE
+#define OMPI_F08_HANDLE_ALIGNED __opal_attribute_aligned__(OMPI_FORTRAN_F08_HANDLE_ALIGNMENT)
+#else
+#define OMPI_F08_HANDLE_ALIGNED
+#endif
 
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_max      = {OMPI_MPI_MAX};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_min      = {OMPI_MPI_MIN};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_sum      = {OMPI_MPI_SUM};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_prod     = {OMPI_MPI_PROD};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_land     = {OMPI_MPI_LAND};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_band     = {OMPI_MPI_BAND};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_lor      = {OMPI_MPI_LOR};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_bor      = {OMPI_MPI_BOR};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_lxor     = {OMPI_MPI_LXOR};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_bxor     = {OMPI_MPI_BXOR};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_maxloc   = {OMPI_MPI_MAXLOC};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_minloc   = {OMPI_MPI_MINLOC};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_replace  = {OMPI_MPI_REPLACE};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_comm_world       = {OMPI_MPI_COMM_WORLD};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_comm_self        = {OMPI_MPI_COMM_SELF};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_group_empty      = {OMPI_MPI_GROUP_EMPTY};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_errors_are_fatal = {OMPI_MPI_ERRORS_ARE_FATAL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_errors_return    = {OMPI_MPI_ERRORS_RETURN};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_message_no_proc  = {OMPI_MPI_MESSAGE_NO_PROC};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_info_env         = {OMPI_MPI_INFO_ENV};
+
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_max      = {OMPI_MPI_MAX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_min      = {OMPI_MPI_MIN};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_sum      = {OMPI_MPI_SUM};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_prod     = {OMPI_MPI_PROD};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_land     = {OMPI_MPI_LAND};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_band     = {OMPI_MPI_BAND};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_lor      = {OMPI_MPI_LOR};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_bor      = {OMPI_MPI_BOR};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_lxor     = {OMPI_MPI_LXOR};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_bxor     = {OMPI_MPI_BXOR};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_maxloc   = {OMPI_MPI_MAXLOC};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_minloc   = {OMPI_MPI_MINLOC};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_replace  = {OMPI_MPI_REPLACE};
 
 /*
  * NULL "handles" (indices)
  */
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_comm_null       = {OMPI_MPI_COMM_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_datatype_null   = {OMPI_MPI_DATATYPE_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_errhandler_null = {OMPI_MPI_ERRHANDLER_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_group_null      = {OMPI_MPI_GROUP_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_info_null       = {OMPI_MPI_INFO_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_message_null    = {OMPI_MPI_MESSAGE_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_op_null         = {OMPI_MPI_OP_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_request_null    = {OMPI_MPI_REQUEST_NULL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_win_null        = {OMPI_MPI_WIN_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_comm_null       = {OMPI_MPI_COMM_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_datatype_null   = {OMPI_MPI_DATATYPE_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_errhandler_null = {OMPI_MPI_ERRHANDLER_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_group_null      = {OMPI_MPI_GROUP_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_info_null       = {OMPI_MPI_INFO_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_message_null    = {OMPI_MPI_MESSAGE_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_op_null         = {OMPI_MPI_OP_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_request_null    = {OMPI_MPI_REQUEST_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_win_null        = {OMPI_MPI_WIN_NULL};
 #if OMPI_PROVIDE_MPI_FILE_INTERFACE
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_file_null       = {OMPI_MPI_FILE_NULL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_file_null       = {OMPI_MPI_FILE_NULL};
 #endif
 
 /*
  * common block items from ompi/include/mpif-common.h
  */
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_byte              = {OMPI_MPI_BYTE};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_packed            = {OMPI_MPI_PACKED};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_ub                = {OMPI_MPI_UB};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_lb                = {OMPI_MPI_LB};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_character         = {OMPI_MPI_CHARACTER};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_logical           = {OMPI_MPI_LOGICAL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer           = {OMPI_MPI_INTEGER};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer1          = {OMPI_MPI_INTEGER1};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer2          = {OMPI_MPI_INTEGER2};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer4          = {OMPI_MPI_INTEGER4};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer8          = {OMPI_MPI_INTEGER8};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_integer16         = {OMPI_MPI_INTEGER16};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_real              = {OMPI_MPI_REAL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_real4             = {OMPI_MPI_REAL4};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_real8             = {OMPI_MPI_REAL8};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_real16            = {OMPI_MPI_REAL16};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_double_precision  = {OMPI_MPI_DOUBLE_PRECISION};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_complex           = {OMPI_MPI_COMPLEX};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_complex8          = {OMPI_MPI_COMPLEX8};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_complex16         = {OMPI_MPI_COMPLEX16};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_complex32         = {OMPI_MPI_COMPLEX32};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_double_complex    = {OMPI_MPI_DOUBLE_COMPLEX};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_2real             = {OMPI_MPI_2REAL};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_2double_precision = {OMPI_MPI_2DOUBLE_PRECISION};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_2integer          = {OMPI_MPI_2INTEGER};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_2complex          = {OMPI_MPI_2COMPLEX};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_2double_complex   = {OMPI_MPI_2DOUBLE_COMPLEX};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_real2             = {OMPI_MPI_REAL2};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_logical1          = {OMPI_MPI_LOGICAL1};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_logical2          = {OMPI_MPI_LOGICAL2};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_logical4          = {OMPI_MPI_LOGICAL4};
-OMPI_DECLSPEC ompi_fortran_08_handle_t ompi_f08_mpi_logical8          = {OMPI_MPI_LOGICAL8};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_byte              = {OMPI_MPI_BYTE};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_packed            = {OMPI_MPI_PACKED};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_ub                = {OMPI_MPI_UB};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_lb                = {OMPI_MPI_LB};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_character         = {OMPI_MPI_CHARACTER};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical           = {OMPI_MPI_LOGICAL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer           = {OMPI_MPI_INTEGER};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer1          = {OMPI_MPI_INTEGER1};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer2          = {OMPI_MPI_INTEGER2};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer4          = {OMPI_MPI_INTEGER4};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer8          = {OMPI_MPI_INTEGER8};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_integer16         = {OMPI_MPI_INTEGER16};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_real              = {OMPI_MPI_REAL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_real4             = {OMPI_MPI_REAL4};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_real8             = {OMPI_MPI_REAL8};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_real16            = {OMPI_MPI_REAL16};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_double_precision  = {OMPI_MPI_DOUBLE_PRECISION};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex           = {OMPI_MPI_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex8          = {OMPI_MPI_COMPLEX8};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex16         = {OMPI_MPI_COMPLEX16};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex32         = {OMPI_MPI_COMPLEX32};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_double_complex    = {OMPI_MPI_DOUBLE_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_2real             = {OMPI_MPI_2REAL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_2double_precision = {OMPI_MPI_2DOUBLE_PRECISION};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_2integer          = {OMPI_MPI_2INTEGER};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_2complex          = {OMPI_MPI_2COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_2double_complex   = {OMPI_MPI_2DOUBLE_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_real2             = {OMPI_MPI_REAL2};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical1          = {OMPI_MPI_LOGICAL1};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical2          = {OMPI_MPI_LOGICAL2};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical4          = {OMPI_MPI_LOGICAL4};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical8          = {OMPI_MPI_LOGICAL8};


### PR DESCRIPTION
Fortran uses objects (ompi_f08_mpi_comm_world, mpi_fortran_bottom,, ...) that are defined in C.
Some compilers have different requirements on how these objects should be aligned.
Smaller alignment in C can lead to several confusing warnings from the linker, so try to
find the alignment expected by Fortran compiler, and inform the C compiler.

(cherry picked from commit open-mpi/ompi@99730f798b7aef4c87d282aa24b98916fea45bb6)
