### PR TITLE
mpool: mpi_show_mpi_alloc_mem_leaks don't print out message if there are no leaks

### DIFF
--- a/opal/mca/mpool/base/mpool_base_tree.c
+++ b/opal/mca/mpool/base/mpool_base_tree.c
@@ -182,6 +182,9 @@ void mca_mpool_base_tree_print(int show_up_to_mem_leaks)
     num_leaks = 0;
     max_mem_leaks = show_up_to_mem_leaks;
     opal_rb_tree_traverse(&mca_mpool_base_tree, condition, action);
+    if (0 == num_leaks) {
+        return;
+    }
 
     if (num_leaks <= show_up_to_mem_leaks ||
         show_up_to_mem_leaks < 0) {


### PR DESCRIPTION
Same fix as #634. Very minor bug in the alloc leak detection. Might as well fix it in all releases.

:bot:assign: @bosilca 
:bot:label:bug
:bot:milestone:v2.0.0

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@e0d9e6553f2cb960395b554205d89ff2510dda24)
