### PR TITLE
Initialize datatypes in MPI_Get_accumulate and MPI_Rget_accumulate

### DIFF
--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -475,6 +475,11 @@ ompi_osc_portals4_rget_accumulate(const void *origin_addr,
                 OMPI_OSC_PORTALS4_REQUEST_RETURN(request);
                 return ret;
             }
+	    ret = ompi_osc_portals4_get_dt(origin_dt, &ptl_dt);
+	    if (OMPI_SUCCESS != ret) {
+		OMPI_OSC_PORTALS4_REQUEST_RETURN(request);
+		return ret;
+	    }
             length *= origin_count;
 
             result_md_offset = (ptl_size_t) result_addr;
@@ -837,6 +842,10 @@ ompi_osc_portals4_get_accumulate(const void *origin_addr,
             if (OMPI_SUCCESS != ret) {
                 return ret;
             }
+	    ret = ompi_osc_portals4_get_dt(origin_dt, &ptl_dt);
+	    if (OMPI_SUCCESS != ret) {
+		return ret;
+	    }
             length *= origin_count;
 
             result_md_offset = (ptl_size_t) result_addr;


### PR DESCRIPTION
Datatypes should be initialized during MPI_Get_accumulate et MPI_Rget_accumulate operations
