### PR TITLE
v1.10.1: start the release engines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,51 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+1.10.1
+------
+
+- No longer probe for PCI topology on Solaris (unless running as root).
+- Fix for Intel Parallel Studio 2016 ifort partial support of the
+  !GCC$ pragma.  Thanks to Fabrice Roy for reporting the problem.
+- Bunches of Coverity / static analysis fixes.
+- Fixed ROMIO to look for lstat in <sys/stat.h>.  Thanks to William
+  Throwe for submitting the patch both upstream and to Open MPI.
+- Fixed minor memory leak when attempting to open plugins.
+- Fixed type in MPI_IBARRIER C prototype.  Thanks to Harald Servat for
+  reporting the issue.
+- Add missing man pages for MPI_WIN_CREATE_DYNAMIC, MPI_WIN_ATTACH,
+  MPI_WIN_DETACH, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED.
+- When mpirun-launching new applications, only close file descriptors
+  that are actually open (resulting in a faster launch in some
+  environments).
+- Fix "test ==" issues in Open MPI's configure script.  Thank to Kevin
+  Buckley for pointing out the issue.
+- Fix performance issue in usnic BTL: ensure progress thread is
+  throttled back to not aggressively steal CPU cycles.
+- Fix cache line size detection on POWER architectures.
+- Add missing #include in a few places.  Thanks to Orion Poplawski for
+  supplying the patch.
+- When OpenSHMEM building is disabled, no longer install its header
+  files, help files, or man pages.
+- Fix mpi_f08 implementations of MPI_COMM_SET_INFO, and profiling
+  versions of MPI_BUFFER_DETACH, MPI_WIN_ALLOCATE,
+  MPI_WIN_ALLOCATE_SHARED, MPI_WTICK, and MPI_WTIME.
+- Add orte_rmaps_dist_device MCA param, allowing users to map near a
+  specific device.
+- Various updates/fixes to the openib BTL.
+- Add missing defaults for the Mellanox ConnectX 3 card to the openib BTL.
+- Minor bug fixes in the OFI MTL.
+- Various updates to Mellanox's hcoll and FCA components.
+- Add OpenSHMEM man pages.  Thanks to Tony Curtis for sharing the man
+  pages files from openshmem.org.
+- Add missing "const" attributes to MPI_COMPARE_AND_SWAP,
+  MPI_FETCH_AND_OP, MPI_RACCUMULATE, and MPI_WIN_DETACH prototypes.
+  Thanks to Michael Knobloch and Takahiro Kawashima for bringing this
+  to our attention.
+- Fix linking issues on some platforms (e.g., SLES 12).
+- Fix hang on some corner cases when MPI applications abort.
+
+
 1.10.0
 ------
 ** NOTE: The v1.10.0 release marks the transition to Open MPI's new

--- a/VERSION
+++ b/VERSION
@@ -82,16 +82,22 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=12:0:0
+libmpi_so_version=12:1:0
+# libmpi changed
 libmpi_cxx_so_version=2:3:1
 libmpi_mpifh_so_version=12:0:0
-libmpi_usempi_tkr_so_version=5:0:4
+libmpi_usempi_tkr_so_version=5:1:4
+# libmpi_usempi_tkr changed
 libmpi_usempi_ignore_tkr_so_version=6:0:0
-libmpi_usempif08_so_version=11:0:0
-libopen_rte_so_version=12:0:0
-libopen_pal_so_version=13:0:0
+libmpi_usempif08_so_version=11:1:0
+# libmpi_usempif08 changed
+libopen_rte_so_version=12:1:0
+# libopen_rte changed
+libopen_pal_so_version=13:1:0
+# libopen_pal changed
 libmpi_java_so_version=3:0:2
-liboshmem_so_version=8:0:0
+liboshmem_so_version=8:1:0
+# liboshmem changed
 
 # "Common" components install standalone libraries that are run-time
 # linked by one or more components.  So they need to be versioned as

--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Updates to NEWS and VERSION.

I'd appreciate another pair of eyes on the VERSION shared library version number updates.
