### PR TITLE
pci: do not probe PCI topology on Solaris unless effective uid is root

### DIFF
--- a/opal/mca/hwloc/hwloc191/hwloc/src/topology-pci.c
+++ b/opal/mca/hwloc/hwloc191/hwloc/src/topology-pci.c
@@ -2,6 +2,8 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2015 Inria.  All rights reserved.
  * Copyright © 2009-2011, 2013 Université Bordeaux 1
+ * Copyright © 2015      Research Organization for Information Science
+ *                       and Technology (RIST). All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -394,7 +396,12 @@ hwloc_pci_component_instantiate(struct hwloc_disc_component *component,
   if (!backend)
     return NULL;
   backend->flags = HWLOC_BACKEND_FLAG_NEED_LEVELS;
-  backend->discover = hwloc_look_pci;
+#ifdef HWLOC_SOLARIS_SYS
+  if ((uid_t)0 != geteuid())
+    backend->discover = NULL;
+  else
+#endif
+    backend->discover = hwloc_look_pci;
   return backend;
 }
 


### PR DESCRIPTION
Otherwise libpciaccess sends a big error message to stderr:
  Error opening /devices/pci@0,0:reg: Permission denied

(cherry picked from commit open-mpi/hwloc@1088331409ee865fa94c0bdcaea5ce35f06ef507)
(back-ported from commit open-mpi/ompi@2ac09d5a8dbc3c94a812ef5e2acaf48defd76714)
