### PR TITLE
v2.x recursive lock

### DIFF
--- a/opal/mca/rcache/vma/rcache_vma.c
+++ b/opal/mca/rcache/vma/rcache_vma.c
@@ -42,7 +42,7 @@ void mca_rcache_vma_module_init( mca_rcache_vma_module_t* rcache ) {
     rcache->base.rcache_clean = mca_rcache_vma_clean;
     rcache->base.rcache_finalize = mca_rcache_vma_finalize;
     rcache->base.rcache_dump_range = mca_rcache_vma_dump_range;
-    OBJ_CONSTRUCT(&rcache->base.lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&rcache->base.lock, opal_recursive_mutex_t);
     mca_rcache_vma_tree_init(rcache);
 }
 

--- a/opal/threads/mutex.c
+++ b/opal/threads/mutex.c
@@ -72,3 +72,29 @@ OBJ_CLASS_INSTANCE(opal_mutex_t,
                    opal_object_t,
                    opal_mutex_construct,
                    opal_mutex_destruct);
+
+static void opal_recursive_mutex_construct(opal_recursive_mutex_t *m)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+
+#if OPAL_ENABLE_DEBUG
+    m->m_lock_debug = 0;
+    m->m_lock_file = NULL;
+    m->m_lock_line = 0;
+#endif
+
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+
+    pthread_mutex_init(&m->m_lock_pthread, &attr);
+    pthread_mutexattr_destroy(&attr);
+
+#if OPAL_HAVE_ATOMIC_SPINLOCKS
+    opal_atomic_init( &m->m_lock_atomic, OPAL_ATOMIC_UNLOCKED );
+#endif
+}
+
+OBJ_CLASS_INSTANCE(opal_recursive_mutex_t,
+                   opal_object_t,
+                   opal_recursive_mutex_construct,
+                   opal_mutex_destruct);

--- a/opal/threads/mutex.h
+++ b/opal/threads/mutex.h
@@ -50,7 +50,7 @@ OPAL_DECLSPEC extern bool opal_uses_threads;
  * Opaque mutex object
  */
 typedef struct opal_mutex_t opal_mutex_t;
-
+typedef struct opal_mutex_t opal_recursive_mutex_t;
 
 /**
  * Try to acquire a mutex.

--- a/opal/threads/mutex_unix.h
+++ b/opal/threads/mutex_unix.h
@@ -61,6 +61,7 @@ struct opal_mutex_t {
     opal_atomic_lock_t m_lock_atomic;
 };
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_mutex_t);
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
 
 /************************************************************************
  *


### PR DESCRIPTION
This PR fixes a known issue with the mpool and leave_pinned protocols. With this the openib btl is mostly thread-safe.
