### PR TITLE
oshmem: Add man.1 pages for oshmem tools

### DIFF
--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -13,10 +13,12 @@
 .SH NAME
 .
 orterun, mpirun, mpiexec \- Execute serial and parallel jobs in Open MPI.
+oshrun, shmemrun \- Execute serial and parallel jobs in Open SHMEM.
 
 .B Note:
 \fImpirun\fP, \fImpiexec\fP, and \fIorterun\fP are all synonyms for each
-other.  Using any of the names will produce the same behavior.
+other as well as \fIoshrun\fP, \fIshmemrun\fP in case Open SHMEM is installed.
+Using any of the names will produce the same behavior.
 .
 .\" **************************
 .\"    Synopsis Section

--- a/oshmem/tools/wrappers/Makefile.am
+++ b/oshmem/tools/wrappers/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright (c) 2013      Mellanox Technologies, Inc.
+# Copyright (c) 2013-2015 Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
@@ -10,7 +10,13 @@
 #
 # $HEADER$
 
+include $(top_srcdir)/Makefile.man-page-rules
+
+man_pages = oshcc.1 shmemcc.1 oshfort.1 shmemfort.1 oshrun.1 shmemrun.1
+
 if PROJECT_OSHMEM
+man_MANS = $(man_pages)
+
 nodist_ompidata_DATA =  \
 	shmemcc-wrapper-data.txt \
 	shmemfort-wrapper-data.txt
@@ -40,5 +46,41 @@ uninstall-local:
 	$(DESTDIR)$(pkgdatadir)/oshcc-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/shmemfort-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/oshfort-wrapper-data.txt
+
+########################################################
+#
+# Man page generation / handling
+#
+########################################################
+distclean-local:
+	rm -f $(man_pages)
+
+$(top_builddir)/opal/tools/wrappers/generic_wrapper.1:
+	(cd $(top_builddir)/opal/tools/wrappers && $(MAKE) $(AM_MAKEFLAGS) generic_wrapper.1)
+
+oshcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshcc.1
+	sed -e 's/#COMMAND#/oshcc/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshcc.1
+
+shmemcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemcc.1
+	sed -e 's/#COMMAND#/shmemcc/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemcc.1
+
+oshfort.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshfort.1
+	sed -e 's/#COMMAND#/oshfort/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/Fortran/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshfort.1
+
+shmemfort.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemfort.1
+	sed -e 's/#COMMAND#/shmemfort/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/Fortran/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemfort.1
+
+$(top_builddir)/orte/tools/orterun/orterun.1:
+	(cd $(top_builddir)/orte/tools/orterun && $(MAKE) $(AM_MAKEFLAGS) orterun.1)
+
+oshrun.1: $(top_builddir)/orte/tools/orterun/orterun.1
+	cp -f $(top_builddir)/orte/tools/orterun/orterun.1 oshrun.1
+
+shmemrun.1: $(top_builddir)/orte/tools/orterun/orterun.1
+	cp -f $(top_builddir)/orte/tools/orterun/orterun.1 shmemrun.1
 
 endif # PROJECT_OSHMEM


### PR DESCRIPTION
This changes add man pages for oshrun, oshcc and oshfort as well as
depricated shmemrun, shmemcc and shmemfort.

see master PR: https://github.com/open-mpi/ompi/pull/976

:bot:assign: @jsquyres  
:bot:label:enhancement
:bot:milestone:v1.10.0
