### PR TITLE
mpool: mpi_show_mpi_alloc_mem_leaks don't print out message if there are no leaks

### DIFF
--- a/ompi/mca/mpool/base/mpool_base_tree.c
+++ b/ompi/mca/mpool/base/mpool_base_tree.c
@@ -184,6 +184,9 @@ void mca_mpool_base_tree_print(void)
 
     num_leaks = 0;
     ompi_rb_tree_traverse(&mca_mpool_base_tree, condition, action);
+    if (0 == num_leaks) {
+        return;
+    }
 
     if (num_leaks <= ompi_debug_show_mpi_alloc_mem_leaks ||
         ompi_debug_show_mpi_alloc_mem_leaks < 0) {


### PR DESCRIPTION
:bot:assign: @bosilca 
:bot:label:bug
:bot:milestone:v1.10.1

Minor bug in the mpi_show_mpi_alloc_mem_leaks parameter. I was seeing this message is the absence of leaks:

```
--------------------------------------------------------------------------
The following memory locations were allocated via MPI_ALLOC_MEM but
not freed via MPI_FREE_MEM before invoking MPI_FINALIZE:

Process ID: [[11580,1],1]
Hostname:   2
PID:        5659

(null)
--------------------------------------------------------------------------
```

(cherry-picked from open-mpi/ompi@e0d9e6553f2cb960395b554205d89ff2510dda24)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
