### PR TITLE
v1.10: ompi_mpi_abort.c: use _exit(), not exit()

### DIFF
--- a/ompi/runtime/ompi_mpi_abort.c
+++ b/ompi/runtime/ompi_mpi_abort.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * $COPYRIGHT$
  * 
@@ -133,7 +133,7 @@ ompi_mpi_abort(struct ompi_communicator_t* comm,
         fprintf(stderr, "[%s:%d] Local abort %s completed successfully; not able to aggregate error messages, and not able to guarantee that all other processes were killed!\n",
                 host, (int) pid, ompi_mpi_finalized ? 
                 "after MPI_FINALIZE" : "before MPI_INIT");
-        exit(errcode);
+        _exit(errcode);
     }
 
     /* abort local procs in the communicator.  If the communicator is


### PR DESCRIPTION
In an abort situation, just bail out immediately -- don't try to invoke any atexit()/on_exit()-registered functions.

This is similar rationale to open-mpi/ompi@17846411c328f48a6f3416b760e9599d7f9dd51f.

(cherry picked from commit open-mpi/ompi@556c32e1d19d7a92818862f0b409fd42a28d98e2)

@rhc54 please review
