### PR TITLE
hwloc: do not count not allowed cores in df_search_cores

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -492,6 +492,10 @@ static void df_search_cores(hwloc_obj_t obj, unsigned int *cnt)
             obj->userdata = (void*)data;
         }
         if (NULL == opal_hwloc_base_cpu_set) {
+            if (!hwloc_bitmap_isincluded(obj->cpuset, obj->allowed_cpuset)) {
+                /* do not count not allowed cores */
+                return;
+            }
             data->npus = 1;
         }
         *cnt += data->npus;


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@975b6fd51b6d7f4076b5d0b100543b7231639060)
