### PR TITLE
ompi_proc_complete_init: always reset u16ptr

### DIFF
--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -142,12 +142,12 @@ int ompi_proc_complete_init(void)
     uint16_t u16, *u16ptr;
 
     OPAL_THREAD_LOCK(&ompi_proc_lock);
-    u16ptr = &u16;
 
     OPAL_LIST_FOREACH(proc, &ompi_proc_list, ompi_proc_t) {
         if (OMPI_CAST_RTE_NAME(&proc->super.proc_name)->vpid != OMPI_PROC_MY_NAME->vpid) {
             /* get the locality information - all RTEs are required
             * to provide this information at startup */
+            u16ptr = &u16;
             OPAL_MODEX_RECV_VALUE_OPTIONAL(ret, OPAL_PMIX_LOCALITY, &proc->super.proc_name, &u16ptr, OPAL_UINT16);
             if (OPAL_SUCCESS != ret) {
                 proc->super.proc_flags = OPAL_PROC_NON_LOCAL;

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -139,9 +139,7 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
         _info->type = OPAL_BOOL;                                                         \
         _info->data.flag = true;                                                         \
         opal_list_append(&(_ilist), &(_info)->super);                                    \
-        if (OPAL_SUCCESS != ((r) = opal_pmix.get((p), (s), &(_ilist), &(_kv)))) {        \
-            *(d) = NULL;                                                                 \
-        } else {                                                                         \
+        if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), &(_ilist), &(_kv)))) {        \
             (r) = opal_value_unload(_kv, (void**)(d), (t));                              \
             OBJ_RELEASE(_kv);                                                            \
         }                                                                                \
@@ -168,9 +166,7 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),                 \
                             __FILE__, __LINE__,                                 \
                             OPAL_NAME_PRINT(*(p)), (s)));                       \
-        if (OPAL_SUCCESS != ((r) = opal_pmix.get((p), (s), NULL, &(_kv)))) {    \
-            *(d) = NULL;                                                        \
-        } else {                                                                \
+        if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), NULL, &(_kv)))) {    \
             (r) = opal_value_unload(_kv, (void**)(d), (t));                     \
             OBJ_RELEASE(_kv);                                                   \
         }                                                                       \
@@ -203,9 +199,6 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
             *(sz) = _kv->data.bo.size;                                          \
             _kv->data.bo.bytes = NULL; /* protect the data */                   \
             OBJ_RELEASE(_kv);                                                   \
-        } else {                                                                \
-            *(d) = NULL;                                                        \
-            *(sz) = 0;                                                          \
         }                                                                       \
     } while(0);
 


### PR DESCRIPTION
if a key is not found, u16ptr is set to NULL and following
opal_value_unload calls might fail

(back ported from commit open-mpi/ompi@57ecce4e0f3a5bc4af5a7d156628e24dc3458278)
