### PR TITLE
ompi/win: save value of accumulate_ops info key on window

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -272,6 +272,22 @@ int ompi_info_set (ompi_info_t *info, const char *key, const char *value)
 }
 
 
+int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
+                              mca_base_var_enum_t *var_enum)
+{
+    char *string_value;
+    int ret;
+
+    ret = var_enum->string_from_value (var_enum, value, &string_value);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    return ompi_info_set (info, key, string_value);
+}
+
+
+
 /*
  * Free an info handle and all of its keys and values.
  */

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -151,7 +151,7 @@ int ompi_info_finalize(void);
  */
 int ompi_info_dup (ompi_info_t *info, ompi_info_t **newinfo);
 
-/*
+/**
  * Set a new key,value pair on info.
  *
  * @param info pointer to ompi_info_t object
@@ -162,6 +162,21 @@ int ompi_info_dup (ompi_info_t *info, ompi_info_t **newinfo);
  * @retval MPI_ERR_NO_MEM if out of memory
  */
 OMPI_DECLSPEC int ompi_info_set (ompi_info_t *info, const char *key, const char *value);
+
+/**
+ * Set a new key,value pair from a variable enumerator.
+ *
+ * @param info pointer to ompi_info_t object
+ * @param key pointer to the new key object
+ * @param value integer value of the info key (must be valid in var_enum)
+ * @param var_enum variable enumerator
+ *
+ * @retval MPI_SUCCESS upon success
+ * @retval MPI_ERR_NO_MEM if out of memory
+ * @retval OPAL_ERR_VALUE_OUT_OF_BOUNDS if the value is not valid in the enumerator
+ */
+OMPI_DECLSPEC int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
+                                            mca_base_var_enum_t *var_enum);
 
 /**
  * ompi_info_free - Free an 'MPI_Info' object.

--- a/ompi/mpi/c/win_get_info.c
+++ b/ompi/mpi/c/win_get_info.c
@@ -58,6 +58,7 @@ int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used)
         _win_info_set (*info_used, "no_locks", win->w_flags & OMPI_WIN_NO_LOCKS);
         _win_info_set (*info_used, "same_size", win->w_flags & OMPI_WIN_SAME_SIZE);
         _win_info_set (*info_used, "same_disp_unit", win->w_flags & OMPI_WIN_SAME_DISP);
+        ompi_info_set_value_enum (*info_used, "accumulate_ops", win->w_acc_ops, ompi_win_accumulate_ops);
     }
 
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -44,6 +44,14 @@ BEGIN_C_DECLS
 #define OMPI_WIN_SAME_DISP    0x00000008
 #define OMPI_WIN_SAME_SIZE    0x00000010
 
+enum ompi_win_accumulate_ops_t {
+    OMPI_WIN_ACCUMULATE_OPS_SAME_OP_NO_OP,
+    OMPI_WIN_ACCUMULATE_OPS_SAME_OP,
+};
+typedef enum ompi_win_accumulate_ops_t ompi_win_accumulate_ops_t;
+
+OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_ops;
+
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_windows;
 
 struct ompi_win_t {
@@ -58,6 +66,9 @@ struct ompi_win_t {
 
     /* Information about the state of the window.  */
     uint16_t w_flags;
+
+    /** Accumulate ops */
+    ompi_win_accumulate_ops_t w_acc_ops;
 
     /* Attributes */
     opal_hash_table_t *w_keyhash;


### PR DESCRIPTION
This commit saves the value of the accumulate_ops info key on the window.

:bot:assign: @bosilca 
:bot:milestone:v2.0.0
:bot:label:enhancement

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@6751409c3222b5a2982bf9e695d948450d068735)
