### PR TITLE
Only start a listener for processes that will actually receive connec…

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -616,7 +616,7 @@ static int component_available(void)
 /* Start all modules */
 static int component_startup(void)
 {
-    int rc;
+    int rc = ORTE_SUCCESS;
 
     opal_output_verbose(2, orte_oob_base_framework.framework_output,
                         "%s TCP STARTUP",
@@ -627,10 +627,19 @@ static int component_startup(void)
         mca_oob_tcp_module.api.init();
     }
 
-    /* start the listening thread/event */
-    if (ORTE_SUCCESS != (rc = orte_oob_tcp_start_listening())) {
-        ORTE_ERROR_LOG(rc);
+    /* if we are a daemon/HNP, or we are a standalone app,
+     * then it is possible that someone else may initiate a
+     * connection to us. In these cases, we need to start the
+     * listening thread/event. Otherwise, we will be the one
+     * initiating communication, and there is no need for
+     * a listener */
+    if (ORTE_PROC_IS_HNP || ORTE_PROC_IS_DAEMON ||
+        orte_standalone_operation) {
+        if (ORTE_SUCCESS != (rc = orte_oob_tcp_start_listening())) {
+            ORTE_ERROR_LOG(rc);
+        }
     }
+
     return rc;
 }
 


### PR DESCRIPTION
…tion requests. Tools such as orte-submit always initiate connections and thus do not need to start a listener.

(cherry picked from commit open-mpi/ompi@89c80b2294059a1fac1e4b182c9176500a3f452b)
