### PR TITLE
v1.10 - Add in-finalize indicator, fca fall back to prev barrier if in-finalize

### DIFF
--- a/ompi/mca/coll/fca/coll_fca_ops.c
+++ b/ompi/mca/coll/fca/coll_fca_ops.c
@@ -153,6 +153,10 @@ int mca_coll_fca_barrier(struct ompi_communicator_t *comm,
     int ret;
 
     FCA_VERBOSE(5,"Using FCA Barrier");
+    if (OPAL_UNLIKELY(ompi_mpi_finalize_started)) {
+        FCA_VERBOSE(5, "In finalize, reverting to previous barrier");
+        goto orig_barrier;
+    }
     ret = fca_do_barrier(fca_module->fca_comm);
     if (ret < 0) {
         if (ret == -EUSEMPI) {

--- a/ompi/runtime/mpiruntime.h
+++ b/ompi/runtime/mpiruntime.h
@@ -52,6 +52,8 @@ OMPI_DECLSPEC extern bool ompi_mpi_init_started;
 OMPI_DECLSPEC extern bool ompi_mpi_initialized;
 /** Has mpi been finalized? */
 OMPI_DECLSPEC extern bool ompi_mpi_finalized;
+/** Did mpi start to finalize? */
+OMPI_DECLSPEC extern int32_t ompi_mpi_finalize_started;
 
 /** Do we have multiple threads? */
 OMPI_DECLSPEC extern bool ompi_mpi_thread_multiple;

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -91,7 +91,6 @@ extern bool ompi_enable_timing;
 int ompi_mpi_finalize(void)
 {
     int ret;
-    static int32_t finalize_has_already_started = 0;
     opal_list_item_t *item;
     struct timeval ompistart, ompistop;
     ompi_rte_collective_t *coll;
@@ -103,7 +102,7 @@ int ompi_mpi_finalize(void)
        ompi_comm_free() (or run into other nasty lions, tigers, or
        bears) */
 
-    if (! opal_atomic_cmpset_32(&finalize_has_already_started, 0, 1)) {
+    if (! opal_atomic_cmpset_32(&ompi_mpi_finalize_started, 0, 1)) {
         /* Note that if we're already finalized, we cannot raise an
            MPI exception.  The best that we can do is write something
            to stderr. */

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -124,6 +124,7 @@ const char ompi_version_string[] = OMPI_IDENT_STRING;
 bool ompi_mpi_init_started = false;
 bool ompi_mpi_initialized = false;
 bool ompi_mpi_finalized = false;
+int32_t ompi_mpi_finalize_started = 0;
 
 bool ompi_mpi_thread_multiple = false;
 int ompi_mpi_thread_requested = MPI_THREAD_SINGLE;


### PR DESCRIPTION
https://github.com/open-mpi/ompi/pull/972
