### PR TITLE
darray type incorrectly created or interpreted in mpi_alltoallw (former open-mpi/ompi@#965)

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -7,6 +7,8 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,21 +30,12 @@
 #include "ompi_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #include "ompi/constants.h"
-#include "opal/class/opal_pointer_array.h"
-#include "opal/class/opal_hash_table.h"
 #include "opal/datatype/opal_convertor.h"
-#include "opal/datatype/opal_datatype.h"
 #include "mpi.h"
 
 BEGIN_C_DECLS
@@ -177,31 +170,8 @@ ompi_datatype_add( ompi_datatype_t* pdtBase, const ompi_datatype_t* pdtAdd, uint
     return opal_datatype_add( &pdtBase->super, &pdtAdd->super, count, disp, extent );
 }
 
-
-static inline int32_t
-ompi_datatype_duplicate( const ompi_datatype_t* oldType, ompi_datatype_t** newType )
-{
-    ompi_datatype_t * new_ompi_datatype = ompi_datatype_create( oldType->super.desc.used + 2 );
-
-    *newType = new_ompi_datatype;
-    if( NULL == new_ompi_datatype ) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-    opal_datatype_clone( &oldType->super, &new_ompi_datatype->super);
-    /* Strip the predefined flag at the OMPI level. */
-    new_ompi_datatype->super.flags &= ~OMPI_DATATYPE_FLAG_PREDEFINED;
-    /* By default maintain the relationships related to the old data (such as ops) */
-    new_ompi_datatype->id = oldType->id;
-
-    /* Set the keyhash to NULL -- copying attributes is *only* done at
-       the top level (specifically, MPI_TYPE_DUP). */
-    new_ompi_datatype->d_keyhash = NULL;
-    new_ompi_datatype->args = NULL;
-    snprintf (new_ompi_datatype->name, MPI_MAX_OBJECT_NAME, "Dup %s",
-              oldType->name);
-
-    return OMPI_SUCCESS;
-}
+OMPI_DECLSPEC int32_t
+ompi_datatype_duplicate( const ompi_datatype_t* oldType, ompi_datatype_t** newType );
 
 OMPI_DECLSPEC int32_t ompi_datatype_create_contiguous( int count, const ompi_datatype_t* oldType, ompi_datatype_t** newType );
 OMPI_DECLSPEC int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
@@ -226,7 +196,10 @@ OMPI_DECLSPEC int32_t ompi_datatype_create_subarray(int ndims, int const* size_a
                                                     int const* start_array, int order,
                                                     const ompi_datatype_t* oldtype, ompi_datatype_t** newtype);
 static inline int32_t
-ompi_datatype_create_resized( const ompi_datatype_t* oldType, OPAL_PTRDIFF_TYPE lb, OPAL_PTRDIFF_TYPE extent, ompi_datatype_t** newType )
+ompi_datatype_create_resized( const ompi_datatype_t* oldType,
+                              OPAL_PTRDIFF_TYPE lb,
+                              OPAL_PTRDIFF_TYPE extent,
+                              ompi_datatype_t** newType )
 {
     ompi_datatype_t * type;
     ompi_datatype_duplicate( oldType, &type );
@@ -312,7 +285,7 @@ OMPI_DECLSPEC const ompi_datatype_t* ompi_datatype_match_size( int size, uint16_
 /*
  *
  */
-OMPI_DECLSPEC int32_t ompi_datatype_sndrcv( void *sbuf, int32_t scount, const ompi_datatype_t* sdtype,
+OMPI_DECLSPEC int32_t ompi_datatype_sndrcv( const void *sbuf, int32_t scount, const ompi_datatype_t* sdtype,
                                             void *rbuf, int32_t rcount, const ompi_datatype_t* rdtype);
 
 /*

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -26,8 +26,6 @@
 
 #include <stddef.h>
 
-#include "mpi.h"
-
 #include "opal/align.h"
 #include "opal/types.h"
 #include "opal/util/arch.h"

--- a/ompi/datatype/ompi_datatype_create.c
+++ b/ompi/datatype/ompi_datatype_create.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2010 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -20,11 +20,8 @@
 #include "ompi_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
-#include "ompi/constants.h"
 #include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/attribute/attribute.h"
@@ -87,3 +84,29 @@ int32_t ompi_datatype_destroy( ompi_datatype_t** type)
     *type = NULL;
     return OMPI_SUCCESS;
 }
+
+int32_t
+ompi_datatype_duplicate( const ompi_datatype_t* oldType, ompi_datatype_t** newType )
+{
+    ompi_datatype_t * new_ompi_datatype = ompi_datatype_create( oldType->super.desc.used + 2 );
+
+    *newType = new_ompi_datatype;
+    if( NULL == new_ompi_datatype ) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+    opal_datatype_clone( &oldType->super, &new_ompi_datatype->super);
+    /* Strip the predefined flag at the OMPI level. */
+    new_ompi_datatype->super.flags &= ~OMPI_DATATYPE_FLAG_PREDEFINED;
+    /* By default maintain the relationships related to the old data (such as ops) */
+    new_ompi_datatype->id = oldType->id;
+
+    /* Set the keyhash to NULL -- copying attributes is *only* done at
+       the top level (specifically, MPI_TYPE_DUP). */
+    new_ompi_datatype->d_keyhash = NULL;
+    new_ompi_datatype->args = NULL;
+    snprintf (new_ompi_datatype->name, MPI_MAX_OBJECT_NAME, "Dup %s",
+              oldType->name);
+
+    return OMPI_SUCCESS;
+}
+

--- a/ompi/datatype/ompi_datatype_create_contiguous.c
+++ b/ompi/datatype/ompi_datatype_create_contiguous.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -20,7 +20,6 @@
  */
 
 #include "ompi_config.h"
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "mpi.h"

--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -24,7 +24,6 @@
 
 #include <stddef.h>
 
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 static int

--- a/ompi/datatype/ompi_datatype_create_indexed.c
+++ b/ompi/datatype/ompi_datatype_create_indexed.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2010 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -24,7 +24,6 @@
 
 #include <stddef.h>
 
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 

--- a/ompi/datatype/ompi_datatype_create_struct.c
+++ b/ompi/datatype/ompi_datatype_create_struct.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -24,7 +24,6 @@
 
 #include <stddef.h>
 
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 int32_t ompi_datatype_create_struct( int count, const int* pBlockLength, const OPAL_PTRDIFF_TYPE* pDisp,

--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -26,7 +26,6 @@
 
 #include <stddef.h>
 
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 int32_t ompi_datatype_create_subarray(int ndims,
@@ -97,8 +96,14 @@ int32_t ompi_datatype_create_subarray(int ndims,
      * data inside. Thus, in case the original data contains the hard markers
      * (MPI_LB or MPI_UB) we must force the displacement of the data upward to
      * the right position AND set the hard markers LB and UB.
+     *
+     * NTH: ompi_datatype_create_resized() does not do enough for the general
+     * pack/unpack functions to work correctly. Until this is fixed always use
+     * ompi_datatype_create_struct(). Once this is fixed remove 1 || below. To
+     * verify that the regression is fixed run the subarray test in the Open MPI
+     * ibm testsuite.
      */
-    if( oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
+    if(1 || oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
         MPI_Aint displs[3];
         MPI_Datatype types[3];
         int blength[3] = { 1, 1, 1 };

--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -97,14 +97,8 @@ int32_t ompi_datatype_create_subarray(int ndims,
      * data inside. Thus, in case the original data contains the hard markers
      * (MPI_LB or MPI_UB) we must force the displacement of the data upward to
      * the right position AND set the hard markers LB and UB.
-     *
-     * NTH: ompi_datatype_create_resized() does not do enough for the general
-     * pack/unpack functions to work correctly. Until this is fixed always use
-     * ompi_datatype_create_struct(). Once this is fixed remove 1 || below. To
-     * verify that the regression is fixed run the subarray test in the Open MPI
-     * ibm testsuite.
      */
-    if(1 || oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
+    if( oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
         MPI_Aint displs[3];
         MPI_Datatype types[3];
         int blength[3] = { 1, 1, 1 };

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -24,7 +24,6 @@
 
 #include <stddef.h>
 
-#include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 /* Open questions ...

--- a/ompi/datatype/ompi_datatype_external32.c
+++ b/ompi/datatype/ompi_datatype_external32.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -19,8 +19,6 @@
  */
 
 #include "ompi_config.h"
-
-#include "ompi/constants.h"
 
 #include "opal/datatype/opal_convertor.h"
 #include "opal/util/arch.h"

--- a/ompi/datatype/ompi_datatype_get_elements.c
+++ b/ompi/datatype/ompi_datatype_get_elements.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2010 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart, 
@@ -24,8 +24,6 @@
 #include <limits.h>
 
 #include "ompi/runtime/params.h"
-#include "ompi/communicator/communicator.h"
-#include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 
 int ompi_datatype_get_elements (ompi_datatype_t *datatype, size_t ucount, size_t *count)

--- a/ompi/datatype/ompi_datatype_internal.h
+++ b/ompi/datatype/ompi_datatype_internal.h
@@ -7,6 +7,8 @@
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +28,6 @@
 #define OMPI_DATATYPE_INTERNAL_H
 
 #include "opal/datatype/opal_datatype_internal.h"
-#include "ompi/class/ompi_free_list.h"
 
 /*
  * This is the OMPI-layered numbering of ALL supported MPI types

--- a/ompi/datatype/ompi_datatype_match_size.c
+++ b/ompi/datatype/ompi_datatype_match_size.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -20,6 +20,7 @@
  */
 
 #include "ompi_config.h"
+#include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,9 +29,9 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include "ompi/constants.h"
 #include "opal/datatype/opal_convertor_internal.h"
 #include "opal/util/output.h"
+#include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 

--- a/ompi/datatype/ompi_datatype_sndrcv.c
+++ b/ompi/datatype/ompi_datatype_sndrcv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2009 The University of Tennessee and The University
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -22,7 +22,6 @@
 
 #include "ompi_config.h"
 
-#include "ompi/constants.h"
 #include "opal/datatype/opal_datatype.h"
 #include "opal/datatype/opal_datatype_internal.h"
 #include "opal/datatype/opal_convertor.h"
@@ -43,7 +42,7 @@
  *           - communicator
  * Returns:  - MPI_SUCCESS or error code
  */
-int32_t ompi_datatype_sndrcv( void *sbuf, int32_t scount, const ompi_datatype_t* sdtype,
+int32_t ompi_datatype_sndrcv( const void *sbuf, int32_t scount, const ompi_datatype_t* sdtype,
                               void *rbuf, int32_t rcount, const ompi_datatype_t* rdtype)
 {
     opal_convertor_t send_convertor, recv_convertor;

--- a/opal/datatype/opal_convertor.h
+++ b/opal/datatype/opal_convertor.h
@@ -24,19 +24,8 @@
 
 #include "opal_config.h"
 
-#include <stddef.h>
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
-#endif
-#ifdef HAVE_NET_UIO_H
-#include <net/uio.h>
-#endif
-#if HAVE_STRING_H
-#include <string.h>
 #endif
 
 #include "opal/constants.h"
@@ -229,6 +218,14 @@ static inline void opal_convertor_get_current_pointer( const opal_convertor_t* p
     unsigned char* base = pConv->pBaseBuf + pConv->bConverted + pConv->pDesc->true_lb;
     *position = (void*)base;
 }
+
+static inline void opal_convertor_get_offset_pointer( const opal_convertor_t* pConv,
+                                                      size_t offset, void** position )
+{
+    unsigned char* base = pConv->pBaseBuf + offset + pConv->pDesc->true_lb;
+    *position = (void*)base;
+}
+
 
 /*
  *

--- a/opal/datatype/opal_convertor_internal.h
+++ b/opal/datatype/opal_convertor_internal.h
@@ -16,10 +16,6 @@
 
 #include "opal_config.h"
 
-#include <stddef.h>
-
-#include "opal/constants.h"
-#include "opal/datatype/opal_datatype.h"
 #include "opal/datatype/opal_convertor.h"
 
 BEGIN_C_DECLS
@@ -54,9 +50,7 @@ void opal_convertor_destroy_masters( void );
 
 #if OPAL_ENABLE_DEBUG
 extern bool opal_pack_debug;
-#define DO_DEBUG(INST)  if( opal_pack_debug ) { INST }
-#else
-#define DO_DEBUG(INST)
+extern bool opal_unpack_debug;
 #endif  /* OPAL_ENABLE_DEBUG */
 
 END_C_DECLS

--- a/opal/datatype/opal_convertor_raw.c
+++ b/opal/datatype/opal_convertor_raw.c
@@ -22,6 +22,10 @@
 
 #if OPAL_ENABLE_DEBUG
 #include "opal/util/output.h"
+
+#define DO_DEBUG(INST)  if( opal_pack_debug ) { INST }
+#else
+#define DO_DEBUG(INST)
 #endif /* OPAL_ENABLE_DEBUG */
 
 /**
@@ -44,6 +48,13 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
     uint32_t index = 0, i;    /* the iov index and a simple counter */
 
     assert( (*iov_count) > 0 );
+    if( OPAL_LIKELY(pConvertor->flags & CONVERTOR_COMPLETED) ) {
+        iov[0].iov_base = NULL;
+        iov[0].iov_len  = 0;
+        *iov_count      = 0;
+        *length         = iov[0].iov_len;
+        return 1;  /* We're still done */
+    }
     if( OPAL_LIKELY(pConvertor->flags & CONVERTOR_NO_OP) ) {
         /* The convertor contain minimal informations, we only use the bConverted
          * to manage the conversion. This function work even after the convertor

--- a/opal/datatype/opal_copy_functions_heterogeneous.c
+++ b/opal/datatype/opal_copy_functions_heterogeneous.c
@@ -40,18 +40,34 @@
  */
 
 static inline void
-opal_dt_swap_bytes(void *to_p, const void *from_p, const size_t size)
+opal_dt_swap_bytes(void *to_p, const void *from_p, const size_t size, size_t count)
 {
     size_t i;
     size_t back_i = size - 1;
     uint8_t *to = (uint8_t*) to_p;
     uint8_t *from = (uint8_t*) from_p;
+
+    /* Do the first element */
     for (i = 0 ; i < size ; i++, back_i--) {
         to[back_i] = from[i];
     }
+    /* Do all the others if any */
+    while(count > 1) {
+        to += size;
+        from += size;
+        count--;
+        for (i = 0, back_i = size - 1 ; i < size ; i++, back_i--) {
+            to[back_i] = from[i];
+        }
+    }
 }
 
-
+/**
+ * BEWARE: Do not use the following macro with composed types such as
+ * complex. As the swap is done using the entire type sizeof, the
+ * wrong endianess translation will be done.  Instead, use the
+ * COPY_2SAMETYPE_HETEROGENEOUS.
+ */
 #define COPY_TYPE_HETEROGENEOUS( TYPENAME, TYPE )                                         \
 static int32_t                                                                            \
 copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,             \
@@ -67,10 +83,14 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,   
                                                                         \
     if ((pConvertor->remoteArch & OPAL_ARCH_ISBIGENDIAN) !=             \
         (opal_local_arch & OPAL_ARCH_ISBIGENDIAN)) {                    \
-        for( i = 0; i < count; i++ ) {                                  \
-            opal_dt_swap_bytes(to, from, sizeof(TYPE));                 \
-            to += to_extent;                                            \
-            from += from_extent;                                        \
+        if( (to_extent == from_extent) && (to_extent == sizeof(TYPE)) ) { \
+            opal_dt_swap_bytes(to, from, sizeof(TYPE), count);          \
+        } else {                                                        \
+            for( i = 0; i < count; i++ ) {                              \
+                opal_dt_swap_bytes(to, from, sizeof(TYPE), 1);          \
+                to += to_extent;                                        \
+                from += from_extent;                                    \
+            }                                                           \
         }                                                               \
     } else if ((OPAL_PTRDIFF_TYPE)sizeof(TYPE) == to_extent &&          \
                (OPAL_PTRDIFF_TYPE)sizeof(TYPE) == from_extent) {        \
@@ -87,6 +107,44 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,   
     return count;                                                       \
 }
 
+#define COPY_2SAMETYPE_HETEROGENEOUS( TYPENAME, TYPE )                                         \
+static int32_t                                                                            \
+copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,             \
+                                const char* from, size_t from_len, OPAL_PTRDIFF_TYPE from_extent, \
+                                char* to, size_t to_length, OPAL_PTRDIFF_TYPE to_extent,          \
+                                OPAL_PTRDIFF_TYPE *advance)             \
+{                                                                       \
+    uint32_t i;                                                         \
+                                                                        \
+    datatype_check( #TYPE, sizeof(TYPE), sizeof(TYPE), &count,          \
+                   from, from_len, from_extent,                         \
+                   to, to_length, to_extent);                           \
+                                                                        \
+    if ((pConvertor->remoteArch & OPAL_ARCH_ISBIGENDIAN) !=             \
+        (opal_local_arch & OPAL_ARCH_ISBIGENDIAN)) {                    \
+        if( (to_extent == from_extent) && (to_extent == sizeof(TYPE)) ) { \
+            opal_dt_swap_bytes(to, from, sizeof(TYPE), 2 * count);      \
+        } else {                                                        \
+            for( i = 0; i < count; i++ ) {                              \
+                opal_dt_swap_bytes(to, from, sizeof(TYPE), 2);          \
+                to += to_extent;                                        \
+                from += from_extent;                                    \
+            }                                                           \
+        }                                                               \
+    } else if ((OPAL_PTRDIFF_TYPE)sizeof(TYPE) == to_extent &&          \
+               (OPAL_PTRDIFF_TYPE)sizeof(TYPE) == from_extent) {        \
+         MEMCPY( to, from, count * sizeof(TYPE) );                      \
+    } else {                                                            \
+         /* source or destination are non-contigous */                  \
+         for( i = 0; i < count; i++ ) {                                 \
+             MEMCPY( to, from, sizeof(TYPE) );                          \
+             to += to_extent;                                           \
+             from += from_extent;                                       \
+         }                                                              \
+    }                                                                   \
+    *advance = count * from_extent;                                     \
+    return count;                                                       \
+}
 
 #define COPY_2TYPE_HETEROGENEOUS( TYPENAME, TYPE1, TYPE2 )              \
 static int32_t                                                          \
@@ -109,9 +167,9 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count, \
             TYPE1* to_1, *from_1;                                       \
             TYPE2* to_2, *from_2;                                       \
             to_1 = (TYPE1*) to; from_1 = (TYPE1*) from;                 \
-            opal_dt_swap_bytes(to_1, from_1, sizeof(TYPE1));            \
+            opal_dt_swap_bytes(to_1, from_1, sizeof(TYPE1), 1);         \
             to_2 = (TYPE2*) (to_1 + 1); from_2 = (TYPE2*) (from_1 + 1); \
-            opal_dt_swap_bytes(to_2, from_2, sizeof(TYPE2));            \
+            opal_dt_swap_bytes(to_2, from_2, sizeof(TYPE2), 1);         \
             to += to_extent;                                            \
             from += from_extent;                                        \
         }                                                               \

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -35,9 +35,6 @@
 #include "opal_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
 
 #include "opal/class/opal_object.h"
 

--- a/opal/datatype/opal_datatype_copy.c
+++ b/opal/datatype/opal_datatype_copy.c
@@ -37,7 +37,6 @@
 
 
 #if OPAL_ENABLE_DEBUG
-extern bool opal_copy_debug;
 #define DO_DEBUG(INST)  if( opal_copy_debug ) { INST }
 #else
 #define DO_DEBUG(INST)

--- a/opal/datatype/opal_datatype_create.c
+++ b/opal/datatype/opal_datatype_create.c
@@ -33,23 +33,28 @@ static void opal_datatype_construct( opal_datatype_t* pData )
     int i;
 
     pData->size               = 0;
-    pData->id                 = 0;
-    pData->nbElems            = 0;
-    pData->bdt_used           = 0;
-    for( i = 0; i < OPAL_DATATYPE_MAX_PREDEFINED; i++ )
-        pData->btypes[i]      = 0;
-    pData->btypes[OPAL_DATATYPE_LOOP]    = 0;
-
-    pData->opt_desc.desc      = NULL;
-    pData->opt_desc.length    = 0;
-    pData->opt_desc.used      = 0;
-    pData->align              = 1;
     pData->flags              = OPAL_DATATYPE_FLAG_CONTIGUOUS;
+    pData->id                 = 0;
+    pData->bdt_used           = 0;
+    pData->size               = 0;
     pData->true_lb            = LONG_MAX;
     pData->true_ub            = LONG_MIN;
     pData->lb                 = LONG_MAX;
     pData->ub                 = LONG_MIN;
-    pData->name[0]            = '\0';
+    pData->align              = 1;
+    pData->nbElems            = 0;
+    memset(pData->name, 0, OPAL_MAX_OBJECT_NAME);
+
+    pData->desc.desc          = NULL;
+    pData->desc.length        = 0;
+    pData->desc.used          = 0;
+
+    pData->opt_desc.desc      = NULL;
+    pData->opt_desc.length    = 0;
+    pData->opt_desc.used      = 0;
+
+    for( i = 0; i < OPAL_DATATYPE_MAX_SUPPORTED; i++ )
+        pData->btypes[i]      = 0;
 }
 
 static void opal_datatype_destruct( opal_datatype_t* datatype )

--- a/opal/datatype/opal_datatype_cuda.c
+++ b/opal/datatype/opal_datatype_cuda.c
@@ -7,9 +7,10 @@
  * $HEADER$
  */
 
-#include "ompi_config.h"
+#include "opal_config.h"
 
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "opal/align.h"
@@ -118,7 +119,7 @@ void *opal_cuda_memcpy(void *dest, const void *src, size_t size, opal_convertor_
  * datatypes.  The current code has macros that cannot handle a convertor
  * argument to the memcpy call.
  */
-void *opal_cuda_memcpy_sync(void *dest, void *src, size_t size)
+void *opal_cuda_memcpy_sync(void *dest, const void *src, size_t size)
 {
     int res;
     res = ftable.gpu_cu_memcpy(dest, src, size);

--- a/opal/datatype/opal_datatype_cuda.h
+++ b/opal/datatype/opal_datatype_cuda.h
@@ -24,7 +24,7 @@ typedef struct opal_common_cuda_function_table opal_common_cuda_function_table_t
 void mca_cuda_convertor_init(opal_convertor_t* convertor, const void *pUserBuf);
 bool opal_cuda_check_bufs(char *dest, char *src);
 void* opal_cuda_memcpy(void * dest, const void * src, size_t size, opal_convertor_t* convertor);
-void* opal_cuda_memcpy_sync(void * dest, void * src, size_t size);
+void* opal_cuda_memcpy_sync(void * dest, const void * src, size_t size);
 void* opal_cuda_memmove(void * dest, void * src, size_t size);
 void opal_cuda_add_initialization_function(int (*fptr)(opal_common_cuda_function_table_t *));
 void opal_cuda_set_copy_function_async(opal_convertor_t* convertor, void *stream);

--- a/opal/datatype/opal_datatype_internal.h
+++ b/opal/datatype/opal_datatype_internal.h
@@ -25,15 +25,8 @@
 
 #include "opal_config.h"
 
-#include <stddef.h>
-#include <stdio.h>
-
-#ifdef HAVE_STRING_H
+#include <stdarg.h>
 #include <string.h>
-#endif
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
 
 #if defined(VERBOSE)
 #include "opal/util/output.h"
@@ -151,8 +144,10 @@ struct ddt_elem_id_description {
 };
 typedef struct ddt_elem_id_description ddt_elem_id_description;
 
-/* the basic element. A data description is composed
- * by a set of basic elements.
+/**
+ * The data element description. It is similar to a vector type, a contiguous
+ * blocklen number of basic elements, with a displacement for the first element
+ * and then an extent for all the extra count.
  */
 struct ddt_elem_desc {
     ddt_elem_id_description common;           /**< basic data description and flags */
@@ -163,6 +158,14 @@ struct ddt_elem_desc {
 };
 typedef struct ddt_elem_desc ddt_elem_desc_t;
 
+/**
+ * The loop description, with it's two markers: one for the begining and one for
+ * the end. The initial marker contains the number of repetitions, the number of
+ * elements in the loop, and the extent of each loop. The end marker contains in
+ * addition to the number of elements (so that we can easily pair together the
+ * two markers), the size of the data contained inside and the displacement of
+ * the first element.
+ */
 struct ddt_loop_desc {
     ddt_elem_id_description common;           /**< basic data description and flags */
     uint32_t                loops;            /**< number of elements */
@@ -475,6 +478,11 @@ static inline int GET_FIRST_NON_LOOP( const union dt_elem_desc* _pElem )
 OPAL_DECLSPEC int opal_datatype_contain_basic_datatypes( const struct opal_datatype_t* pData, char* ptr, size_t length );
 OPAL_DECLSPEC int opal_datatype_dump_data_flags( unsigned short usflags, char* ptr, size_t length );
 OPAL_DECLSPEC int opal_datatype_dump_data_desc( union dt_elem_desc* pDesc, int nbElems, char* ptr, size_t length );
+
+#if OPAL_ENABLE_DEBUG
+extern bool opal_position_debug;
+extern bool opal_copy_debug;
+#endif  /* OPAL_ENABLE_DEBUG */
 
 END_C_DECLS
 #endif  /* OPAL_DATATYPE_INTERNAL_H_HAS_BEEN_INCLUDED */

--- a/opal/datatype/opal_datatype_pack.c
+++ b/opal/datatype/opal_datatype_pack.c
@@ -28,6 +28,10 @@
 
 #if OPAL_ENABLE_DEBUG
 #include "opal/util/output.h"
+
+#define DO_DEBUG(INST)  if( opal_pack_debug ) { INST }
+#else
+#define DO_DEBUG(INST)
 #endif  /* OPAL_ENABLE_DEBUG */
 
 #include "opal/datatype/opal_datatype_checksum.h"
@@ -104,49 +108,55 @@ opal_pack_homogeneous_contig_with_gaps_function( opal_convertor_t* pConv,
                                                  size_t* max_data )
 {
     const opal_datatype_t* pData = pConv->pDesc;
-    dt_stack_t* pStack = pConv->pStack;
+    dt_stack_t* stack = pConv->pStack;
     unsigned char *user_memory, *packed_buffer;
     uint32_t i, index, iov_count;
-    size_t max_allowed, total_bytes_converted = 0;
-    OPAL_PTRDIFF_TYPE extent;
+    size_t bConverted, remaining, length, initial_bytes_converted = pConv->bConverted;
+    OPAL_PTRDIFF_TYPE extent= pData->ub - pData->lb;
     OPAL_PTRDIFF_TYPE initial_displ = pConv->use_desc->desc[pConv->use_desc->used].end_loop.first_elem_disp;
 
-    extent = pData->ub - pData->lb;
     assert( (pData->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) && ((OPAL_PTRDIFF_TYPE)pData->size != extent) );
-
-    /* Limit the amount of packed data to the data left over on this convertor */
-    max_allowed = pConv->local_size - pConv->bConverted;
-    if( max_allowed > (*max_data) )
-        max_allowed = (*max_data);
-
-    i = (uint32_t)(pConv->bConverted / pData->size);  /* how many we already pack */
+    DO_DEBUG( opal_output( 0, "pack_homogeneous_contig( pBaseBuf %p, iov_count %d )\n",
+                           pConv->pBaseBuf, *out_size ); );
+    if( stack[1].type != opal_datatype_uint1.id ) {
+        stack[1].count *= opal_datatype_basicDatatypes[stack[1].type]->size;
+        stack[1].type = opal_datatype_uint1.id;
+    }
 
     /* There are some optimizations that can be done if the upper level
      * does not provide a buffer.
      */
-    user_memory = pConv->pBaseBuf + initial_displ + pStack[0].disp + pStack[1].disp;
     for( iov_count = 0; iov_count < (*out_size); iov_count++ ) {
-        if( 0 == max_allowed ) break;  /* we're done this time */
-        if( iov[iov_count].iov_base == NULL ) {
+        /* Limit the amount of packed data to the data left over on this convertor */
+        remaining = pConv->local_size - pConv->bConverted;
+        if( 0 == remaining ) break;  /* we're done this time */
+        if( remaining > (uint32_t)iov[iov_count].iov_len )
+            remaining = iov[iov_count].iov_len;
+        packed_buffer = (unsigned char *)iov[iov_count].iov_base;
+        bConverted = remaining; /* how much will get unpacked this time */
+        user_memory = pConv->pBaseBuf + initial_displ + stack[0].disp + stack[1].disp;
+        i = pConv->count - stack[0].count;  /* how many we already packed */
+        assert(i == ((uint32_t)(pConv->bConverted / pData->size)));
+
+        if( packed_buffer == NULL ) {
             /* special case for small data. We avoid allocating memory if we
              * can fill the iovec directly with the address of the remaining
              * data.
              */
-            if( (uint32_t)pStack->count < ((*out_size) - iov_count) ) {
-                pStack[1].count = pData->size - (pConv->bConverted % pData->size);
+            if( (uint32_t)stack->count < ((*out_size) - iov_count) ) {
+                stack[1].count = pData->size - (pConv->bConverted % pData->size);
                 for( index = iov_count; i < pConv->count; i++, index++ ) {
                     iov[index].iov_base = (IOVBASE_TYPE *) user_memory;
-                    iov[index].iov_len = pStack[1].count;
-                    pStack[0].disp += extent;
-                    total_bytes_converted += pStack[1].count;
-                    pStack[1].disp  = 0;  /* reset it for the next round */
-                    pStack[1].count = pData->size;
-                    user_memory = pConv->pBaseBuf + initial_displ + pStack[0].disp;
+                    iov[index].iov_len = stack[1].count;
+                    stack[0].disp += extent;
+                    pConv->bConverted += stack[1].count;
+                    stack[1].disp  = 0;  /* reset it for the next round */
+                    stack[1].count = pData->size;
+                    user_memory = pConv->pBaseBuf + initial_displ + stack[0].disp;
                     COMPUTE_CSUM( iov[index].iov_base, iov[index].iov_len, pConv );
                 }
                 *out_size = iov_count + index;
-                pConv->bConverted += total_bytes_converted;
-                *max_data = total_bytes_converted;
+                *max_data = (pConv->bConverted - initial_bytes_converted);
                 pConv->flags |= CONVERTOR_COMPLETED;
                 return 1;  /* we're done */
             }
@@ -157,10 +167,10 @@ opal_pack_homogeneous_contig_with_gaps_function( opal_convertor_t* pConv,
                  */
                 for( index = iov_count; (i < pConv->count) && (index < (*out_size));
                      i++, index++ ) {
-                    if( max_allowed < pData->size ) {
+                    if( remaining < pData->size ) {
                         iov[index].iov_base = (IOVBASE_TYPE *) user_memory;
-                        iov[index].iov_len = max_allowed;
-                        max_allowed = 0;
+                        iov[index].iov_len = remaining;
+                        remaining = 0;
                         COMPUTE_CSUM( iov[index].iov_base, iov[index].iov_len, pConv );
                         break;
                     } else {
@@ -169,12 +179,11 @@ opal_pack_homogeneous_contig_with_gaps_function( opal_convertor_t* pConv,
                         user_memory += extent;
                         COMPUTE_CSUM( iov[index].iov_base, (size_t)iov[index].iov_len, pConv );
                     }
-                    max_allowed -= iov[index].iov_len;
-                    total_bytes_converted += iov[index].iov_len;
+                    remaining -= iov[index].iov_len;
+                    pConv->bConverted += iov[index].iov_len;
                 }
                 *out_size = index;
-                *max_data = total_bytes_converted;
-                pConv->bConverted += total_bytes_converted;
+                *max_data = (pConv->bConverted - initial_bytes_converted);
                 if( pConv->bConverted == pConv->local_size ) {
                     pConv->flags |= CONVERTOR_COMPLETED;
                     return 1;
@@ -184,52 +193,63 @@ opal_pack_homogeneous_contig_with_gaps_function( opal_convertor_t* pConv,
         }
 
         {
-            uint32_t counter;
-            size_t done;
+            DO_DEBUG( opal_output( 0, "pack_homogeneous_contig( user_memory %p, packed_buffer %p length %lu\n",
+                                   user_memory, packed_buffer, (unsigned long)remaining ); );
 
-            packed_buffer = (unsigned char *) iov[iov_count].iov_base;
-            done = pConv->bConverted - i * pData->size;  /* partial data from last pack */
+            length = (0 == pConv->stack_pos ? 0 : stack[1].count);  /* left over from the last pack */
             /* data left from last round and enough space in the buffer */
-            if( (done + max_allowed) >= pData->size ) {
+            if( (0 != length) && (length <= remaining)) {
                 /* copy the partial left-over from the previous round */
-                done = pData->size - done;
-                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, done, pConv->pBaseBuf, pData, pConv->count );
-                MEMCPY_CSUM( packed_buffer, user_memory, done, pConv );
-                packed_buffer += done;
-                max_allowed -= done;
-                total_bytes_converted += done;
-                user_memory += (extent - pData->size + done);
-
-                /* copy entire types */
-                counter = (uint32_t)(max_allowed / pData->size);
-                if( counter > pConv->count ) counter = pConv->count;
-                for( i = 0; i < counter; i++ ) {
-                    OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, pData->size, pConv->pBaseBuf, pData, pConv->count );
-                    MEMCPY_CSUM( packed_buffer, user_memory, pData->size, pConv );
-                    packed_buffer+= pData->size;
-                    user_memory += extent;
+                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, length, pConv->pBaseBuf,
+                                                 pData, pConv->count );
+                DO_DEBUG( opal_output( 0, "2. pack dest %p src %p length %lu\n",
+                                       user_memory, packed_buffer, (unsigned long)length ); );
+                MEMCPY_CSUM( packed_buffer, user_memory, length, pConv );
+                packed_buffer  += length;
+                user_memory    += (extent - pData->size + length);
+                remaining      -= length;
+                stack[1].count -= length;
+                if( 0 == stack[1].count) { /* one completed element */
+                    stack[0].count--;
+                    stack[0].disp += extent;
+                    if( 0 != stack[0].count ) {  /* not yet done */
+                        stack[1].count = pData->size;
+                        stack[1].disp = 0;
+                    }
                 }
-                done = (counter * pData->size);
-                max_allowed -= done;
-                total_bytes_converted += done;
             }
-            /* If there is anything pending ... */
-            if( 0 != max_allowed ) {
-                done = max_allowed;
-                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, done, pConv->pBaseBuf, pData, pConv->count );
-                MEMCPY_CSUM( packed_buffer, user_memory, done, pConv );
-                packed_buffer += done;
-                max_allowed = 0;
-                total_bytes_converted += done;
-                user_memory += done;
+            for( i = 0;  pData->size <= remaining; i++ ) {
+                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, pData->size, pConv->pBaseBuf,
+                                                 pData, pConv->count );
+                DO_DEBUG( opal_output( 0, "3. pack dest %p src %p length %lu\n",
+                                       user_memory, packed_buffer, (unsigned long)pData->size ); );
+                MEMCPY_CSUM( packed_buffer, user_memory, pData->size, pConv );
+                packed_buffer += pData->size;
+                user_memory   += extent;
+                remaining   -= pData->size;
+            }
+            stack[0].count -= i;  /* the filled up and the entire types */
+            stack[0].disp  += (i * extent);
+            stack[1].disp  += remaining;
+            /* Copy the last bits */
+            if( 0 != remaining ) {
+                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, remaining, pConv->pBaseBuf,
+                                                 pData, pConv->count );
+                DO_DEBUG( opal_output( 0, "4. pack dest %p src %p length %lu\n",
+                                       user_memory, packed_buffer, (unsigned long)remaining ); );
+                MEMCPY_CSUM( packed_buffer, user_memory, remaining, pConv );
+                user_memory += remaining;
+                stack[1].count -= remaining;
+            }
+            if( 0 == stack[1].count ) {  /* prepare for the next element */
+                stack[1].count = pData->size;
+                stack[1].disp  = 0;
             }
         }
+        pConv->bConverted += bConverted;
     }
-    pStack[0].disp = (intptr_t)user_memory - (intptr_t)pConv->pBaseBuf - initial_displ;
-    pStack[1].disp = max_allowed;
-    *max_data = total_bytes_converted;
-    pConv->bConverted += total_bytes_converted;
     *out_size = iov_count;
+    *max_data = (pConv->bConverted - initial_bytes_converted);
     if( pConv->bConverted == pConv->local_size ) {
         pConv->flags |= CONVERTOR_COMPLETED;
         return 1;
@@ -263,7 +283,8 @@ opal_generic_simple_pack_function( opal_convertor_t* pConvertor,
     size_t iov_len_local;
     uint32_t iov_count;
 
-    DO_DEBUG( opal_output( 0, "opal_convertor_generic_simple_pack( %p, {%p, %lu}, %d )\n", (void*)pConvertor,
+    DO_DEBUG( opal_output( 0, "opal_convertor_generic_simple_pack( %p:%p, {%p, %lu}, %d )\n",
+                           (void*)pConvertor, (void*)pConvertor->pBaseBuf,
                            iov[0].iov_base, (unsigned long)iov[0].iov_len, *out_size ); );
 
     description = pConvertor->use_desc->desc;
@@ -366,7 +387,7 @@ opal_generic_simple_pack_function( opal_convertor_t* pConvertor,
         return 1;
     }
     /* Save the global position for the next round */
-    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_INT8, count_desc,
+    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, pElem->elem.common.type, count_desc,
                 conv_ptr - pConvertor->pBaseBuf );
     DO_DEBUG( opal_output( 0, "pack save stack stack_pos %d pos_desc %d count_desc %d disp %ld\n",
                            pConvertor->stack_pos, pStack->index, (int)pStack->count, (long)pStack->disp ); );

--- a/opal/datatype/opal_datatype_pack.h
+++ b/opal/datatype/opal_datatype_pack.h
@@ -18,9 +18,6 @@
 #include "opal_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
 
 #if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
 /* Make use of existing macro to do CUDA style memcpy */
@@ -30,7 +27,7 @@
 #endif
 
 static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
-                                         dt_elem_desc_t* ELEM,
+                                         const dt_elem_desc_t* ELEM,
                                          uint32_t* COUNT,
                                          unsigned char** SOURCE,
                                          unsigned char** DESTINATION,
@@ -38,7 +35,7 @@ static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
 {
     uint32_t _copy_count = *(COUNT);
     size_t _copy_blength;
-    ddt_elem_desc_t* _elem = &((ELEM)->elem);
+    const ddt_elem_desc_t* _elem = &((ELEM)->elem);
     unsigned char* _source = (*SOURCE) + _elem->disp;
 
     _copy_blength = opal_datatype_basicDatatypes[_elem->common.type]->size;
@@ -76,14 +73,14 @@ static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
 }
 
 static inline void pack_contiguous_loop( opal_convertor_t* CONVERTOR,
-                                         dt_elem_desc_t* ELEM,
+                                         const dt_elem_desc_t* ELEM,
                                          uint32_t* COUNT,
                                          unsigned char** SOURCE,
                                          unsigned char** DESTINATION,
                                          size_t* SPACE )
 {
-    ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
-    ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
+    const ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
+    const ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
     unsigned char* _source = (*SOURCE) + _end_loop->first_elem_disp;
     uint32_t _copy_loops = *(COUNT);
     uint32_t _i;

--- a/opal/datatype/opal_datatype_position.c
+++ b/opal/datatype/opal_datatype_position.c
@@ -36,7 +36,6 @@
 #if OPAL_ENABLE_DEBUG
 #include "opal/util/output.h"
 
-extern bool opal_position_debug;
 #define DO_DEBUG(INST)  if( opal_position_debug ) { INST }
 #else
 #define DO_DEBUG(INST)
@@ -109,9 +108,8 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
     dt_stack_t* pStack;       /* pointer to the position on the stack */
     uint32_t pos_desc;        /* actual position in the description of the derived datatype */
     uint32_t count_desc;      /* the number of items already done in the actual pos_desc */
-    uint16_t type;            /* type at current position */
     dt_elem_desc_t* description = pConvertor->use_desc->desc;
-    dt_elem_desc_t* pElem;
+    dt_elem_desc_t* pElem;    /* current position */
     unsigned char *base_pointer = pConvertor->pBaseBuf;
     size_t iov_len_local;
     OPAL_PTRDIFF_TYPE extent = pConvertor->pDesc->ub - pConvertor->pDesc->lb;
@@ -133,8 +131,8 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
                                (unsigned long)pConvertor->bConverted, (unsigned long)*position, (unsigned long)pConvertor->pDesc->size,
                                (unsigned long)iov_len_local, count_desc ); );
         /* Update all the stack including the last one */
-        for( type = 0; type <= pConvertor->stack_pos; type++ )
-            pStack[type].disp += count_desc * extent;
+        for( pos_desc = 0; pos_desc <= pConvertor->stack_pos; pos_desc++ )
+            pStack[pos_desc].disp += count_desc * extent;
         pConvertor->bConverted += count_desc * pConvertor->pDesc->size;
         iov_len_local = *position - pConvertor->bConverted;
         pStack[0].count -= count_desc;
@@ -228,7 +226,6 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
             POSITION_PREDEFINED_DATATYPE( pConvertor, pElem, count_desc,
                                           base_pointer, iov_len_local );
             if( 0 != count_desc ) {  /* completed */
-                type = pElem->elem.common.type;
                 pConvertor->partial_length = (uint32_t)iov_len_local;
                 goto complete_loop;
             }
@@ -245,7 +242,7 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
 
     if( !(pConvertor->flags & CONVERTOR_COMPLETED) ) {
         /* I complete an element, next step I should go to the next one */
-        PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_UINT1, count_desc,
+        PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, pElem->elem.common.type, count_desc,
                     base_pointer - pConvertor->pBaseBuf );
         DO_DEBUG( opal_output( 0, "position save stack stack_pos %d pos_desc %d count_desc %d disp %llx\n",
                                pConvertor->stack_pos, pStack->index, (int)pStack->count, (unsigned long long)pStack->disp ); );

--- a/opal/datatype/opal_datatype_resize.c
+++ b/opal/datatype/opal_datatype_resize.c
@@ -21,6 +21,9 @@ int32_t opal_datatype_resize( opal_datatype_t* type, OPAL_PTRDIFF_TYPE lb, OPAL_
     type->lb = lb;
     type->ub = lb + extent;
 
+    type->true_lb += lb;
+    type->true_ub += lb;
+
     type->flags &= ~OPAL_DATATYPE_FLAG_NO_GAPS;
     if( (extent == (OPAL_PTRDIFF_TYPE)type->size) &&
         (type->flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) ) {

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -30,6 +30,10 @@
 
 #if OPAL_ENABLE_DEBUG
 #include "opal/util/output.h"
+
+#define DO_DEBUG(INST)  if( opal_unpack_debug ) { INST }
+#else
+#define DO_DEBUG(INST)
 #endif  /* OPAL_ENABLE_DEBUG */
 
 #include "opal/datatype/opal_datatype_checksum.h"
@@ -72,11 +76,16 @@ opal_unpack_homogeneous_contig_function( opal_convertor_t* pConv,
 
     DO_DEBUG( opal_output( 0, "unpack_homogeneous_contig( pBaseBuf %p, iov_count %d )\n",
                            pConv->pBaseBuf, *out_size ); );
+    if( stack[1].type != opal_datatype_uint1.id ) {
+        stack[1].count *= opal_datatype_basicDatatypes[stack[1].type]->size;
+        stack[1].type = opal_datatype_uint1.id;
+    }
     for( iov_count = 0; iov_count < (*out_size); iov_count++ ) {
-        packed_buffer = (unsigned char*)iov[iov_count].iov_base;
         remaining = pConv->local_size - pConv->bConverted;
+        if( 0 == remaining ) break;  /* we're done this time */
         if( remaining > (uint32_t)iov[iov_count].iov_len )
             remaining = iov[iov_count].iov_len;
+        packed_buffer = (unsigned char*)iov[iov_count].iov_base;
         bConverted = remaining; /* how much will get unpacked this time */
         user_memory = pConv->pBaseBuf + initial_displ;
 
@@ -97,21 +106,25 @@ opal_unpack_homogeneous_contig_function( opal_convertor_t* pConv,
             DO_DEBUG( opal_output( 0, "unpack_homogeneous_contig( user_memory %p, packed_buffer %p length %lu\n",
                                    user_memory, packed_buffer, (unsigned long)remaining ); );
 
-            length = pConv->bConverted / pData->size;  /* already done */
-            length = pConv->bConverted - length * pData->size;  /* how much of the last data we convert */
-
+            length = (0 == pConv->stack_pos ? 0 : stack[1].count);  /* left over from the last unpack */
             /* complete the last copy */
-            if( length != 0 ) {
-                length = pData->size - length;
-                if( length <= remaining ) {
-                    OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, length, pConv->pBaseBuf,
-                                                pData, pConv->count );
-                    DO_DEBUG( opal_output( 0, "2. unpack dest %p src %p length %lu\n",
-                                           user_memory, packed_buffer, (unsigned long)length ); );
-                    MEMCPY_CSUM( user_memory, packed_buffer, length, pConv );
-                    packed_buffer += length;
-                    user_memory   += (extent - (pData->size - length));
-                    remaining     -= length;
+            if( (0 != length) && (length <= remaining) ) {
+                OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, length, pConv->pBaseBuf,
+                                                 pData, pConv->count );
+                DO_DEBUG( opal_output( 0, "2. unpack dest %p src %p length %lu\n",
+                                       user_memory, packed_buffer, (unsigned long)length ); );
+                MEMCPY_CSUM( user_memory, packed_buffer, length, pConv );
+                packed_buffer  += length;
+                user_memory    += (extent - (pData->size - length));
+                remaining      -= length;
+                stack[1].count -= length;
+                if( 0 == stack[1].count) { /* one completed element */
+                    stack[0].count--;
+                    stack[0].disp += extent;
+                    if( 0 != stack[0].count ) {  /* not yet done */
+                        stack[1].count = pData->size;
+                        stack[1].disp = 0;
+                    }
                 }
             }
             for( i = 0; pData->size <= remaining; i++ ) {
@@ -124,16 +137,18 @@ opal_unpack_homogeneous_contig_function( opal_convertor_t* pConv,
                 user_memory   += extent;
                 remaining     -= pData->size;
             }
-            stack[0].disp = (intptr_t)user_memory - (intptr_t)pConv->pBaseBuf - initial_displ;
-            stack[1].disp = remaining;
+            stack[0].count -= i;
+            stack[0].disp  += (i * extent);
+            stack[1].disp  += remaining;
             /* copy the last bits */
-            if( remaining != 0 ) {
+            if( 0 != remaining ) {
                 OPAL_DATATYPE_SAFEGUARD_POINTER( user_memory, remaining, pConv->pBaseBuf,
                                             pData, pConv->count );
                 DO_DEBUG( opal_output( 0, "4. unpack dest %p src %p length %lu\n",
                                        user_memory, packed_buffer, (unsigned long)remaining ); );
                 MEMCPY_CSUM( user_memory, packed_buffer, remaining, pConv );
                 user_memory += remaining;
+                stack[1].count -= remaining;
             }
         }
         pConv->bConverted += bConverted;
@@ -396,7 +411,7 @@ opal_generic_simple_unpack_function( opal_convertor_t* pConvertor,
         return 1;
     }
     /* Save the global position for the next round */
-    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_UINT1, count_desc,
+    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, pElem->elem.common.type, count_desc,
                 conv_ptr - pConvertor->pBaseBuf );
     DO_DEBUG( opal_output( 0, "unpack save stack stack_pos %d pos_desc %d count_desc %d disp %ld\n",
                            pConvertor->stack_pos, pStack->index, (int)pStack->count, (long)pStack->disp ); );
@@ -466,7 +481,7 @@ opal_unpack_general_function( opal_convertor_t* pConvertor,
             while( pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA ) {
                 /* now here we have a basic datatype */
                 type = description[pos_desc].elem.common.type;
-                OPAL_DATATYPE_SAFEGUARD_POINTER( conv_ptr, pData->size, pConvertor->pBaseBuf,
+                OPAL_DATATYPE_SAFEGUARD_POINTER( conv_ptr + pElem->elem.disp, pData->size, pConvertor->pBaseBuf,
                                                  pData, pConvertor->count );
                 DO_DEBUG( opal_output( 0, "unpack (%p, %ld) -> (%p:%ld, %d, %ld) type %s\n",
                                        iov_ptr, iov_len_local,
@@ -560,7 +575,7 @@ opal_unpack_general_function( opal_convertor_t* pConvertor,
         return 1;
     }
     /* Save the global position for the next round */
-    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_UINT1, count_desc,
+    PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, pElem->elem.common.type, count_desc,
                 conv_ptr - pConvertor->pBaseBuf );
     DO_DEBUG( opal_output( 0, "unpack save stack stack_pos %d pos_desc %d count_desc %d disp %ld\n",
                            pConvertor->stack_pos, pStack->index, (int)pStack->count, (long)pStack->disp ); );

--- a/opal/datatype/opal_datatype_unpack.h
+++ b/opal/datatype/opal_datatype_unpack.h
@@ -17,11 +17,6 @@
 
 #include "opal_config.h"
 
-#include <stddef.h>
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
-
 #if !defined(CHECKSUM) && OPAL_CUDA_SUPPORT
 /* Make use of existing macro to do CUDA style memcpy */
 #undef MEMCPY_CSUM
@@ -29,19 +24,17 @@
     CONVERTOR->cbmemcpy( (DST), (SRC), (BLENGTH), (CONVERTOR) )
 #endif
 
-#include "opal/datatype/opal_convertor.h"
-
-
-static inline void unpack_predefined_data( opal_convertor_t* CONVERTOR, /* the convertor */
-                                           dt_elem_desc_t* ELEM,         /* the element description */
-                                           uint32_t* COUNT,              /* the number of elements */
-                                           unsigned char** SOURCE,       /* the source pointer */
-                                           unsigned char** DESTINATION,  /* the destination pointer */
-                                           size_t* SPACE )               /* the space in the destination buffer */
+static inline void
+unpack_predefined_data( opal_convertor_t* CONVERTOR,  /* the convertor */
+                        const dt_elem_desc_t* ELEM,   /* the element description */
+                        uint32_t* COUNT,              /* the number of elements */
+                        unsigned char** SOURCE,       /* the source pointer */
+                        unsigned char** DESTINATION,  /* the destination pointer */
+                        size_t* SPACE )               /* the space in the destination buffer */
 {
     uint32_t _copy_count = *(COUNT);
     size_t _copy_blength;
-    ddt_elem_desc_t* _elem = &((ELEM)->elem);
+    const ddt_elem_desc_t* _elem = &((ELEM)->elem);
     unsigned char* _destination = (*DESTINATION) + _elem->disp;
 
     _copy_blength = opal_datatype_basicDatatypes[_elem->common.type]->size;
@@ -79,14 +72,14 @@ static inline void unpack_predefined_data( opal_convertor_t* CONVERTOR, /* the c
 }
 
 static inline void unpack_contiguous_loop( opal_convertor_t* CONVERTOR,
-                                           dt_elem_desc_t* ELEM,
+                                           const dt_elem_desc_t* ELEM,
                                            uint32_t* COUNT,
                                            unsigned char** SOURCE,
                                            unsigned char** DESTINATION,
                                            size_t* SPACE )
 {
-    ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
-    ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
+    const ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
+    const ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
     unsigned char* _destination = (*DESTINATION) + _end_loop->first_elem_disp;
     uint32_t _copy_loops = *(COUNT);
     uint32_t _i;


### PR DESCRIPTION
In addition to fixing the darray issue I updated the datatype engine and convertor of the v1.10 to be in sync with the current trunk. No interface modification, so we keep the ABI.
