### PR TITLE
usnic: sync with master open-mpi/ompi@8ac0dbf1

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_compat.h
+++ b/ompi/mca/btl/usnic/btl_usnic_compat.h
@@ -34,6 +34,9 @@
 /* Inclue the progress thread stuff */
 #  include "opal/runtime/opal_progress_threads.h"
 
+/* Hhwloc is now guaranteed */
+#  define OPAL_HAVE_HWLOC 1
+
 #  define USNIC_OUT opal_btl_base_framework.framework_output
 /* JMS Really want to be able to get the job size somehow...  But for
    now, so that we can compile, just set it to a constant :-( */

--- a/ompi/mca/btl/usnic/btl_usnic_hwloc.c
+++ b/ompi/mca/btl/usnic/btl_usnic_hwloc.c
@@ -7,11 +7,6 @@
  * $HEADER$
  */
 
-/*
- * This file is only compiled (via AM_CONDITIONAL) if OPAL_HAVE_HWLOC
- * is set.
- */
-
 #include "opal_config.h"
 
 /* Define this before including hwloc.h so that we also get the hwloc

--- a/ompi/mca/btl/usnic/btl_usnic_hwloc.h
+++ b/ompi/mca/btl/usnic/btl_usnic_hwloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mca/btl/usnic/btl_usnic_mca.c
+++ b/ompi/mca/btl/usnic/btl_usnic_mca.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -427,7 +427,7 @@ static int usnic_add_procs(struct mca_btl_base_module_t* base_module,
 
     /* Find all the endpoints with a complete set of USD destinations
        and mark them as reachable */
-    for (size_t i = 0; i < nprocs; ++i) {
+    for (size_t i = 0; NULL != reachable && i < nprocs; ++i) {
         if (NULL != endpoints[i]) {
             bool happy = true;
             for (int channel = 0; channel < USNIC_NUM_CHANNELS; ++channel) {


### PR DESCRIPTION
Sync all *.c and *.h code from the usnic BTL on master.

This fixes a performance issue on the v1.10 branch: the emulation of opal_progress_thread() was spinning too hard because it lacked a long-lived timer event on the emulate OPAL event base.

@goodell Please review.
