### PR TITLE
btl/sm: mca_btl_sm_sendi: do not set *descriptor when descriptor is NULL

### DIFF
--- a/opal/mca/btl/sm/btl_sm.c
+++ b/opal/mca/btl/sm/btl_sm.c
@@ -899,7 +899,9 @@ int mca_btl_sm_sendi( struct mca_btl_base_module_t* btl,
         /* note that frag==NULL is equivalent to rc returning an error code */
         MCA_BTL_SM_FRAG_ALLOC_EAGER(frag);
         if( OPAL_UNLIKELY(NULL == frag) ) {
-            *descriptor = NULL;
+            if (NULL != descriptor) {
+                *descriptor = NULL;
+            }
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
 


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@d5af5d106c12b836b4ae3984ac62ee5634ccdb65)
