### PR TITLE
unpack_ooo: fix empty initializer

### DIFF
--- a/test/datatype/unpack_ooo.c
+++ b/test/datatype/unpack_ooo.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -31,12 +32,12 @@ uint32_t remote_arch = 0xffffffff;
 struct foo_t {
     int i[3];
     double d[3];
-} foo = {}, *bar = NULL;
+} foo = {0}, *bar = NULL;
 
 struct pfoo_t {
     int i[2];
     double d[2];
-} pfoo = {}, *pbar = NULL;
+} pfoo = {0}, *pbar = NULL;
 
 static void print_hex(void* ptr, int count, int space)
 {


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@447eb4238aab3bab054eecb529e66a45365f9072)

@bosilca This is pretty trivial -- can you review?  Thanks.
