### PR TITLE
btl/openib: fix udcm coverity errors

### DIFF
--- a/ompi/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/ompi/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -2521,8 +2521,8 @@ static int udcm_xrc_recv_qp_connect (mca_btl_openib_endpoint_t *lcl_ep)
     lcl_ep->xrc_recv_qp = ibv_open_qp(openib_btl->device->ib_dev_context, &attr);
     if (NULL == lcl_ep->xrc_recv_qp) { /* failed to regester the qp, so it is already die and we should create new one */
        /* Return NOT READY !!!*/
-        BTL_ERROR(("Failed to register qp_num: %d , get error: %s (%d)\n. Replying with RNR",
-                   lcl_ep->xrc_recv_qp->qp_num, strerror(errno), errno));
+        BTL_ERROR(("Failed to register qp_num: %d, get error: %s (%d)\n. Replying with RNR",
+                   qp_num, strerror(errno), errno));
         return OMPI_ERROR;
     } else {
         BTL_VERBOSE(("Connected to XRC Recv qp [%d]", lcl_ep->xrc_recv_qp->qp_num));
@@ -2795,6 +2795,9 @@ static int udcm_xrc_handle_xconnect (mca_btl_openib_endpoint_t *lcl_ep, udcm_msg
     int response_type;
     int rc = OMPI_ERROR;
 
+    /* sanity check on message type */
+    assert (UDCM_MESSAGE_XCONNECT == msg_hdr->type || UDCM_MESSAGE_XCONNECT2 == msg_hdr->type);
+
     do {
         if (NULL == udep) {
             break;
@@ -2851,7 +2854,9 @@ static int udcm_xrc_handle_xconnect (mca_btl_openib_endpoint_t *lcl_ep, udcm_msg
         return OMPI_SUCCESS;
     } while (0);
 
-    opal_mutex_unlock (&udep->udep_lock);
+    if (udep) {
+        opal_mutex_unlock (&udep->udep_lock);
+    }
 
     /* Reject the request */
     BTL_VERBOSE(("rejecting request for reason %d", rej_reason));


### PR DESCRIPTION
Fix CID 1312120: Uninitialized scalar variable

The response type will always be set unless a message of another type is passed to this function. To make sure that error is caught I am adding an assert.

Fix CID 1312116: Dereference after null check

This is a potential bug. If there is no endpoint data for an incoming connection a rejection should be sent. In this case we would just SEGV.

Fix CID 1312115: Dereference after null check

Clear error in the error message. Use the queue pair number that was passed in.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@60f3dbd1605cf36f04efb2ab9ec199acd6d48813)
