### PR TITLE
fortran ignore TKR: update for strange Intel 2016 compiler suite behavior

### DIFF
--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -156,8 +156,8 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   complex :: buffer3(4,4)
   complex, pointer, dimension(:,:) :: ptr
   target :: buffer3
-  ptr => buffer3  
   integer :: buffer4
+  ptr => buffer3  
 
 ! Set some known values (somewhat irrelevant for this test, but just be
 ! sure that the values are initialized)

--- a/config/ompi_fortran_check_ignore_tkr.m4
+++ b/config/ompi_fortran_check_ignore_tkr.m4
@@ -13,7 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved. 
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl 
 dnl Additional copyrights may follow
@@ -157,6 +157,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   complex, pointer, dimension(:,:) :: ptr
   target :: buffer3
   ptr => buffer3  
+  integer :: buffer4
 
 ! Set some known values (somewhat irrelevant for this test, but just be
 ! sure that the values are initialized)
@@ -174,6 +175,11 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_IGNORE_TKR_SUB], [
   call force_assumed_shape(buffer3, count)
 ! Force a pointer call through an assumed shape (!)
   ptr => buffer3  
+! Also try with a simple scalar integer
+! (Intel 2016 compiler suite only partially supports GCC pragmas;
+! they work with all the above buffer types, but fail with a
+! simple scalar integer)
+  call foo(buffer4, count)
 
   end program
 


### PR DESCRIPTION
The Intel 2016 compiler suite apparently only partially supports the !GCC pragmas (prior versions either didn't support it at all, or our existing configure test was sufficient to disqualify !GCC pragma support when compiling with the Intel compiler).

With the existing configure test, the Intel 2016 compiler suite would _pass_ the test and therefore think that it could use !GCC as the "ignore TKR" pragma.  However, the "!GCC ATTRIBUTES NO_ARG_CHECK" pragma doesn't work with scalar integers (although it seems to work for the other types in this test).

This commit adds a scalar integer test to the ignore TKR pragma configure test, which is enough to make the Intel 2016 compiler suite fail with !GCC (this then allows configure to advance on to trying the !DEC pragma, which _does_ work properly with the Intel 2016 compiler suite).

Thanks to Fabrice Roy for reporting the problem.

Fixes open-mpi/ompi#937.

(cherry picked from commit open-mpi/ompi@3698621df0bffd3711be2f2d81afd8e3ae2947e6)
