### PR TITLE
ROMIO configure looks for lstat in wrong header

### DIFF
--- a/ompi/mca/io/romio/romio/configure.ac
+++ b/ompi/mca/io/romio/romio/configure.ac
@@ -2054,7 +2054,8 @@ fi
 AC_CHECK_FUNCS(lstat)
 if test "$ac_cv_func_lstat" = "yes" ; then
     # Do we need to declare lstat?
-    PAC_FUNC_NEEDS_DECL([#include <unistd.h>],lstat)
+    PAC_FUNC_NEEDS_DECL([#include <unistd.h>
+                         #include <sys/stat.h>],lstat)
 fi
 AC_CHECK_FUNCS(readlink)
 if test "$ac_cv_func_readlink" = "yes" ; then


### PR DESCRIPTION
ROMIO configure looks for lstat in wrong header

The ROMIO configure script checks for a declaration of lstat in
unistd.h, but, at least on the Linux machines I checked, lstat is in
sys/stat.h.  (The detection failure led to a linker error when building
ROMIO as part of OpenMPI on one of my admittedly strangely configured
machines, somehow.)  It appears from the man page that either location
is possible, so check both.

(cherry picked from mpich/mpich@7b8bd055dfdeb)
(cherry picked from open-mpi/ompi@80bb41a079f1c5bf6350cd7188559ea5c47152b7)

Signed-off-by: Rob Latham robl@mcs.anl.gov
Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
