### PR TITLE
man: fix a typo in MPI_Ibarrier C prototype

### DIFF
--- a/ompi/mpi/man/man3/MPI_Barrier.3in
+++ b/ompi/mpi/man/man3/MPI_Barrier.3in
@@ -14,7 +14,7 @@
 #include <mpi.h>
 int MPI_Barrier(MPI_Comm \fIcomm\fP)
 
-int MPI_Ibarrier(MPI_Comm \fIcomm\fP, MPI_Request \fIrequest\fP)
+int MPI_Ibarrier(MPI_Comm \fIcomm\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax


### PR DESCRIPTION
Thanks Harald Servat for reporting this

(cherry picked from commit open-mpi/ompi@97b9d12c580b1756e41020c7892388494cdac8b3)
