### PR TITLE
fortran: link the opal-pal.la library directly

### DIFF
--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Inria.  All rights reserved.
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
@@ -56,7 +56,14 @@ AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
 CLEANFILES =
-libmpi_mpifh_la_LIBADD = $(top_builddir)/ompi/libmpi.la $(OMPI_MPIEXT_MPIFH_LIBS)
+# Note that we invoke some OPAL functions directly in libmpi_mpifh.la,
+# so we need to link in the OPAL library directly (pulling it in
+# indirectly via libmpi.la does not work on all platforms).
+libmpi_mpifh_la_LIBADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(OMPI_MPIEXT_MPIFH_LIBS) \
+        $(OMPI_TOP_BUILDDIR)/opal/libopen-pal.la
+
 libmpi_mpifh_la_LDFLAGS = -version-info $(libmpi_mpifh_so_version)
 
 # Are we building the mpif.h bindings at all?

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 #
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 #
@@ -48,6 +48,13 @@ nodist_libmpi_usempi_ignore_tkr_la_SOURCES += \
         mpi-ignore-tkr-sizeof.f90
 endif
 
+# Note that we invoke some OPAL functions directly in
+# libmpi_usempi_ignore_tkr.la, so we need to link in the OPAL library
+# directly (pulling it in indirectly via libmpi.la does not work on
+# all platforms).
+libmpi_usempi_ignore_tkr_la_LIBADD = \
+        $(OMPI_MPIEXT_USEMPI_LIBS) \
+        $(OMPI_TOP_BUILDDIR)/opal/libopen-pal.la
 libmpi_usempi_ignore_tkr_la_LDFLAGS = \
         -version-info $(libmpi_usempi_ignore_tkr_so_version) \
         $(OMPI_FORTRAN_EXTRA_SHARED_LIBRARY_FLAGS)

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 #                         reserved. 
 # Copyright (c) 2014-2015 Research Organization for Information Science
@@ -74,8 +74,6 @@ libmpi_usempi_la_SOURCES = \
      mpi_waitsome_f90.f90 \
      mpi_wtick_f90.f90 \
      mpi_wtime_f90.f90
-libmpi_usempi_la_LIBADD = \
-     $(top_builddir)/ompi/mpi/fortran/mpif-h/libmpi_mpifh.la
 
 # Don't distribute mpi-tkr-sizeof-*; they're generated.
 
@@ -86,6 +84,14 @@ nodist_libmpi_usempi_la_SOURCES += \
      mpi-tkr-sizeof.f90
 endif
 
+# Note that we invoke some OPAL functions directly in
+# libmpi_usempi.la, so we need to link in the OPAL library directly
+# (pulling it in indirectly via libmpi.la does not work on all
+# platforms).
+libmpi_usempi_la_LIBADD = \
+        $(top_builddir)/ompi/mpi/fortran/mpif-h/libmpi_mpifh.la \
+        $(OMPI_MPIEXT_USEMPI_LIBS) \
+        $(OMPI_TOP_BUILDDIR)/opal/libopen-pal.la
 # Set the library version
 libmpi_usempi_la_LDFLAGS = \
         -version-info $(libmpi_usempi_tkr_so_version) \


### PR DESCRIPTION
The `libmpi_*.la` fortran libraries make some direct calls to libopen-pal.la.  In many (most?) cases, having `libmpi_*` link against libmpi is sufficient (because libmpi pulls in libopen-pal).  But when building RPMs on SLES, some compiler/linker flags are used that seem to make this implicit linking not sufficient -- we get missing opal symbols when creating `libmpi_mpifh.la`.  So link in open-pal directly (vs. indirectly), which solves the problem.

Cherry picked from open-mpi/ompi@a7f897ae49a336bcc51ce4af362553c8aabde04a

This commit is already on the v2.x branch.

@miked-mellanox Please test / review.
