### PR TITLE
op: allow user operations in ompi_3buff_op_reduce

### DIFF
--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +13,8 @@
  * Copyright (c) 2008      UT-Battelle, LLC
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -595,6 +597,13 @@ static inline void ompi_op_reduce(ompi_op_t * op, void *source,
     return;
 }
 
+static inline void ompi_3buff_op_user (ompi_op_t *op, void * restrict source1, void * restrict source2,
+                                       void * restrict result, int count, struct ompi_datatype_t *dtype)
+{
+    ompi_datatype_copy_content_same_ddt (dtype, count, result, source1);
+    op->o_func.c_fn (source2, result, &count, &dtype);
+}
+
 /**
  * Perform a reduction operation.
  *
@@ -629,10 +638,14 @@ static inline void ompi_3buff_op_reduce(ompi_op_t * op, void *source1,
     src2 = source2;
     tgt = target;
 
-    op->o_3buff_intrinsic.fns[ompi_op_ddt_map[dtype->id]](src1, src2,
-                                                          tgt, &count,
-                                                          &dtype,
-                                                          op->o_3buff_intrinsic.modules[ompi_op_ddt_map[dtype->id]]);
+    if (OPAL_LIKELY(ompi_op_is_intrinsic (op))) {
+        op->o_3buff_intrinsic.fns[ompi_op_ddt_map[dtype->id]](src1, src2,
+                                                              tgt, &count,
+                                                              &dtype,
+                                                              op->o_3buff_intrinsic.modules[ompi_op_ddt_map[dtype->id]]);
+    } else {
+        ompi_3buff_op_user (op, src1, src2, tgt, count, dtype);
+    }
 }
 
 END_C_DECLS


### PR DESCRIPTION
This commit allows user operations to be used in the
ompi_3buff_op_reduce function. This fixes an issue identified in:

http://www.open-mpi.org/community/lists/devel/2014/04/14586.php

and

http://www.open-mpi.org/community/lists/users/2015/10/27769.php

The fix is to copy source1 into the target then call the user op
function with source2 and target.

Fixes #966

(cherry picked from commit open-mpi/ompi@57d3b832972a9d914a7c2067a526dfa3df1dbb34)

:bot:assign: @bosilca 
:bot:label:bug
:bot:milestone:v1.10.1

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
