### PR TITLE
ompi/man: fix typos in formatting

### DIFF
--- a/ompi/mpi/man/man3/MPI_Compare_and_swap.3in
+++ b/ompi/mpi/man/man3/MPI_Compare_and_swap.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2013-2014 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright 2013-2015 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
@@ -14,7 +14,7 @@
 .nf
 #include <mpi.h>
 int MPI_Compare_and_swap(const void *\fIorigin_addr\fP, const void *\fIcompar_addr\fP,
-	void *\fresult_addr\fP, MPI_Datatype \fdatatype\fP, int \fItarget_rank\fP,
+	void *\fIresult_addr\fP, MPI_Datatype \fIdatatype\fP, int \fItarget_rank\fP,
 	MPI_Aint \fItarget_disp\fP, MPI_Win \fIwin\fP)
 
 .fi

--- a/ompi/mpi/man/man3/MPI_Fetch_and_op.3in
+++ b/ompi/mpi/man/man3/MPI_Fetch_and_op.3in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright 2013-2014 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright 2013-2015 Los Alamos National Security, LLC. All rights reserved.
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
@@ -13,8 +13,8 @@
 .SH C Syntax
 .nf
 #include <mpi.h>
-int MPI_Fetch_and_op(const void *\fIorigin_addr\fP, void *\fresult_addr\fP,
-	MPI_Datatype \fdatatype\fP, int \fItarget_rank\fP, MPI_Aint \fItarget_disp\fP,
+int MPI_Fetch_and_op(const void *\fIorigin_addr\fP, void *\fIresult_addr\fP,
+	MPI_Datatype \fIdatatype\fP, int \fItarget_rank\fP, MPI_Aint \fItarget_disp\fP,
 	MPI_Op \fIop\fP, MPI_Win \fIwin\fP)
 
 .fi


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@fbaa79835febc9bb458bf73f457c8d0ca99e1750)

:bot:assign @jsquyres 
:bot:label:bug
:bot:milestone:v1.10.1

Signed-off-by: Nathan Hjelm hjelmn@me.com
