### PR TITLE
mtl_ofi_component.c: add missing argv.h header

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -13,6 +13,7 @@
  */
 
 #include "mtl_ofi.h"
+#include "opal/util/argv.h"
 
 static int ompi_mtl_ofi_component_open(void);
 static int ompi_mtl_ofi_component_query(mca_base_module_t **module, int *priority);


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@567c9e3a5b330c61792c13e8a3eb1ae1759a1a37)

Submitted by @opoplawski, reviewed by @jsquyres

@rhc54 @hppritcha
