### PR TITLE
ft_removal: remove cr calls in 'c' interfaces

### DIFF
--- a/ompi/mpi/c/abort.c
+++ b/ompi/mpi/c/abort.c
@@ -43,8 +43,6 @@ int MPI_Abort(MPI_Comm comm, int errorcode)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_ABORT_LIBRARY();
-
     /* Don't even bother checking comm and errorcode values for
        errors */
 

--- a/ompi/mpi/c/accumulate.c
+++ b/ompi/mpi/c/accumulate.c
@@ -126,8 +126,6 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origi
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_win->w_osc_module->osc_accumulate(origin_addr,
                                                 origin_count,
                                                 origin_datatype,

--- a/ompi/mpi/c/add_error_class.c
+++ b/ompi/mpi/c/add_error_class.c
@@ -42,8 +42,6 @@ int MPI_Add_error_class(int *errorclass)
     int err_class;
     int rc;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/add_error_code.c
+++ b/ompi/mpi/c/add_error_code.c
@@ -42,8 +42,6 @@ int MPI_Add_error_code(int errorclass, int *errorcode)
     int code;
     int rc;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/add_error_string.c
+++ b/ompi/mpi/c/add_error_string.c
@@ -41,8 +41,6 @@ int MPI_Add_error_string(int errorcode, const char *string)
 {
     int rc;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/address.c
+++ b/ompi/mpi/c/address.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Address";
 int MPI_Address(void *location, MPI_Aint *address)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if( MPI_PARAM_CHECK ) {
       OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
       if (NULL == location || NULL == address) {

--- a/ompi/mpi/c/allgather.c
+++ b/ompi/mpi/c/allgather.c
@@ -115,8 +115,6 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 	}
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     err = comm->c_coll.coll_allgather(sendbuf, sendcount, sendtype,

--- a/ompi/mpi/c/allgatherv.c
+++ b/ompi/mpi/c/allgatherv.c
@@ -137,8 +137,6 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
        something */
 
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_allgatherv(sendbuf, sendcount, sendtype,
                                        recvbuf, (int *) recvcounts,

--- a/ompi/mpi/c/alloc_mem.c
+++ b/ompi/mpi/c/alloc_mem.c
@@ -66,10 +66,7 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     *((void **) baseptr) = mca_mpool_base_alloc((size_t) size, (struct opal_info_t*)info);
-    OPAL_CR_EXIT_LIBRARY();
     if (NULL == *((void **) baseptr)) {
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
                                       FUNC_NAME);

--- a/ompi/mpi/c/allreduce.c
+++ b/ompi/mpi/c/allreduce.c
@@ -102,8 +102,6 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/alltoall.c
+++ b/ompi/mpi/c/alltoall.c
@@ -104,8 +104,6 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_alltoall(sendbuf, sendcount, sendtype,
                                      recvbuf, recvcount, recvtype,

--- a/ompi/mpi/c/alltoallv.c
+++ b/ompi/mpi/c/alltoallv.c
@@ -120,8 +120,6 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
                                       recvbuf, recvcounts, rdispls, recvtype,

--- a/ompi/mpi/c/alltoallw.c
+++ b/ompi/mpi/c/alltoallw.c
@@ -115,8 +115,6 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_alltoallw(sendbuf, sendcounts, sdispls, (ompi_datatype_t **) sendtypes,
                                       recvbuf, recvcounts, rdispls, (ompi_datatype_t **) recvtypes,

--- a/ompi/mpi/c/attr_delete.c
+++ b/ompi/mpi/c/attr_delete.c
@@ -54,7 +54,6 @@ int MPI_Attr_delete(MPI_Comm comm, int keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_delete(COMM_ATTR, comm, comm->c_keyhash, keyval,
                            false);

--- a/ompi/mpi/c/attr_get.c
+++ b/ompi/mpi/c/attr_get.c
@@ -52,7 +52,6 @@ int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* This stuff is very confusing.  Be sure to see
        src/attribute/attribute.c for a lengthy comment explaining Open

--- a/ompi/mpi/c/attr_put.c
+++ b/ompi/mpi/c/attr_put.c
@@ -53,7 +53,6 @@ int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_set_c(COMM_ATTR, comm, &comm->c_keyhash,
                           keyval, attribute_val, false);

--- a/ompi/mpi/c/barrier.c
+++ b/ompi/mpi/c/barrier.c
@@ -52,8 +52,6 @@ int MPI_Barrier(MPI_Comm comm)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   /* Intracommunicators: Only invoke the back-end coll module barrier
      function if there's more than one process in the communicator */
 

--- a/ompi/mpi/c/bcast.c
+++ b/ompi/mpi/c/bcast.c
@@ -103,8 +103,6 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     err = comm->c_coll.coll_bcast(buffer, count, datatype, root, comm,

--- a/ompi/mpi/c/bindings.h
+++ b/ompi/mpi/c/bindings.h
@@ -24,11 +24,6 @@
 #include "mpi.h"
 #include "ompi/datatype/ompi_datatype.h"
 
-/* This library needs to be here so that we can define
- * the OPAL_CR_* checks
- */
-#include "opal/runtime/opal_cr.h"
-
 BEGIN_C_DECLS
 
 /* If compiling in the profile directory, then we don't have weak

--- a/ompi/mpi/c/bsend.c
+++ b/ompi/mpi/c/bsend.c
@@ -77,7 +77,6 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     rc = MCA_PML_CALL(send(buf, count, type, dest, tag, MCA_PML_BASE_SEND_BUFFERED, comm));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/bsend_init.c
+++ b/ompi/mpi/c/bsend_init.c
@@ -87,8 +87,6 @@ int MPI_Bsend_init(const void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Here, we just initialize the request -- memchecker should set the buffer in MPI_Start.
      */

--- a/ompi/mpi/c/buffer_attach.c
+++ b/ompi/mpi/c/buffer_attach.c
@@ -47,10 +47,8 @@ int MPI_Buffer_attach(void *buffer, int size)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
   ret = mca_pml_base_bsend_attach(buffer, size);
 
-  OPAL_CR_EXIT_LIBRARY();
   return ret;
 }
 

--- a/ompi/mpi/c/buffer_detach.c
+++ b/ompi/mpi/c/buffer_detach.c
@@ -47,9 +47,7 @@ int MPI_Buffer_detach(void *buffer, int *size)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
   ret = mca_pml_base_bsend_detach(buffer, size);
 
-  OPAL_CR_EXIT_LIBRARY();
   return ret;
 }

--- a/ompi/mpi/c/cancel.c
+++ b/ompi/mpi/c/cancel.c
@@ -60,7 +60,6 @@ int MPI_Cancel(MPI_Request *request)
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     rc = ompi_request_cancel(*request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_coords.c
+++ b/ompi/mpi/c/cart_coords.c
@@ -72,10 +72,8 @@ int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[])
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                       FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cart_coords(comm, rank, maxdims, coords);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_create.c
+++ b/ompi/mpi/c/cart_create.c
@@ -105,8 +105,6 @@ int MPI_Cart_create(MPI_Comm old_comm, int ndims, const int dims[],
     err = topo->topo.cart.cart_create(topo, old_comm,
                                       ndims, dims, periods,
                                       (0 == reorder) ? false : true, comm_cart);
-    OPAL_CR_EXIT_LIBRARY();
-
     if (MPI_SUCCESS != err) {
         OBJ_RELEASE(topo);
         return OMPI_ERRHANDLER_INVOKE(old_comm, err, FUNC_NAME);

--- a/ompi/mpi/c/cart_get.c
+++ b/ompi/mpi/c/cart_get.c
@@ -66,10 +66,8 @@ int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[],
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                       FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cart_get(comm, maxdims, dims, periods, coords);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_map.c
+++ b/ompi/mpi/c/cart_map.c
@@ -69,8 +69,6 @@ int MPI_Cart_map(MPI_Comm comm, int ndims, const int dims[],
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     if(!OMPI_COMM_IS_CART(comm)) {
         /* In case the communicator has no topo-module attached to
            it, we just return the "default" value suggested by MPI:
@@ -81,6 +79,5 @@ int MPI_Cart_map(MPI_Comm comm, int ndims, const int dims[],
                                                periods, newrank);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_rank.c
+++ b/ompi/mpi/c/cart_rank.c
@@ -98,10 +98,8 @@ int MPI_Cart_rank(MPI_Comm comm, const int coords[], int *rank)
                                            FUNC_NAME);
         }
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cart_rank(comm, coords, rank);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_shift.c
+++ b/ompi/mpi/c/cart_shift.c
@@ -72,11 +72,9 @@ int MPI_Cart_shift(MPI_Comm comm, int direction, int disp,
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                       FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     /* call the function */
     err = comm->c_topo->topo.cart.cart_shift(comm, direction, disp, rank_source, rank_dest);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cart_sub.c
+++ b/ompi/mpi/c/cart_sub.c
@@ -73,10 +73,8 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *new_comm)
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                       FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cart_sub(comm, remain_dims, new_comm);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/cartdim_get.c
+++ b/ompi/mpi/c/cartdim_get.c
@@ -67,10 +67,8 @@ int MPI_Cartdim_get(MPI_Comm comm, int *ndims)
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                        FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cartdim_get(comm, ndims);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/close_port.c
+++ b/ompi/mpi/c/close_port.c
@@ -44,8 +44,6 @@ int MPI_Close_port(const char *port_name)
 {
     int ret;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_accept.c
+++ b/ompi/mpi/c/comm_accept.c
@@ -93,7 +93,6 @@ int MPI_Comm_accept(const char *port_name, MPI_Info info, int root,
      * if ( rank == root && MPI_INFO_NULL != info ) {
      * }
      */
-    OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {
 	rc = ompi_dpm_connect_accept (comm, root, port_name, send_first,

--- a/ompi/mpi/c/comm_c2f.c
+++ b/ompi/mpi/c/comm_c2f.c
@@ -43,8 +43,6 @@ MPI_Fint MPI_Comm_c2f(MPI_Comm comm)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_call_errhandler.c
+++ b/ompi/mpi/c/comm_call_errhandler.c
@@ -42,8 +42,6 @@ int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/comm_compare.c
+++ b/ompi/mpi/c/comm_compare.c
@@ -59,7 +59,6 @@ int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result) {
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_compare ( (ompi_communicator_t*)comm1,
                              (ompi_communicator_t*)comm2,

--- a/ompi/mpi/c/comm_connect.c
+++ b/ompi/mpi/c/comm_connect.c
@@ -95,7 +95,6 @@ int MPI_Comm_connect(const char *port_name, MPI_Info info, int root,
      * }
      */
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {
         rc = ompi_dpm_connect_accept (comm, root, port_name, send_first,

--- a/ompi/mpi/c/comm_create.c
+++ b/ompi/mpi/c/comm_create.c
@@ -60,7 +60,6 @@ int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm) {
                                           FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_create ( (ompi_communicator_t*)comm, (ompi_group_t*)group,
                            (ompi_communicator_t**)newcomm );

--- a/ompi/mpi/c/comm_create_errhandler.c
+++ b/ompi/mpi/c/comm_create_errhandler.c
@@ -53,7 +53,6 @@ int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function *function,
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
 
   /* Create and cache the errhandler.  Sets a refcount of 1. */
 

--- a/ompi/mpi/c/comm_create_group.c
+++ b/ompi/mpi/c/comm_create_group.c
@@ -72,7 +72,6 @@ int MPI_Comm_create_group (MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *ne
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_create_group ((ompi_communicator_t *) comm, (ompi_group_t *) group,
                                  tag, (ompi_communicator_t **) newcomm);

--- a/ompi/mpi/c/comm_create_keyval.c
+++ b/ompi/mpi/c/comm_create_keyval.c
@@ -53,7 +53,6 @@ int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*)comm_copy_attr_fn;
     del_fn.attr_communicator_delete_fn = comm_delete_attr_fn;

--- a/ompi/mpi/c/comm_delete_attr.c
+++ b/ompi/mpi/c/comm_delete_attr.c
@@ -53,7 +53,6 @@ int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_delete(COMM_ATTR, comm, comm->c_keyhash, comm_keyval,
                            false);

--- a/ompi/mpi/c/comm_disconnect.c
+++ b/ompi/mpi/c/comm_disconnect.c
@@ -60,7 +60,6 @@ int MPI_Comm_disconnect(MPI_Comm *comm)
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if ( OMPI_COMM_IS_DYNAMIC(*comm)) {
         if (OMPI_SUCCESS != ompi_dpm_disconnect (*comm)) {
@@ -73,6 +72,5 @@ int MPI_Comm_disconnect(MPI_Comm *comm)
 
     ompi_comm_free(comm);
 
-    OPAL_CR_EXIT_LIBRARY();
     return ret;
 }

--- a/ompi/mpi/c/comm_dup.c
+++ b/ompi/mpi/c/comm_dup.c
@@ -57,7 +57,6 @@ int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
                                           FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_dup ( comm, newcomm );
     OMPI_ERRHANDLER_RETURN ( rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/comm_dup_with_info.c
+++ b/ompi/mpi/c/comm_dup_with_info.c
@@ -64,7 +64,6 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm)
                                           FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_dup_with_info (comm, info, newcomm);
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/comm_f2c.c
+++ b/ompi/mpi/c/comm_f2c.c
@@ -41,8 +41,6 @@ MPI_Comm MPI_Comm_f2c(MPI_Fint comm)
 {
     int o_index= OMPI_FINT_2_INT(comm);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/comm_free.c
+++ b/ompi/mpi/c/comm_free.c
@@ -56,11 +56,9 @@ int MPI_Comm_free(MPI_Comm *comm)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_comm_free ( comm );
     OMPI_ERRHANDLER_CHECK(ret, *comm, ret, FUNC_NAME);
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/comm_free_keyval.c
+++ b/ompi/mpi/c/comm_free_keyval.c
@@ -49,7 +49,6 @@ int MPI_Comm_free_keyval(int *comm_keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_free_keyval(COMM_ATTR, comm_keyval, 0);
 

--- a/ompi/mpi/c/comm_get_attr.c
+++ b/ompi/mpi/c/comm_get_attr.c
@@ -58,7 +58,6 @@ int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* This stuff is very confusing.  Be sure to see
        src/attribute/attribute.c for a lengthy comment explaining Open

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -46,8 +46,6 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/comm_get_info.c
+++ b/ompi/mpi/c/comm_get_info.c
@@ -31,8 +31,6 @@ static const char FUNC_NAME[] = "MPI_Comm_get_info";
 
 int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == info_used) {

--- a/ompi/mpi/c/comm_get_name.c
+++ b/ompi/mpi/c/comm_get_name.c
@@ -46,8 +46,6 @@ int MPI_Comm_get_name(MPI_Comm comm, char *name, int *length)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_get_parent.c
+++ b/ompi/mpi/c/comm_get_parent.c
@@ -37,8 +37,6 @@ static const char FUNC_NAME[] = "MPI_Comm_get_parent";
 int MPI_Comm_get_parent(MPI_Comm *parent)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_group.c
+++ b/ompi/mpi/c/comm_group.c
@@ -57,7 +57,6 @@ int MPI_Comm_group(MPI_Comm comm, MPI_Group *group) {
                                           FUNC_NAME);
     } /* end if ( MPI_PARAM_CHECK) */
 
-    OPAL_CR_ENTER_LIBRARY();
 
    rc = ompi_comm_group ( (ompi_communicator_t*)comm, (ompi_group_t**)group );
    OMPI_ERRHANDLER_RETURN ( rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/comm_idup.c
+++ b/ompi/mpi/c/comm_idup.c
@@ -60,7 +60,6 @@ int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request)
                                           FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_idup (comm, newcomm, request);
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/comm_join.c
+++ b/ompi/mpi/c/comm_join.c
@@ -73,7 +73,6 @@ int MPI_Comm_join(int fd, MPI_Comm *intercomm)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* send my process name */
     tmp_name = *OMPI_PROC_MY_NAME;
@@ -91,7 +90,6 @@ int MPI_Comm_join(int fd, MPI_Comm *intercomm)
         } else if (OMPI_PROC_MY_NAME->vpid == rname.vpid) {
             /* joining to myself is not allowed */
             *intercomm = MPI_COMM_NULL;
-            OPAL_CR_EXIT_LIBRARY();
             return MPI_ERR_INTERN;
         } else {
             send_first = false;
@@ -112,7 +110,6 @@ int MPI_Comm_join(int fd, MPI_Comm *intercomm)
     if (send_first) {
         /* open a port */
         if (OMPI_SUCCESS != (rc = ompi_dpm_open_port(port_name))) {
-            OPAL_CR_EXIT_LIBRARY();
             return rc;
         }
         llen   = (uint32_t)(strlen(port_name)+1);

--- a/ompi/mpi/c/comm_rank.c
+++ b/ompi/mpi/c/comm_rank.c
@@ -42,8 +42,6 @@ int MPI_Comm_rank(MPI_Comm comm, int *rank)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_remote_group.c
+++ b/ompi/mpi/c/comm_remote_group.c
@@ -44,8 +44,6 @@ int MPI_Comm_remote_group(MPI_Comm comm, MPI_Group *group)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (ompi_comm_invalid (comm)) {

--- a/ompi/mpi/c/comm_remote_size.c
+++ b/ompi/mpi/c/comm_remote_size.c
@@ -42,8 +42,6 @@ int MPI_Comm_remote_size(MPI_Comm comm, int *size) {
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_set_attr.c
+++ b/ompi/mpi/c/comm_set_attr.c
@@ -53,7 +53,6 @@ int MPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_set_c(COMM_ATTR, comm, &comm->c_keyhash,
                           comm_keyval, attribute_val, false);

--- a/ompi/mpi/c/comm_set_errhandler.c
+++ b/ompi/mpi/c/comm_set_errhandler.c
@@ -44,8 +44,6 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* Error checking */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/comm_set_info.c
+++ b/ompi/mpi/c/comm_set_info.c
@@ -31,8 +31,6 @@ static const char FUNC_NAME[] = "MPI_Comm_set_info";
 
 int MPI_Comm_set_info(MPI_Comm comm, MPI_Info info)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == info || MPI_INFO_NULL == info ||

--- a/ompi/mpi/c/comm_set_name.c
+++ b/ompi/mpi/c/comm_set_name.c
@@ -64,7 +64,6 @@ int MPI_Comm_set_name(MPI_Comm comm, const char *name)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_set_name (comm, name );
     /* -- Tracing information for new communicator name -- */

--- a/ompi/mpi/c/comm_size.c
+++ b/ompi/mpi/c/comm_size.c
@@ -44,8 +44,6 @@ int MPI_Comm_size(MPI_Comm comm, int *size)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/comm_spawn.c
+++ b/ompi/mpi/c/comm_spawn.c
@@ -104,7 +104,6 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
         ompi_info_get_bool(info, "ompi_non_mpi", &non_mpi, &flag);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {
         if (!non_mpi) {
@@ -131,7 +130,6 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
     }
 
 error:
-    OPAL_CR_EXIT_LIBRARY();
 
     /* close the port */
     if (rank == root && !non_mpi) {

--- a/ompi/mpi/c/comm_spawn_multiple.c
+++ b/ompi/mpi/c/comm_spawn_multiple.c
@@ -144,7 +144,6 @@ int MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_o
     /* initialize the port name to avoid problems */
     memset(port_name, 0, MPI_MAX_PORT_NAME);
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {
         if (!non_mpi) {
@@ -172,7 +171,6 @@ int MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_o
     }
 
 error:
-    OPAL_CR_EXIT_LIBRARY();
 
     /* close the port */
     if (rank == root && !non_mpi) {

--- a/ompi/mpi/c/comm_split.c
+++ b/ompi/mpi/c/comm_split.c
@@ -63,7 +63,6 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm) {
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_split ( (ompi_communicator_t*)comm, color, key,
                           (ompi_communicator_t**)newcomm, false);

--- a/ompi/mpi/c/comm_split_type.c
+++ b/ompi/mpi/c/comm_split_type.c
@@ -85,7 +85,6 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if( (MPI_COMM_SELF == comm) && (MPI_UNDEFINED == split_type) ) {
         *newcomm = MPI_COMM_NULL;

--- a/ompi/mpi/c/comm_test_inter.c
+++ b/ompi/mpi/c/comm_test_inter.c
@@ -42,8 +42,6 @@ int MPI_Comm_test_inter(MPI_Comm comm, int *flag) {
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/compare_and_swap.c
+++ b/ompi/mpi/c/compare_and_swap.c
@@ -66,7 +66,6 @@ int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr, void
 
     if (MPI_PROC_NULL == target_rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = win->w_osc_module->osc_compare_and_swap(origin_addr, compare_addr, result_addr,
                                                  datatype, target_rank, target_disp, win);

--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -59,8 +59,6 @@ int MPI_Dims_create(int nnodes, int ndims, int dims[])
     int *p;
     int err;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/errhandler_c2f.c
+++ b/ompi/mpi/c/errhandler_c2f.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Errhandler_c2f";
 MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/errhandler_f2c.c
+++ b/ompi/mpi/c/errhandler_f2c.c
@@ -40,8 +40,6 @@ MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler_f)
 {
     int eh_index = OMPI_FINT_2_INT(errhandler_f);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* Error checking */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/errhandler_free.c
+++ b/ompi/mpi/c/errhandler_free.c
@@ -37,8 +37,6 @@ static const char FUNC_NAME[] = "MPI_Errhandler_free";
 int MPI_Errhandler_free(MPI_Errhandler *errhandler)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/errhandler_get.c
+++ b/ompi/mpi/c/errhandler_get.c
@@ -41,8 +41,6 @@ int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
   if (MPI_PARAM_CHECK) {
     OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
   }

--- a/ompi/mpi/c/errhandler_set.c
+++ b/ompi/mpi/c/errhandler_set.c
@@ -41,8 +41,6 @@ int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
   if (MPI_PARAM_CHECK) {
     OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
   }

--- a/ompi/mpi/c/error_class.c
+++ b/ompi/mpi/c/error_class.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Error_class";
 int MPI_Error_class(int errorcode, int *errorclass)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/error_string.c
+++ b/ompi/mpi/c/error_string.c
@@ -40,8 +40,6 @@ int MPI_Error_string(int errorcode, char *string, int *resultlen)
 {
     char *tmpstring;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/exscan.c
+++ b/ompi/mpi/c/exscan.c
@@ -84,8 +84,6 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/fetch_and_op.c
+++ b/ompi/mpi/c/fetch_and_op.c
@@ -66,8 +66,6 @@ int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype da
 
     if (MPI_PROC_NULL == target_rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_fetch_and_op(origin_addr, result_addr, datatype,
                                              target_rank, target_disp, op, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);

--- a/ompi/mpi/c/file_c2f.c
+++ b/ompi/mpi/c/file_c2f.c
@@ -39,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_File_c2f";
 MPI_Fint MPI_File_c2f(MPI_File file)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/file_call_errhandler.c
+++ b/ompi/mpi/c/file_call_errhandler.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_File_call_errhandler";
 int MPI_File_call_errhandler(MPI_File fh, int errorcode)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/file_close.c
+++ b/ompi/mpi/c/file_close.c
@@ -51,8 +51,6 @@ int MPI_File_close(MPI_File *fh)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Release the MPI_File; the destructor releases the component,
        zeroes out fiels, etc. */
 

--- a/ompi/mpi/c/file_create_errhandler.c
+++ b/ompi/mpi/c/file_create_errhandler.c
@@ -51,8 +51,6 @@ int MPI_File_create_errhandler(MPI_File_errhandler_function *function,
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   /* Create and cache the errhandler.  Sets a refcount of 1. */
 
   *errhandler =

--- a/ompi/mpi/c/file_delete.c
+++ b/ompi/mpi/c/file_delete.c
@@ -74,8 +74,6 @@ int MPI_File_delete(const char *filename, MPI_Info info)
         return OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Since there is no MPI_File handle associated with this
        function, the MCA has to do a selection and perform the
        action */

--- a/ompi/mpi/c/file_f2c.c
+++ b/ompi/mpi/c/file_f2c.c
@@ -41,8 +41,6 @@ MPI_File MPI_File_f2c(MPI_Fint file_f)
 {
     int file_index = OMPI_FINT_2_INT(file_f);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/file_get_amode.c
+++ b/ompi/mpi/c/file_get_amode.c
@@ -51,8 +51,6 @@ int MPI_File_get_amode(MPI_File fh, int *amode)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_atomicity.c
+++ b/ompi/mpi/c/file_get_atomicity.c
@@ -51,8 +51,6 @@ int MPI_File_get_atomicity(MPI_File fh, int *flag)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_byte_offset.c
+++ b/ompi/mpi/c/file_get_byte_offset.c
@@ -52,8 +52,6 @@ int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_errhandler.c
+++ b/ompi/mpi/c/file_get_errhandler.c
@@ -40,8 +40,6 @@ int MPI_File_get_errhandler( MPI_File file, MPI_Errhandler *errhandler)
 {
     MPI_Errhandler tmp;
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/file_get_group.c
+++ b/ompi/mpi/c/file_get_group.c
@@ -51,8 +51,6 @@ int MPI_File_get_group(MPI_File fh, MPI_Group *group)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Does not need to invoke a back-end io function */
 
     rc = ompi_comm_group (fh->f_comm, group);

--- a/ompi/mpi/c/file_get_info.c
+++ b/ompi/mpi/c/file_get_info.c
@@ -51,8 +51,6 @@ int MPI_File_get_info(MPI_File fh, MPI_Info *info_used)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_position.c
+++ b/ompi/mpi/c/file_get_position.c
@@ -51,8 +51,6 @@ int MPI_File_get_position(MPI_File fh, MPI_Offset *offset)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_position_shared.c
+++ b/ompi/mpi/c/file_get_position_shared.c
@@ -51,8 +51,6 @@ int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_size.c
+++ b/ompi/mpi/c/file_get_size.c
@@ -51,8 +51,6 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_type_extent.c
+++ b/ompi/mpi/c/file_get_type_extent.c
@@ -57,8 +57,6 @@ int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_get_view.c
+++ b/ompi/mpi/c/file_get_view.c
@@ -55,8 +55,6 @@ int MPI_File_get_view(MPI_File fh, MPI_Offset *disp,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_iread.c
+++ b/ompi/mpi/c/file_iread.c
@@ -64,8 +64,6 @@ int MPI_File_iread(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iread_all.c
+++ b/ompi/mpi/c/file_iread_all.c
@@ -65,8 +65,6 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iread_at.c
+++ b/ompi/mpi/c/file_iread_at.c
@@ -64,8 +64,6 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iread_at_all.c
+++ b/ompi/mpi/c/file_iread_at_all.c
@@ -65,8 +65,6 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iread_shared.c
+++ b/ompi/mpi/c/file_iread_shared.c
@@ -64,8 +64,6 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iwrite.c
+++ b/ompi/mpi/c/file_iwrite.c
@@ -70,8 +70,6 @@ int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iwrite_all.c
+++ b/ompi/mpi/c/file_iwrite_all.c
@@ -71,8 +71,6 @@ int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iwrite_at.c
+++ b/ompi/mpi/c/file_iwrite_at.c
@@ -71,8 +71,6 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iwrite_at_all.c
+++ b/ompi/mpi/c/file_iwrite_at_all.c
@@ -72,8 +72,6 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_iwrite_shared.c
+++ b/ompi/mpi/c/file_iwrite_shared.c
@@ -69,8 +69,6 @@ int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:

--- a/ompi/mpi/c/file_open.c
+++ b/ompi/mpi/c/file_open.c
@@ -87,8 +87,6 @@ int MPI_File_open(MPI_Comm comm, const char *filename, int amode,
         return OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Create an empty MPI_File handle */
 
     *fh = MPI_FILE_NULL;

--- a/ompi/mpi/c/file_preallocate.c
+++ b/ompi/mpi/c/file_preallocate.c
@@ -49,8 +49,6 @@ int MPI_File_preallocate(MPI_File fh, MPI_Offset size)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read.c
+++ b/ompi/mpi/c/file_read.c
@@ -60,8 +60,6 @@ int MPI_File_read(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_all.c
+++ b/ompi/mpi/c/file_read_all.c
@@ -60,8 +60,6 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_all_begin.c
+++ b/ompi/mpi/c/file_read_all_begin.c
@@ -60,8 +60,6 @@ int MPI_File_read_all_begin(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_all_end.c
+++ b/ompi/mpi/c/file_read_all_end.c
@@ -49,7 +49,6 @@ int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* Call the back-end io component function */
 

--- a/ompi/mpi/c/file_read_at.c
+++ b/ompi/mpi/c/file_read_at.c
@@ -60,8 +60,6 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_at_all.c
+++ b/ompi/mpi/c/file_read_at_all.c
@@ -61,8 +61,6 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_at_all_begin.c
+++ b/ompi/mpi/c/file_read_at_all_begin.c
@@ -60,8 +60,6 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_at_all_end.c
+++ b/ompi/mpi/c/file_read_at_all_end.c
@@ -49,8 +49,6 @@ int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_ordered.c
+++ b/ompi/mpi/c/file_read_ordered.c
@@ -55,8 +55,6 @@ int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_ordered_begin.c
+++ b/ompi/mpi/c/file_read_ordered_begin.c
@@ -60,8 +60,6 @@ int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_ordered_end.c
+++ b/ompi/mpi/c/file_read_ordered_end.c
@@ -49,8 +49,6 @@ int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_read_shared.c
+++ b/ompi/mpi/c/file_read_shared.c
@@ -60,8 +60,6 @@ int MPI_File_read_shared(MPI_File fh, void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_seek.c
+++ b/ompi/mpi/c/file_seek.c
@@ -52,8 +52,6 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_seek_shared.c
+++ b/ompi/mpi/c/file_seek_shared.c
@@ -52,8 +52,6 @@ int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_set_atomicity.c
+++ b/ompi/mpi/c/file_set_atomicity.c
@@ -49,8 +49,6 @@ int MPI_File_set_atomicity(MPI_File fh, int flag)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_set_errhandler.c
+++ b/ompi/mpi/c/file_set_errhandler.c
@@ -39,8 +39,6 @@ int MPI_File_set_errhandler( MPI_File file, MPI_Errhandler errhandler)
 {
     MPI_Errhandler tmp;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* Error checking */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/file_set_info.c
+++ b/ompi/mpi/c/file_set_info.c
@@ -50,8 +50,6 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_set_size.c
+++ b/ompi/mpi/c/file_set_size.c
@@ -49,8 +49,6 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_set_view.c
+++ b/ompi/mpi/c/file_set_view.c
@@ -67,8 +67,6 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_sync.c
+++ b/ompi/mpi/c/file_sync.c
@@ -49,7 +49,6 @@ int MPI_File_sync(MPI_File fh)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* Call the back-end io component function */
 

--- a/ompi/mpi/c/file_write.c
+++ b/ompi/mpi/c/file_write.c
@@ -66,8 +66,6 @@ int MPI_File_write(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_all.c
+++ b/ompi/mpi/c/file_write_all.c
@@ -66,8 +66,6 @@ int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_all_begin.c
+++ b/ompi/mpi/c/file_write_all_begin.c
@@ -66,8 +66,6 @@ int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_all_end.c
+++ b/ompi/mpi/c/file_write_all_end.c
@@ -54,8 +54,6 @@ int MPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_at.c
+++ b/ompi/mpi/c/file_write_at.c
@@ -67,8 +67,6 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_at_all.c
+++ b/ompi/mpi/c/file_write_at_all.c
@@ -67,8 +67,6 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_at_all_begin.c
+++ b/ompi/mpi/c/file_write_at_all_begin.c
@@ -66,8 +66,6 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_at_all_end.c
+++ b/ompi/mpi/c/file_write_at_all_end.c
@@ -54,8 +54,6 @@ int MPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_ordered.c
+++ b/ompi/mpi/c/file_write_ordered.c
@@ -66,8 +66,6 @@ int MPI_File_write_ordered(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_ordered_begin.c
+++ b/ompi/mpi/c/file_write_ordered_begin.c
@@ -66,8 +66,6 @@ int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_ordered_end.c
+++ b/ompi/mpi/c/file_write_ordered_end.c
@@ -54,8 +54,6 @@ int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/file_write_shared.c
+++ b/ompi/mpi/c/file_write_shared.c
@@ -66,8 +66,6 @@ int MPI_File_write_shared(MPI_File fh, const void *buf, int count,
         OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
 
     switch (fh->f_io_version) {

--- a/ompi/mpi/c/finalize.c
+++ b/ompi/mpi/c/finalize.c
@@ -35,8 +35,6 @@ static const char FUNC_NAME[] = "MPI_Finalize";
 
 int MPI_Finalize(void)
 {
-    OPAL_CR_FINALIZE_LIBRARY();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/finalized.c
+++ b/ompi/mpi/c/finalized.c
@@ -38,8 +38,6 @@ int MPI_Finalized(int *flag)
 {
     MPI_Comm null = NULL;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         if (NULL == flag) {
 

--- a/ompi/mpi/c/free_mem.c
+++ b/ompi/mpi/c/free_mem.c
@@ -40,7 +40,6 @@ static const char FUNC_NAME[] = "MPI_Free_mem";
 
 int MPI_Free_mem(void *baseptr)
 {
-    OPAL_CR_ENTER_LIBRARY();
 
     /* Per these threads:
 
@@ -50,11 +49,9 @@ int MPI_Free_mem(void *baseptr)
        If you call MPI_ALLOC_MEM with a size of 0, you get NULL
        back.  So don't consider a NULL==baseptr an error. */
     if (NULL != baseptr && OMPI_SUCCESS != mca_mpool_base_free(baseptr)) {
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM, FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }
 

--- a/ompi/mpi/c/gather.c
+++ b/ompi/mpi/c/gather.c
@@ -176,8 +176,6 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_gather(sendbuf, sendcount, sendtype, recvbuf,
                                    recvcount, recvtype, root, comm,

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -190,8 +190,6 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcounts, displs,

--- a/ompi/mpi/c/get.c
+++ b/ompi/mpi/c/get.c
@@ -69,8 +69,6 @@ int MPI_Get(void *origin_addr, int origin_count,
 
     if (MPI_PROC_NULL == target_rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_get(origin_addr, origin_count, origin_datatype,
                                     target_rank, target_disp, target_count,
                                     target_datatype, win);

--- a/ompi/mpi/c/get_accumulate.c
+++ b/ompi/mpi/c/get_accumulate.c
@@ -133,8 +133,6 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype o
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_win->w_osc_module->osc_get_accumulate(origin_addr,
                                                     origin_count,
                                                     origin_datatype,

--- a/ompi/mpi/c/get_address.c
+++ b/ompi/mpi/c/get_address.c
@@ -39,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Get_address";
 int MPI_Get_address(const void *location, MPI_Aint *address)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if( MPI_PARAM_CHECK ) {
       OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
       if (NULL == location || NULL == address) {

--- a/ompi/mpi/c/get_count.c
+++ b/ompi/mpi/c/get_count.c
@@ -46,8 +46,6 @@ int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count)
     size_t size = 0, internal_count;
     int rc      = MPI_SUCCESS;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     MEMCHECKER(
                if (status != MPI_STATUSES_IGNORE) {
                    /*

--- a/ompi/mpi/c/get_elements.c
+++ b/ompi/mpi/c/get_elements.c
@@ -45,8 +45,6 @@ int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count
     size_t internal_count;
     int ret;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     MEMCHECKER(
                if (status != MPI_STATUSES_IGNORE) {
                    /*

--- a/ompi/mpi/c/get_elements_x.c
+++ b/ompi/mpi/c/get_elements_x.c
@@ -45,8 +45,6 @@ int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Coun
     size_t internal_count;
     int ret;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     MEMCHECKER(
                if (status != MPI_STATUSES_IGNORE) {
                    /*

--- a/ompi/mpi/c/get_library_version.c
+++ b/ompi/mpi/c/get_library_version.c
@@ -41,8 +41,6 @@ int MPI_Get_library_version(char *version, int *resultlen)
     MPI_Comm null = MPI_COMM_NULL;
     char *ptr, tmp[MPI_MAX_LIBRARY_VERSION_STRING];
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         /* Per MPI-3, this function can be invoked before
            MPI_INIT, so we don't invoke the normal

--- a/ompi/mpi/c/get_processor_name.c
+++ b/ompi/mpi/c/get_processor_name.c
@@ -41,8 +41,6 @@ static const char FUNC_NAME[] = "MPI_Get_processor_name";
 
 int MPI_Get_processor_name(char *name, int *resultlen)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if ( NULL == name  ) {

--- a/ompi/mpi/c/get_version.c
+++ b/ompi/mpi/c/get_version.c
@@ -38,8 +38,6 @@ int MPI_Get_version(int *version, int *subversion)
 {
     MPI_Comm null = NULL;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         /* Per MPI-2:3.1, this function can be invoked before
            MPI_INIT, so we don't invoke the normal

--- a/ompi/mpi/c/graph_create.c
+++ b/ompi/mpi/c/graph_create.c
@@ -88,7 +88,6 @@ int MPI_Graph_create(MPI_Comm old_comm, int nnodes, const int indx[],
                                        FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     /*
      * everything seems to be alright with the communicator, we can go
      * ahead and select a topology module for this purpose and create
@@ -105,8 +104,6 @@ int MPI_Graph_create(MPI_Comm old_comm, int nnodes, const int indx[],
     err = topo->topo.graph.graph_create(topo, old_comm,
                                         nnodes, indx, edges,
                                         (0 == reorder) ? false : true, comm_graph);
-    OPAL_CR_EXIT_LIBRARY();
-
     if (MPI_SUCCESS != err) {
         OBJ_RELEASE(topo);
         return OMPI_ERRHANDLER_INVOKE(old_comm, err, FUNC_NAME);

--- a/ompi/mpi/c/graph_get.c
+++ b/ompi/mpi/c/graph_get.c
@@ -68,11 +68,9 @@ int MPI_Graph_get(MPI_Comm comm, int maxindx, int maxedges,
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                        FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     /* call the function */
     err = comm->c_topo->topo.graph.graph_get(comm, maxindx, maxedges, indx, edges);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/graph_map.c
+++ b/ompi/mpi/c/graph_map.c
@@ -69,7 +69,6 @@ int MPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[]
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if(!OMPI_COMM_IS_GRAPH(comm)) {
         /* In case the communicator has no topo-module attached to
@@ -79,7 +78,6 @@ int MPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[]
     } else {
       err = comm->c_topo->topo.graph.graph_map(comm, nnodes, indx, edges, newrank);
     }
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/graph_neighbors.c
+++ b/ompi/mpi/c/graph_neighbors.c
@@ -73,11 +73,9 @@ int MPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors,
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                        FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     /* call the function */
     err = comm->c_topo->topo.graph.graph_neighbors(comm, rank, maxneighbors, neighbors);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/graph_neighbors_count.c
+++ b/ompi/mpi/c/graph_neighbors_count.c
@@ -71,10 +71,8 @@ int MPI_Graph_neighbors_count(MPI_Comm comm, int rank, int *nneighbors)
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                        FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.graph.graph_neighbors_count(comm, rank, nneighbors);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/graphdims_get.c
+++ b/ompi/mpi/c/graphdims_get.c
@@ -67,10 +67,8 @@ int MPI_Graphdims_get(MPI_Comm comm, int *nnodes, int *nedges)
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                        FUNC_NAME);
     }
-    OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.graph.graphdims_get(comm, nnodes, nedges);
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/grequest_complete.c
+++ b/ompi/mpi/c/grequest_complete.c
@@ -55,8 +55,6 @@ int MPI_Grequest_complete(MPI_Request request)
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_grequest_complete(request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, MPI_ERR_INTERN, FUNC_NAME);
 }

--- a/ompi/mpi/c/grequest_start.c
+++ b/ompi/mpi/c/grequest_start.c
@@ -51,8 +51,6 @@ int MPI_Grequest_start(MPI_Grequest_query_function *query_fn,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_grequest_start(query_fn,free_fn,cancel_fn,extra_state,request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/group_c2f.c
+++ b/ompi/mpi/c/group_c2f.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Group_c2f";
 
 MPI_Fint MPI_Group_c2f(MPI_Group group)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/group_compare.c
+++ b/ompi/mpi/c/group_compare.c
@@ -56,8 +56,6 @@ int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result) {
         }
     }
 
-    OPAL_CR_NOOP_PROGRESS();
-
     return_value = ompi_group_compare((ompi_group_t *)group1, (ompi_group_t *)group2, result);
 
     return return_value;

--- a/ompi/mpi/c/group_difference.c
+++ b/ompi/mpi/c/group_difference.c
@@ -53,8 +53,6 @@ int MPI_Group_difference(MPI_Group group1, MPI_Group group2,
       }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   err = ompi_group_difference ( group1, group2,  new_group );
   OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );
 }

--- a/ompi/mpi/c/group_excl.c
+++ b/ompi/mpi/c/group_excl.c
@@ -81,8 +81,6 @@ int MPI_Group_excl(MPI_Group group, int n, const int ranks[],
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_group_excl ( group, n, ranks, new_group );
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );
 }

--- a/ompi/mpi/c/group_f2c.c
+++ b/ompi/mpi/c/group_f2c.c
@@ -41,8 +41,6 @@ MPI_Group MPI_Group_f2c(MPI_Fint group_f)
 {
     int group_index = OMPI_FINT_2_INT(group_f);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/group_free.c
+++ b/ompi/mpi/c/group_free.c
@@ -65,11 +65,9 @@ int MPI_Group_free(MPI_Group *group)
 
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_group_free ( group);
     OMPI_ERRHANDLER_CHECK(ret, MPI_COMM_WORLD, ret, FUNC_NAME);
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/group_incl.c
+++ b/ompi/mpi/c/group_incl.c
@@ -81,8 +81,6 @@ int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *new_gro
       return MPI_SUCCESS;
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   err = ompi_group_incl(group,n,ranks,new_group);
   OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD,err,FUNC_NAME);
 }

--- a/ompi/mpi/c/group_intersection.c
+++ b/ompi/mpi/c/group_intersection.c
@@ -54,8 +54,6 @@ int MPI_Group_intersection(MPI_Group group1, MPI_Group group2,
       }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   err = ompi_group_intersection ( group1, group2,  new_group );
   OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );
 }

--- a/ompi/mpi/c/group_range_excl.c
+++ b/ompi/mpi/c/group_range_excl.c
@@ -110,8 +110,6 @@ int MPI_Group_range_excl(MPI_Group group, int n_triplets, int ranges[][3],
         free (elements_int_list);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_group_range_excl(group,n_triplets,ranges,new_group);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD,err,FUNC_NAME);
 

--- a/ompi/mpi/c/group_range_incl.c
+++ b/ompi/mpi/c/group_range_incl.c
@@ -111,8 +111,6 @@ int MPI_Group_range_incl(MPI_Group group, int n_triplets, int ranges[][3],
         free ( elements_int_list);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_group_range_incl ( group, n_triplets, ranges, new_group );
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );
 

--- a/ompi/mpi/c/group_rank.c
+++ b/ompi/mpi/c/group_rank.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Group_rank";
 
 int MPI_Group_rank(MPI_Group group, int *rank)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     /* error checking */
     if( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);

--- a/ompi/mpi/c/group_size.c
+++ b/ompi/mpi/c/group_size.c
@@ -39,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Group_size";
 int MPI_Group_size(MPI_Group group, int *size)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* error checking */
     if( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);

--- a/ompi/mpi/c/group_translate_ranks.c
+++ b/ompi/mpi/c/group_translate_ranks.c
@@ -67,8 +67,6 @@ int MPI_Group_translate_ranks(MPI_Group group1, int n_ranks, const int ranks1[],
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_group_translate_ranks ( group1, n_ranks, ranks1,
                                        group2, ranks2 );
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );

--- a/ompi/mpi/c/group_union.c
+++ b/ompi/mpi/c/group_union.c
@@ -54,8 +54,6 @@ int MPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *new_group)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_group_union ( group1, group2,  new_group );
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME );
 }

--- a/ompi/mpi/c/iallgather.c
+++ b/ompi/mpi/c/iallgather.c
@@ -93,8 +93,6 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_iallgather(sendbuf, sendcount, sendtype,
                                        recvbuf, recvcount, recvtype, comm,

--- a/ompi/mpi/c/iallgatherv.c
+++ b/ompi/mpi/c/iallgatherv.c
@@ -116,8 +116,6 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_iallgatherv(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcounts, displs,

--- a/ompi/mpi/c/iallreduce.c
+++ b/ompi/mpi/c/iallreduce.c
@@ -94,8 +94,6 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/ialltoall.c
+++ b/ompi/mpi/c/ialltoall.c
@@ -90,8 +90,6 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ialltoall(sendbuf, sendcount, sendtype,
                                       recvbuf, recvcount, recvtype, comm,

--- a/ompi/mpi/c/ialltoallv.c
+++ b/ompi/mpi/c/ialltoallv.c
@@ -115,8 +115,6 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ialltoallv(sendbuf, sendcounts, sdispls,
                                        sendtype, recvbuf, recvcounts, rdispls,

--- a/ompi/mpi/c/ialltoallw.c
+++ b/ompi/mpi/c/ialltoallw.c
@@ -111,8 +111,6 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ialltoallw(sendbuf, sendcounts, sdispls,
                                        sendtypes, recvbuf, recvcounts,

--- a/ompi/mpi/c/ibarrier.c
+++ b/ompi/mpi/c/ibarrier.c
@@ -54,8 +54,6 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = comm->c_coll.coll_ibarrier(comm, request, comm->c_coll.coll_ibarrier_module);
 
     /* All done */

--- a/ompi/mpi/c/ibcast.c
+++ b/ompi/mpi/c/ibcast.c
@@ -72,8 +72,6 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
       }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     err = comm->c_coll.coll_ibcast(buffer, count, datatype, root, comm,

--- a/ompi/mpi/c/ibsend.c
+++ b/ompi/mpi/c/ibsend.c
@@ -79,7 +79,6 @@ int MPI_Ibsend(const void *buf, int count, MPI_Datatype type, int dest,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     MEMCHECKER (
         memchecker_call(&opal_memchecker_base_mem_noaccess, buf, count, type);
     );

--- a/ompi/mpi/c/iexscan.c
+++ b/ompi/mpi/c/iexscan.c
@@ -76,7 +76,6 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
 

--- a/ompi/mpi/c/igather.c
+++ b/ompi/mpi/c/igather.c
@@ -165,8 +165,6 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_igather(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcount, recvtype, root, comm, request,

--- a/ompi/mpi/c/igatherv.c
+++ b/ompi/mpi/c/igatherv.c
@@ -190,8 +190,6 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_igatherv(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcounts, displs, recvtype,

--- a/ompi/mpi/c/improbe.c
+++ b/ompi/mpi/c/improbe.c
@@ -69,8 +69,6 @@ int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(improbe(source, tag, comm, flag, message, status));
     /* Per MPI-1, the MPI_ERROR field is not defined for
        single-completion calls */

--- a/ompi/mpi/c/imrecv.c
+++ b/ompi/mpi/c/imrecv.c
@@ -64,8 +64,6 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
      }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(imrecv(buf, count, type, message, request));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/ineighbor_allgather.c
+++ b/ompi/mpi/c/ineighbor_allgather.c
@@ -94,8 +94,6 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                                 recvcount, recvtype, comm, request,

--- a/ompi/mpi/c/ineighbor_allgatherv.c
+++ b/ompi/mpi/c/ineighbor_allgatherv.c
@@ -117,8 +117,6 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ineighbor_allgatherv(sendbuf, sendcount, sendtype,
                                                  recvbuf, (int *) recvcounts, (int *) displs,

--- a/ompi/mpi/c/ineighbor_alltoall.c
+++ b/ompi/mpi/c/ineighbor_alltoall.c
@@ -91,8 +91,6 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ineighbor_alltoall(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcount, recvtype, comm,

--- a/ompi/mpi/c/ineighbor_alltoallv.c
+++ b/ompi/mpi/c/ineighbor_alltoallv.c
@@ -115,8 +115,6 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ineighbor_alltoallv(sendbuf, sendcounts, sdispls,
                                                 sendtype, recvbuf, recvcounts, rdispls,

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -113,8 +113,6 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
                                                 recvbuf, recvcounts, rdispls, recvtypes, comm, request,

--- a/ompi/mpi/c/info_c2f.c
+++ b/ompi/mpi/c/info_c2f.c
@@ -39,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Info_c2f";
 MPI_Fint MPI_Info_c2f(MPI_Info info)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/info_create.c
+++ b/ompi/mpi/c/info_create.c
@@ -49,8 +49,6 @@ static const char FUNC_NAME[] = "MPI_Info_create";
 int MPI_Info_create(MPI_Info *info)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == info) {

--- a/ompi/mpi/c/info_delete.c
+++ b/ompi/mpi/c/info_delete.c
@@ -74,8 +74,6 @@ int MPI_Info_delete(MPI_Info info, const char *key) {
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_info_delete (info, key);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_dup.c
+++ b/ompi/mpi/c/info_dup.c
@@ -78,8 +78,6 @@ int MPI_Info_dup(MPI_Info info, MPI_Info *newinfo) {
                                       FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Now to actually duplicate all the values
      */

--- a/ompi/mpi/c/info_f2c.c
+++ b/ompi/mpi/c/info_f2c.c
@@ -47,8 +47,6 @@ MPI_Info MPI_Info_f2c(MPI_Fint info)
 {
     int info_index = OMPI_FINT_2_INT(info);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* check the arguments */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/info_free.c
+++ b/ompi/mpi/c/info_free.c
@@ -63,7 +63,6 @@ int MPI_Info_free(MPI_Info *info)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     err = ompi_info_free(info);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);

--- a/ompi/mpi/c/info_get.c
+++ b/ompi/mpi/c/info_get.c
@@ -97,8 +97,6 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_info_get (info, key, valuelen, value, flag);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_nkeys.c
+++ b/ompi/mpi/c/info_get_nkeys.c
@@ -66,8 +66,6 @@ int MPI_Info_get_nkeys(MPI_Info info, int *nkeys)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_info_get_nkeys(info, nkeys);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_nthkey.c
+++ b/ompi/mpi/c/info_get_nthkey.c
@@ -75,7 +75,6 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* Keys are indexed on 0, which makes the "n" parameter offset by
        1 from the value returned by get_nkeys().  So be sure to
@@ -84,7 +83,6 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
     err = ompi_info_get_nkeys(info, &nkeys);
     OMPI_ERRHANDLER_CHECK(err, MPI_COMM_WORLD, err, FUNC_NAME);
     if (n > (nkeys - 1)) {
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_INFO_KEY,
                                        FUNC_NAME);
     }

--- a/ompi/mpi/c/info_get_valuelen.c
+++ b/ompi/mpi/c/info_get_valuelen.c
@@ -87,8 +87,6 @@ int MPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     err = ompi_info_get_valuelen (info, key, valuelen, flag);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_set.c
+++ b/ompi/mpi/c/info_set.c
@@ -96,8 +96,6 @@ int MPI_Info_set(MPI_Info info, const char *key, const char *value)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * If all is right with the arguments, then call the back-end
      * allocator.

--- a/ompi/mpi/c/init.c
+++ b/ompi/mpi/c/init.c
@@ -99,7 +99,5 @@ int MPI_Init(int *argc, char ***argv)
                                       err, FUNC_NAME);
     }
 
-    OPAL_CR_INIT_LIBRARY();
-
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/init_thread.c
+++ b/ompi/mpi/c/init_thread.c
@@ -97,7 +97,5 @@ int MPI_Init_thread(int *argc, char ***argv, int required,
                                       err, FUNC_NAME);
     }
 
-    OPAL_CR_INIT_LIBRARY();
-
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/initialized.c
+++ b/ompi/mpi/c/initialized.c
@@ -38,8 +38,6 @@ int MPI_Initialized(int *flag)
 {
     MPI_Comm null = NULL;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         if (NULL == flag) {
 

--- a/ompi/mpi/c/intercomm_create.c
+++ b/ompi/mpi/c/intercomm_create.c
@@ -78,7 +78,6 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
         */
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     local_size = ompi_comm_size ( local_comm );
     local_rank = ompi_comm_rank ( local_comm );
@@ -95,12 +94,10 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
         if ( local_rank == local_leader ) {
             if ( ompi_comm_invalid ( bridge_comm ) ||
                  (bridge_comm->c_flags & OMPI_COMM_INTER) ) {
-                OPAL_CR_EXIT_LIBRARY();
                 return OMPI_ERRHANDLER_INVOKE ( local_comm, MPI_ERR_COMM,
                                                 FUNC_NAME);
             }
             if ( (remote_leader < 0) || (remote_leader >= ompi_comm_size(bridge_comm))) {
-                OPAL_CR_EXIT_LIBRARY();
                 return OMPI_ERRHANDLER_INVOKE ( local_comm, MPI_ERR_ARG,
                                                 FUNC_NAME);
             }
@@ -227,7 +224,6 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
     }
 
  err_exit:
-    OPAL_CR_EXIT_LIBRARY();
 
     if ( NULL != rprocs ) {
         free ( rprocs );

--- a/ompi/mpi/c/intercomm_merge.c
+++ b/ompi/mpi/c/intercomm_merge.c
@@ -69,8 +69,6 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
                                             FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     local_size  = ompi_comm_size ( intercomm );
     remote_size = ompi_comm_remote_size ( intercomm );
     total_size  = local_size + remote_size;
@@ -142,7 +140,6 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
     }
 
  exit:
-    OPAL_CR_EXIT_LIBRARY();
 
     if ( NULL != procs ) {
         free ( procs );

--- a/ompi/mpi/c/iprobe.c
+++ b/ompi/mpi/c/iprobe.c
@@ -74,8 +74,6 @@ int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(iprobe(source, tag, comm, flag, status));
 
     /*

--- a/ompi/mpi/c/irecv.c
+++ b/ompi/mpi/c/irecv.c
@@ -71,8 +71,6 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype type, int source,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     MEMCHECKER (
         memchecker_call(&opal_memchecker_base_mem_noaccess, buf, count, type);
     );

--- a/ompi/mpi/c/ireduce.c
+++ b/ompi/mpi/c/ireduce.c
@@ -121,8 +121,6 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     OBJ_RETAIN(op);
     err = comm->c_coll.coll_ireduce(sendbuf, recvbuf, count,

--- a/ompi/mpi/c/ireduce_scatter.c
+++ b/ompi/mpi/c/ireduce_scatter.c
@@ -111,8 +111,6 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/ireduce_scatter_block.c
+++ b/ompi/mpi/c/ireduce_scatter_block.c
@@ -94,8 +94,6 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/irsend.c
+++ b/ompi/mpi/c/irsend.c
@@ -80,8 +80,6 @@ int MPI_Irsend(const void *buf, int count, MPI_Datatype type, int dest,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     MEMCHECKER (
         memchecker_call(&opal_memchecker_base_mem_noaccess, buf, count, type);
     );

--- a/ompi/mpi/c/is_thread_main.c
+++ b/ompi/mpi/c/is_thread_main.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Is_thread_main";
 
 int MPI_Is_thread_main(int *flag)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == flag) {

--- a/ompi/mpi/c/iscan.c
+++ b/ompi/mpi/c/iscan.c
@@ -90,8 +90,6 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the coll component to actually perform the allgather */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/iscatter.c
+++ b/ompi/mpi/c/iscatter.c
@@ -148,8 +148,6 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_iscatter(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcount, recvtype, root, comm, request,

--- a/ompi/mpi/c/iscatterv.c
+++ b/ompi/mpi/c/iscatterv.c
@@ -188,8 +188,6 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_iscatterv(sendbuf, sendcounts, displs,
                                       sendtype, recvbuf, recvcount, recvtype, root, comm,

--- a/ompi/mpi/c/isend.c
+++ b/ompi/mpi/c/isend.c
@@ -81,8 +81,6 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype type, int dest,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     MEMCHECKER (
         memchecker_call(&opal_memchecker_base_mem_noaccess, buf, count, type);
     );

--- a/ompi/mpi/c/issend.c
+++ b/ompi/mpi/c/issend.c
@@ -78,8 +78,6 @@ int MPI_Issend(const void *buf, int count, MPI_Datatype type, int dest,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     MEMCHECKER (
         memchecker_call(&opal_memchecker_base_mem_noaccess, buf, count, type);
     );

--- a/ompi/mpi/c/keyval_create.c
+++ b/ompi/mpi/c/keyval_create.c
@@ -55,8 +55,6 @@ int MPI_Keyval_create(MPI_Copy_function *copy_attr_fn,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     copy_fn.attr_communicator_copy_fn = (MPI_Comm_internal_copy_attr_function*)copy_attr_fn;
     del_fn.attr_communicator_delete_fn = delete_attr_fn;
 

--- a/ompi/mpi/c/keyval_free.c
+++ b/ompi/mpi/c/keyval_free.c
@@ -47,8 +47,6 @@ int MPI_Keyval_free(int *keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_attr_free_keyval(COMM_ATTR, keyval, 0);
     OMPI_ERRHANDLER_RETURN(ret, MPI_COMM_WORLD, MPI_ERR_OTHER, FUNC_NAME);
 }

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -67,8 +67,6 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     OBJ_CONSTRUCT(&pinfo, opal_list_t);
 
     /* OMPI supports info keys to pass the range to
@@ -115,6 +113,5 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
     strncpy ( port_name, pdat->value.data.string, MPI_MAX_PORT_NAME );
     OPAL_LIST_DESTRUCT(&results);
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/message_c2f.c
+++ b/ompi/mpi/c/message_c2f.c
@@ -44,8 +44,6 @@ MPI_Fint MPI_Message_c2f(MPI_Message message)
         memchecker_message(&message);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/message_f2c.c
+++ b/ompi/mpi/c/message_f2c.c
@@ -40,8 +40,6 @@ MPI_Message MPI_Message_f2c(MPI_Fint message)
 {
     int message_index = OMPI_FINT_2_INT(message);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/mprobe.c
+++ b/ompi/mpi/c/mprobe.c
@@ -68,8 +68,6 @@ int MPI_Mprobe(int source, int tag, MPI_Comm comm,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(mprobe(source, tag, comm, message, status));
     /* Per MPI-1, the MPI_ERROR field is not defined for
        single-completion calls */

--- a/ompi/mpi/c/mrecv.c
+++ b/ompi/mpi/c/mrecv.c
@@ -66,8 +66,6 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
      }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(mrecv(buf, count, type, message, status));
     /* Per MPI-1, the MPI_ERROR field is not defined for
        single-completion calls */

--- a/ompi/mpi/c/neighbor_allgather.c
+++ b/ompi/mpi/c/neighbor_allgather.c
@@ -115,8 +115,6 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_neighbor_allgather(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcount, recvtype, comm,

--- a/ompi/mpi/c/neighbor_allgatherv.c
+++ b/ompi/mpi/c/neighbor_allgatherv.c
@@ -138,8 +138,6 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
        something */
 
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_neighbor_allgatherv(sendbuf, sendcount, sendtype,
                                                 recvbuf, recvcounts, displs,

--- a/ompi/mpi/c/neighbor_alltoall.c
+++ b/ompi/mpi/c/neighbor_alltoall.c
@@ -105,8 +105,6 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf,
                                               recvcount, recvtype, comm,

--- a/ompi/mpi/c/neighbor_alltoallv.c
+++ b/ompi/mpi/c/neighbor_alltoallv.c
@@ -121,8 +121,6 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
                                                recvbuf, recvcounts, rdispls, recvtype,

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -117,8 +117,6 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_neighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
                                                recvbuf, recvcounts, rdispls, recvtypes,

--- a/ompi/mpi/c/op_c2f.c
+++ b/ompi/mpi/c/op_c2f.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Op_c2f";
 
 MPI_Fint MPI_Op_c2f(MPI_Op op)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/op_commutative.c
+++ b/ompi/mpi/c/op_commutative.c
@@ -39,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Op_commutative";
 
 int MPI_Op_commutative(MPI_Op op, int *commute)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     /* Error checking */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/op_create.c
+++ b/ompi/mpi/c/op_create.c
@@ -53,8 +53,6 @@ int MPI_Op_create(MPI_User_function * function, int commute, MPI_Op * op)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Create and cache the op.  Sets a refcount of 1. */
 
     *op = ompi_op_create_user(OPAL_INT_TO_BOOL(commute),

--- a/ompi/mpi/c/op_f2c.c
+++ b/ompi/mpi/c/op_f2c.c
@@ -40,8 +40,6 @@ MPI_Op MPI_Op_f2c(MPI_Fint op_f)
 {
     int op_index = OMPI_FINT_2_INT(op_f);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     /* Error checking */
 
     if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/op_free.c
+++ b/ompi/mpi/c/op_free.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Op_free";
 int MPI_Op_free(MPI_Op *op)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
   /* Error checking */
 
   if (MPI_PARAM_CHECK) {

--- a/ompi/mpi/c/open_port.c
+++ b/ompi/mpi/c/open_port.c
@@ -65,8 +65,6 @@ int MPI_Open_port(MPI_Info info, char *port_name)
         */
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_dpm_open_port(port_name);
 
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);

--- a/ompi/mpi/c/pack.c
+++ b/ompi/mpi/c/pack.c
@@ -71,8 +71,6 @@ int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     OBJ_CONSTRUCT( &local_convertor, opal_convertor_t );
     /* the resulting convertor will be set to the position ZERO */
     opal_convertor_copy_and_prepare_for_send( ompi_mpi_local_convertor, &(datatype->super),
@@ -82,7 +80,6 @@ int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
     opal_convertor_get_packed_size( &local_convertor, &size );
     if( (*position + size) > (unsigned int)outsize ) {  /* we can cast as we already checked for < 0 */
         OBJ_DESTRUCT( &local_convertor );
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
     }
 

--- a/ompi/mpi/c/pack_external.c
+++ b/ompi/mpi/c/pack_external.c
@@ -69,8 +69,6 @@ int MPI_Pack_external(const char datarep[], const void *inbuf, int incount,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     OBJ_CONSTRUCT(&local_convertor, opal_convertor_t);
 
     /* The resulting convertor will be set to the position zero. We have to use
@@ -86,7 +84,6 @@ int MPI_Pack_external(const char datarep[], const void *inbuf, int incount,
     opal_convertor_get_packed_size( &local_convertor, &size );
     if( (*position + size) > (size_t)outsize ) {  /* we can cast as we already checked for < 0 */
         OBJ_DESTRUCT( &local_convertor );
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE( MPI_COMM_WORLD, MPI_ERR_TRUNCATE, FUNC_NAME );
     }
 

--- a/ompi/mpi/c/pack_external_size.c
+++ b/ompi/mpi/c/pack_external_size.c
@@ -60,7 +60,6 @@ int MPI_Pack_external_size(const char datarep[], int incount,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     OBJ_CONSTRUCT(&local_convertor, opal_convertor_t);
 
@@ -74,6 +73,5 @@ int MPI_Pack_external_size(const char datarep[], int incount,
     *size = (MPI_Aint)length;
     OBJ_DESTRUCT( &local_convertor );
 
-    OPAL_CR_EXIT_LIBRARY();
     return OMPI_SUCCESS;
 }

--- a/ompi/mpi/c/pack_size.c
+++ b/ompi/mpi/c/pack_size.c
@@ -60,7 +60,6 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     OBJ_CONSTRUCT( &local_convertor, opal_convertor_t );
     /* the resulting convertor will be set to the position ZERO */
@@ -71,7 +70,6 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm,
     *size = (int)length;
     OBJ_DESTRUCT( &local_convertor );
 
-    OPAL_CR_EXIT_LIBRARY();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/pcontrol.c
+++ b/ompi/mpi/c/pcontrol.c
@@ -37,8 +37,6 @@ int MPI_Pcontrol(const int level, ...)
 {
     va_list arglist;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/probe.c
+++ b/ompi/mpi/c/probe.c
@@ -73,8 +73,6 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(probe(source, tag, comm, status));
     /*
      * Per MPI-1, the MPI_ERROR field is not defined for single-completion calls

--- a/ompi/mpi/c/publish_name.c
+++ b/ompi/mpi/c/publish_name.c
@@ -68,7 +68,6 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     OBJ_CONSTRUCT(&values, opal_list_t);
 
     /* OMPI supports info keys to pass the range and persistence to
@@ -140,7 +139,6 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
     rc = opal_pmix.publish(&values);
     OPAL_LIST_DESTRUCT(&values);
 
-    OPAL_CR_EXIT_LIBRARY();
     if ( OPAL_SUCCESS != rc ) {
         if (OPAL_EXISTS == rc) {
             /* already exists - can't publish it */

--- a/ompi/mpi/c/put.c
+++ b/ompi/mpi/c/put.c
@@ -77,8 +77,6 @@ int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datat
 
     if (MPI_PROC_NULL == target_rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_put(origin_addr, origin_count, origin_datatype,
                                     target_rank, target_disp, target_count,
                                     target_datatype, win);

--- a/ompi/mpi/c/query_thread.c
+++ b/ompi/mpi/c/query_thread.c
@@ -37,8 +37,6 @@ static const char FUNC_NAME[] = "MPI_Query_thread";
 int MPI_Query_thread(int *provided)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
   if (MPI_PARAM_CHECK) {
     OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     if (NULL == provided) {

--- a/ompi/mpi/c/raccumulate.c
+++ b/ompi/mpi/c/raccumulate.c
@@ -128,8 +128,6 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype orig
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_win->w_osc_module->osc_raccumulate(origin_addr,
                                                 origin_count,
                                                 origin_datatype,

--- a/ompi/mpi/c/recv.c
+++ b/ompi/mpi/c/recv.c
@@ -73,8 +73,6 @@ int MPI_Recv(void *buf, int count, MPI_Datatype type, int source,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = MCA_PML_CALL(recv(buf, count, type, source, tag, comm, status));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/recv_init.c
+++ b/ompi/mpi/c/recv_init.c
@@ -81,8 +81,6 @@ int MPI_Recv_init(void *buf, int count, MPI_Datatype type, int source,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Here, we just initialize the request -- memchecker should set the buffer in MPI_Start.
      */

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -129,8 +129,6 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/reduce_local.c
+++ b/ompi/mpi/c/reduce_local.c
@@ -70,8 +70,6 @@ int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the op component to perform the back-end operation */
     OBJ_RETAIN(op);
     /* XXX -- CONST -- do not cast away const -- update mca/coll */

--- a/ompi/mpi/c/reduce_scatter.c
+++ b/ompi/mpi/c/reduce_scatter.c
@@ -124,8 +124,6 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/reduce_scatter_block.c
+++ b/ompi/mpi/c/reduce_scatter_block.c
@@ -93,8 +93,6 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/register_datarep.c
+++ b/ompi/mpi/c/register_datarep.c
@@ -67,8 +67,6 @@ int MPI_Register_datarep(const char *datarep,
         return OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the back-end io component function */
     rc = mca_io_base_register_datarep(datarep, read_conversion_fn,
                                       write_conversion_fn,

--- a/ompi/mpi/c/request_c2f.c
+++ b/ompi/mpi/c/request_c2f.c
@@ -44,8 +44,6 @@ MPI_Fint MPI_Request_c2f(MPI_Request request)
         memchecker_request(&request);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/request_f2c.c
+++ b/ompi/mpi/c/request_f2c.c
@@ -40,8 +40,6 @@ MPI_Request MPI_Request_f2c(MPI_Fint request)
 {
     int request_index = OMPI_FINT_2_INT(request);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/request_free.c
+++ b/ompi/mpi/c/request_free.c
@@ -55,8 +55,6 @@ int MPI_Request_free(MPI_Request *request)
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_request_free(request);
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/request_get_status.c
+++ b/ompi/mpi/c/request_get_status.c
@@ -52,8 +52,6 @@ int MPI_Request_get_status(MPI_Request request, int *flag,
         memchecker_request(&request);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if( (NULL == flag) ) {

--- a/ompi/mpi/c/rget.c
+++ b/ompi/mpi/c/rget.c
@@ -75,8 +75,6 @@ int MPI_Rget(void *origin_addr, int origin_count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_rget(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count,
                                      target_datatype, win, request);

--- a/ompi/mpi/c/rget_accumulate.c
+++ b/ompi/mpi/c/rget_accumulate.c
@@ -135,8 +135,6 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype 
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_win->w_osc_module->osc_rget_accumulate(origin_addr,
                                                     origin_count,
                                                     origin_datatype,

--- a/ompi/mpi/c/rput.c
+++ b/ompi/mpi/c/rput.c
@@ -80,8 +80,6 @@ int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_data
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_rput(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count,
                                      target_datatype, win, request);

--- a/ompi/mpi/c/rsend.c
+++ b/ompi/mpi/c/rsend.c
@@ -77,7 +77,6 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     rc = MCA_PML_CALL(send(buf, count, type, dest, tag,
                            MCA_PML_BASE_SEND_READY, comm));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/rsend_init.c
+++ b/ompi/mpi/c/rsend_init.c
@@ -88,8 +88,6 @@ int MPI_Rsend_init(const void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Here, we just initialize the request -- memchecker should set the buffer in MPI_Start.
      */

--- a/ompi/mpi/c/scan.c
+++ b/ompi/mpi/c/scan.c
@@ -98,8 +98,6 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Call the coll component to actually perform the allgather */
 
     OBJ_RETAIN(op);

--- a/ompi/mpi/c/scatter.c
+++ b/ompi/mpi/c/scatter.c
@@ -159,8 +159,6 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_scatter(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcount, recvtype, root, comm,

--- a/ompi/mpi/c/scatterv.c
+++ b/ompi/mpi/c/scatterv.c
@@ -188,8 +188,6 @@ int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[]
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Invoke the coll component to perform the back-end operation */
     err = comm->c_coll.coll_scatterv(sendbuf, sendcounts, displs,
                                      sendtype, recvbuf, recvcount, recvtype, root, comm,

--- a/ompi/mpi/c/send.c
+++ b/ompi/mpi/c/send.c
@@ -75,7 +75,6 @@ int MPI_Send(const void *buf, int count, MPI_Datatype type, int dest,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     rc = MCA_PML_CALL(send(buf, count, type, dest, tag, MCA_PML_BASE_SEND_STANDARD, comm));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/send_init.c
+++ b/ompi/mpi/c/send_init.c
@@ -88,8 +88,6 @@ int MPI_Send_init(const void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Here, we just initialize the request -- memchecker should set the buffer in MPI_Start.
      */

--- a/ompi/mpi/c/sendrecv.c
+++ b/ompi/mpi/c/sendrecv.c
@@ -77,8 +77,6 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     if (source != MPI_PROC_NULL) { /* post recv */
         rc = MCA_PML_CALL(irecv(recvbuf, recvcount, recvtype,
                                 source, recvtag, comm, &req));

--- a/ompi/mpi/c/sendrecv_replace.c
+++ b/ompi/mpi/c/sendrecv_replace.c
@@ -73,13 +73,10 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* simple case */
     if ( source == MPI_PROC_NULL || dest == MPI_PROC_NULL || count == 0 ) {
         rc = MPI_Sendrecv(buf,count,datatype,dest,sendtag,buf,count,datatype,source,recvtag,comm,status);
 
-        OPAL_CR_EXIT_LIBRARY();
         return rc;
     } else {
 
@@ -138,7 +135,6 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
         }
         OBJ_DESTRUCT(&convertor);
 
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 }

--- a/ompi/mpi/c/ssend.c
+++ b/ompi/mpi/c/ssend.c
@@ -76,7 +76,6 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     rc = MCA_PML_CALL(send(buf, count, type, dest, tag,
                            MCA_PML_BASE_SEND_SYNCHRONOUS, comm));
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/c/ssend_init.c
+++ b/ompi/mpi/c/ssend_init.c
@@ -88,8 +88,6 @@ int MPI_Ssend_init(const void *buf, int count, MPI_Datatype type,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /*
      * Here, we just initialize the request -- memchecker should set the buffer in MPI_Start.
      */

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -65,11 +65,9 @@ int MPI_Start(MPI_Request *request)
 
     switch((*request)->req_type) {
     case OMPI_REQUEST_PML:
-        OPAL_CR_ENTER_LIBRARY();
 
         ret = MCA_PML_CALL(start(1, request));
 
-        OPAL_CR_EXIT_LIBRARY();
         return ret;
 
     case OMPI_REQUEST_NOOP:

--- a/ompi/mpi/c/startall.c
+++ b/ompi/mpi/c/startall.c
@@ -74,7 +74,6 @@ int MPI_Startall(int count, MPI_Request requests[])
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     for (i = 0; i < count; ++i) {
         if (OMPI_REQUEST_NOOP == requests[i]->req_type) {
@@ -91,7 +90,6 @@ int MPI_Startall(int count, MPI_Request requests[])
     }
     ret = MCA_PML_CALL(start(count, requests));
 
-    OPAL_CR_EXIT_LIBRARY();
     return ret;
 }
 

--- a/ompi/mpi/c/status_c2f.c
+++ b/ompi/mpi/c/status_c2f.c
@@ -56,8 +56,6 @@ int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status)
         }
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/status_f2c.c
+++ b/ompi/mpi/c/status_f2c.c
@@ -43,8 +43,6 @@ int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status)
 {
     int i, *c_ints;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/status_set_cancelled.c
+++ b/ompi/mpi/c/status_set_cancelled.c
@@ -48,8 +48,6 @@ int MPI_Status_set_cancelled(MPI_Status *status, int flag)
         }
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         int rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);

--- a/ompi/mpi/c/status_set_elements.c
+++ b/ompi/mpi/c/status_set_elements.c
@@ -56,8 +56,6 @@ int MPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype, int count
         }
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == datatype || MPI_DATATYPE_NULL == datatype) {

--- a/ompi/mpi/c/status_set_elements_x.c
+++ b/ompi/mpi/c/status_set_elements_x.c
@@ -56,8 +56,6 @@ int MPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype, MPI_Cou
         }
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == datatype || MPI_DATATYPE_NULL == datatype) {

--- a/ompi/mpi/c/test.c
+++ b/ompi/mpi/c/test.c
@@ -56,7 +56,6 @@ int MPI_Test(MPI_Request *request, int *completed, MPI_Status *status)
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_request_test(request, completed, status);
     if (*completed < 0) {
@@ -67,7 +66,6 @@ int MPI_Test(MPI_Request *request, int *completed, MPI_Status *status)
         opal_memchecker_base_mem_undefined(&status->MPI_ERROR, sizeof(int));
     );
 
-    OPAL_CR_EXIT_LIBRARY();
 
     if (OMPI_SUCCESS == rc) {
         return MPI_SUCCESS;

--- a/ompi/mpi/c/test_cancelled.c
+++ b/ompi/mpi/c/test_cancelled.c
@@ -47,8 +47,6 @@ int MPI_Test_cancelled(const MPI_Status *status, int *flag)
             memchecker_status(status);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == flag || NULL == status) {

--- a/ompi/mpi/c/testall.c
+++ b/ompi/mpi/c/testall.c
@@ -74,20 +74,16 @@ int MPI_Testall(int count, MPI_Request requests[], int *flag,
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_test_all(count, requests, flag,
                                               statuses)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
     if (MPI_SUCCESS !=
         ompi_errhandler_request_invoke(count, requests, FUNC_NAME)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_ERR_IN_STATUS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/testany.c
+++ b/ompi/mpi/c/testany.c
@@ -80,14 +80,11 @@ int MPI_Testany(int count, MPI_Request requests[], int *indx, int *completed, MP
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_test_any(count, requests,
                                               indx, completed, status)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return ompi_errhandler_request_invoke(count, requests, FUNC_NAME);
 }

--- a/ompi/mpi/c/testsome.c
+++ b/ompi/mpi/c/testsome.c
@@ -76,20 +76,16 @@ int MPI_Testsome(int incount, MPI_Request requests[],
         return OMPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_test_some(incount, requests, outcount,
                                                indices, statuses)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
     if (MPI_SUCCESS !=
         ompi_errhandler_request_invoke(incount, requests, FUNC_NAME)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_ERR_IN_STATUS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/topo_test.c
+++ b/ompi/mpi/c/topo_test.c
@@ -42,8 +42,6 @@ int MPI_Topo_test(MPI_Comm comm, int *status)
         memchecker_comm(comm);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (ompi_comm_invalid (comm)) {

--- a/ompi/mpi/c/type_c2f.c
+++ b/ompi/mpi/c/type_c2f.c
@@ -40,8 +40,6 @@ static const char FUNC_NAME[] = "MPI_Type_c2f";
 MPI_Fint MPI_Type_c2f(MPI_Datatype datatype)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     MEMCHECKER(
         memchecker_datatype(datatype);
     );

--- a/ompi/mpi/c/type_commit.c
+++ b/ompi/mpi/c/type_commit.c
@@ -52,8 +52,6 @@ int MPI_Type_commit(MPI_Datatype *type)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   rc = ompi_datatype_commit( type );
   OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 }

--- a/ompi/mpi/c/type_contiguous.c
+++ b/ompi/mpi/c/type_contiguous.c
@@ -60,8 +60,6 @@ int MPI_Type_contiguous(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_datatype_create_contiguous( count, oldtype, newtype );
     OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 

--- a/ompi/mpi/c/type_create_darray.c
+++ b/ompi/mpi/c/type_create_darray.c
@@ -93,8 +93,6 @@ int MPI_Type_create_darray(int size,
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = ompi_datatype_create_darray( size, rank, ndims,
                                       gsize_array, distrib_array, darg_array, psize_array,
                                       order, oldtype, newtype );
@@ -105,8 +103,6 @@ int MPI_Type_create_darray(int size,
         ompi_datatype_set_args( *newtype, 4 * ndims + 4, a_i, 0, NULL, 1, &oldtype,
                                 MPI_COMBINER_DARRAY );
     }
-
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -45,8 +45,6 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
 {
     uint64_t key;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/type_create_f90_integer.c
+++ b/ompi/mpi/c/type_create_f90_integer.c
@@ -42,8 +42,6 @@ static const char FUNC_NAME[] = "MPI_Type_create_f90_integer";
 int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype)
 
 {
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -45,8 +45,6 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
 {
     uint64_t key;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/type_create_hindexed.c
+++ b/ompi/mpi/c/type_create_hindexed.c
@@ -73,7 +73,6 @@ int MPI_Type_create_hindexed(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_hindexed( count, array_of_blocklengths, array_of_displacements,
                                         oldtype, newtype );
@@ -89,6 +88,5 @@ int MPI_Type_create_hindexed(int count,
                                 1, &oldtype, MPI_COMBINER_HINDEXED );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_create_hindexed_block.c
+++ b/ompi/mpi/c/type_create_hindexed_block.c
@@ -59,7 +59,6 @@ int MPI_Type_create_hindexed_block(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_hindexed_block( count, blocklength, array_of_displacements,
                                               oldtype, newtype );
@@ -73,6 +72,5 @@ int MPI_Type_create_hindexed_block(int count,
                                 MPI_COMBINER_HINDEXED_BLOCK );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_create_hvector.c
+++ b/ompi/mpi/c/type_create_hvector.c
@@ -66,7 +66,6 @@ int MPI_Type_create_hvector(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_hvector ( count, blocklength, stride, oldtype,
                                         newtype );
@@ -79,6 +78,5 @@ int MPI_Type_create_hvector(int count,
         ompi_datatype_set_args( *newtype, 2, a_i, 1, a_a, 1, &oldtype, MPI_COMBINER_HVECTOR );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_create_indexed_block.c
+++ b/ompi/mpi/c/type_create_indexed_block.c
@@ -66,7 +66,6 @@ int MPI_Type_create_indexed_block(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_indexed_block( count, blocklength, array_of_displacements,
                                              oldtype, newtype );
@@ -81,6 +80,5 @@ int MPI_Type_create_indexed_block(int count,
                                 MPI_COMBINER_INDEXED_BLOCK );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_create_keyval.c
+++ b/ompi/mpi/c/type_create_keyval.c
@@ -55,8 +55,6 @@ int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     copy_fn.attr_datatype_copy_fn = (MPI_Type_internal_copy_attr_function*)type_copy_attr_fn;
     del_fn.attr_datatype_delete_fn = type_delete_attr_fn;
 

--- a/ompi/mpi/c/type_create_resized.c
+++ b/ompi/mpi/c/type_create_resized.c
@@ -56,7 +56,6 @@ int MPI_Type_create_resized(MPI_Datatype oldtype,
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
 
    rc = ompi_datatype_create_resized( oldtype, lb, extent, newtype );
    if( rc != MPI_SUCCESS ) {
@@ -71,7 +70,6 @@ int MPI_Type_create_resized(MPI_Datatype oldtype,
       ompi_datatype_set_args( *newtype, 0, NULL, 2, a_a, 1, &oldtype, MPI_COMBINER_RESIZED );
    }
 
-   OPAL_CR_EXIT_LIBRARY();
    return MPI_SUCCESS;
 }
 

--- a/ompi/mpi/c/type_create_struct.c
+++ b/ompi/mpi/c/type_create_struct.c
@@ -79,7 +79,6 @@ int MPI_Type_create_struct(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_struct( count, array_of_blocklengths, array_of_displacements,
                                       array_of_types, newtype );
@@ -96,6 +95,5 @@ int MPI_Type_create_struct(int count,
                                 count, array_of_types, MPI_COMBINER_STRUCT );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_create_subarray.c
+++ b/ompi/mpi/c/type_create_subarray.c
@@ -74,7 +74,6 @@ int MPI_Type_create_subarray(int ndims,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_subarray( ndims, size_array, subsize_array, start_array,
                                         order, oldtype, newtype);
@@ -85,7 +84,6 @@ int MPI_Type_create_subarray(int ndims,
                                 MPI_COMBINER_SUBARRAY );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
 
     OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/type_delete_attr.c
+++ b/ompi/mpi/c/type_delete_attr.c
@@ -54,8 +54,6 @@ int MPI_Type_delete_attr (MPI_Datatype type, int type_keyval)
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
-
    ret = ompi_attr_delete(TYPE_ATTR, type, type->d_keyhash, type_keyval,
                           false);
    OMPI_ERRHANDLER_RETURN(ret, MPI_COMM_WORLD,

--- a/ompi/mpi/c/type_dup.c
+++ b/ompi/mpi/c/type_dup.c
@@ -53,7 +53,6 @@ int MPI_Type_dup (MPI_Datatype type,
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
 
    if (OMPI_SUCCESS != ompi_datatype_duplicate( type, newtype)) {
        ompi_datatype_destroy( newtype );
@@ -80,7 +79,6 @@ int MPI_Type_dup (MPI_Datatype type,
        }
    }
 
-   OPAL_CR_EXIT_LIBRARY();
 
    return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_extent.c
+++ b/ompi/mpi/c/type_extent.c
@@ -54,8 +54,6 @@ int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   rc = ompi_datatype_get_extent( type, &lb, extent );
   OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 }

--- a/ompi/mpi/c/type_f2c.c
+++ b/ompi/mpi/c/type_f2c.c
@@ -46,8 +46,6 @@ MPI_Datatype MPI_Type_f2c(MPI_Fint datatype)
         memchecker_datatype(datatype);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/type_free.c
+++ b/ompi/mpi/c/type_free.c
@@ -54,7 +54,6 @@ int MPI_Type_free(MPI_Datatype *type)
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
 
    rc = ompi_datatype_destroy( type );
    if( rc != MPI_SUCCESS ) {
@@ -63,6 +62,5 @@ int MPI_Type_free(MPI_Datatype *type)
    }
    *type = MPI_DATATYPE_NULL;
 
-   OPAL_CR_EXIT_LIBRARY();
    return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_free_keyval.c
+++ b/ompi/mpi/c/type_free_keyval.c
@@ -50,8 +50,6 @@ int MPI_Type_free_keyval(int *type_keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_attr_free_keyval(TYPE_ATTR, type_keyval, 0);
 
     OMPI_ERRHANDLER_RETURN(ret, MPI_COMM_WORLD,

--- a/ompi/mpi/c/type_get_attr.c
+++ b/ompi/mpi/c/type_get_attr.c
@@ -63,8 +63,6 @@ int MPI_Type_get_attr (MPI_Datatype type,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* This stuff is very confusing.  Be sure to see
        src/attribute/attribute.c for a lengthy comment explaining Open
        MPI attribute behavior. */

--- a/ompi/mpi/c/type_get_contents.c
+++ b/ompi/mpi/c/type_get_contents.c
@@ -64,7 +64,6 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_get_args( mtype, 1, &max_integers, array_of_integers,
                             &max_addresses, array_of_addresses,
@@ -89,6 +88,5 @@ int MPI_Type_get_contents(MPI_Datatype mtype,
         }
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_get_envelope.c
+++ b/ompi/mpi/c/type_get_envelope.c
@@ -60,8 +60,6 @@ int MPI_Type_get_envelope(MPI_Datatype type,
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
-
    rc = ompi_datatype_get_args( type, 0, num_integers, NULL, num_addresses, NULL,
                            num_datatypes, NULL, combiner );
    OMPI_ERRHANDLER_RETURN( rc, MPI_COMM_WORLD, rc, FUNC_NAME );

--- a/ompi/mpi/c/type_get_extent.c
+++ b/ompi/mpi/c/type_get_extent.c
@@ -54,8 +54,6 @@ int MPI_Type_get_extent(MPI_Datatype type, MPI_Aint *lb, MPI_Aint *extent)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   rc = ompi_datatype_get_extent( type, lb, extent );
   OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 }

--- a/ompi/mpi/c/type_get_extent_x.c
+++ b/ompi/mpi/c/type_get_extent_x.c
@@ -55,8 +55,6 @@ int MPI_Type_get_extent_x(MPI_Datatype type, MPI_Count *lb, MPI_Count *extent)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   rc = ompi_datatype_get_extent( type, &alb, &aextent );
   if (OMPI_SUCCESS == rc) {
     *lb = (MPI_Count) alb;

--- a/ompi/mpi/c/type_get_name.c
+++ b/ompi/mpi/c/type_get_name.c
@@ -46,8 +46,6 @@ int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen)
         memchecker_datatype(type);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
    if ( MPI_PARAM_CHECK ) {
       OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
       if (NULL == type || MPI_DATATYPE_NULL == type) {

--- a/ompi/mpi/c/type_get_true_extent.c
+++ b/ompi/mpi/c/type_get_true_extent.c
@@ -58,8 +58,6 @@ int MPI_Type_get_true_extent(MPI_Datatype datatype,
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
-
    rc = ompi_datatype_get_true_extent( datatype, true_lb, true_extent );
    OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 }

--- a/ompi/mpi/c/type_get_true_extent_x.c
+++ b/ompi/mpi/c/type_get_true_extent_x.c
@@ -59,8 +59,6 @@ int MPI_Type_get_true_extent_x(MPI_Datatype datatype,
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
-
    rc = ompi_datatype_get_true_extent( datatype, &atrue_lb, &atrue_extent );
    if (OMPI_SUCCESS == rc) {
       *true_lb = (MPI_Count) atrue_lb;

--- a/ompi/mpi/c/type_indexed.c
+++ b/ompi/mpi/c/type_indexed.c
@@ -72,7 +72,6 @@ int MPI_Type_indexed(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_indexed ( count, array_of_blocklengths,
                                         array_of_displacements,
@@ -90,7 +89,6 @@ int MPI_Type_indexed(int count,
                                 MPI_COMBINER_INDEXED );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_lb.c
+++ b/ompi/mpi/c/type_lb.c
@@ -54,8 +54,6 @@ int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   rc = ompi_datatype_get_extent( type, lb, &extent );
   OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
 }

--- a/ompi/mpi/c/type_match_size.c
+++ b/ompi/mpi/c/type_match_size.c
@@ -43,7 +43,6 @@ int MPI_Type_match_size(int typeclass, int size, MPI_Datatype *type)
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     switch( typeclass ) {
     case MPI_TYPECLASS_REAL:
@@ -59,7 +58,6 @@ int MPI_Type_match_size(int typeclass, int size, MPI_Datatype *type)
         *type = &ompi_mpi_datatype_null.dt;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     if( *type != &ompi_mpi_datatype_null.dt ) {
         return MPI_SUCCESS;
     }

--- a/ompi/mpi/c/type_set_attr.c
+++ b/ompi/mpi/c/type_set_attr.c
@@ -56,8 +56,6 @@ int MPI_Type_set_attr (MPI_Datatype type,
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_attr_set_c(TYPE_ATTR, type, &type->d_keyhash,
                           type_keyval, attribute_val, false);
 

--- a/ompi/mpi/c/type_set_name.c
+++ b/ompi/mpi/c/type_set_name.c
@@ -49,8 +49,6 @@ int MPI_Type_set_name (MPI_Datatype type, const char *type_name)
         memchecker_datatype(type);
         );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == type || MPI_DATATYPE_NULL == type) {

--- a/ompi/mpi/c/type_size.c
+++ b/ompi/mpi/c/type_size.c
@@ -46,8 +46,6 @@ int MPI_Type_size(MPI_Datatype type, int *size)
         memchecker_datatype(type);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == type || MPI_DATATYPE_NULL == type) {

--- a/ompi/mpi/c/type_size_x.c
+++ b/ompi/mpi/c/type_size_x.c
@@ -46,8 +46,6 @@ int MPI_Type_size_x(MPI_Datatype type, MPI_Count *size)
         memchecker_datatype(type);
     );
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (NULL == type || MPI_DATATYPE_NULL == type) {

--- a/ompi/mpi/c/type_ub.c
+++ b/ompi/mpi/c/type_ub.c
@@ -55,8 +55,6 @@ int MPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
     }
   }
 
-  OPAL_CR_ENTER_LIBRARY();
-
   status = ompi_datatype_get_extent( mtype, &lb, &extent );
   if (MPI_SUCCESS == status) {
     *ub = lb + extent;

--- a/ompi/mpi/c/type_vector.c
+++ b/ompi/mpi/c/type_vector.c
@@ -65,7 +65,6 @@ int MPI_Type_vector(int count,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_datatype_create_vector ( count, blocklength, stride, oldtype, newtype );
     OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
@@ -76,6 +75,5 @@ int MPI_Type_vector(int count,
         ompi_datatype_set_args( *newtype, 3, a_i, 0, NULL, 1, &oldtype, MPI_COMBINER_VECTOR );
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/unpack.c
+++ b/ompi/mpi/c/unpack.c
@@ -74,7 +74,6 @@ int MPI_Unpack(const void *inbuf, int insize, int *position,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if( insize > 0 ) {
         OBJ_CONSTRUCT( &local_convertor, opal_convertor_t );
@@ -86,7 +85,6 @@ int MPI_Unpack(const void *inbuf, int insize, int *position,
         opal_convertor_get_packed_size( &local_convertor, &size );
         if( (*position + size) > (unsigned int)insize ) {
             OBJ_DESTRUCT( &local_convertor );
-            OPAL_CR_EXIT_LIBRARY();
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
         }
 

--- a/ompi/mpi/c/unpack_external.c
+++ b/ompi/mpi/c/unpack_external.c
@@ -66,7 +66,6 @@ int MPI_Unpack_external (const char datarep[], const void *inbuf, MPI_Aint insiz
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     OBJ_CONSTRUCT(&local_convertor, opal_convertor_t);
 
@@ -78,7 +77,6 @@ int MPI_Unpack_external (const char datarep[], const void *inbuf, MPI_Aint insiz
     opal_convertor_get_packed_size( &local_convertor, &size );
     if( (*position + size) > (unsigned int)insize ) {
         OBJ_DESTRUCT( &local_convertor );
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TRUNCATE, FUNC_NAME);
     }
 

--- a/ompi/mpi/c/unpublish_name.c
+++ b/ompi/mpi/c/unpublish_name.c
@@ -70,7 +70,6 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
     OBJ_CONSTRUCT(&pinfo, opal_list_t);
 
     /* OMPI supports info keys to pass the range to
@@ -109,13 +108,11 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
     if ( OPAL_SUCCESS != rc ) {
         if (OPAL_ERR_NOT_FOUND == rc) {
             /* service couldn't be found */
-            OPAL_CR_EXIT_LIBRARY();
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_SERVICE,
                                           FUNC_NAME);
         }
         if (OPAL_ERR_PERM == rc) {
             /* this process didn't own the specified service */
-            OPAL_CR_EXIT_LIBRARY();
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ACCESS,
                                           FUNC_NAME);
         }
@@ -123,11 +120,9 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
         /* none of the MPI-specific errors occurred - must be some
          * kind of internal error
          */
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_INTERN,
                                       FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/wait.c
+++ b/ompi/mpi/c/wait.c
@@ -65,7 +65,6 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_wait(request, status)) {
         /*
@@ -74,13 +73,11 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
         MEMCHECKER(
             opal_memchecker_base_mem_undefined(&status->MPI_ERROR, sizeof(int));
         );
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
     MEMCHECKER(
         opal_memchecker_base_mem_undefined(&status->MPI_ERROR, sizeof(int));
     );
-    OPAL_CR_EXIT_LIBRARY();
     return ompi_errhandler_request_invoke(1, request, FUNC_NAME);
 }

--- a/ompi/mpi/c/waitall.c
+++ b/ompi/mpi/c/waitall.c
@@ -71,19 +71,15 @@ int MPI_Waitall(int count, MPI_Request requests[], MPI_Status statuses[])
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_wait_all(count, requests, statuses)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
     if (MPI_SUCCESS !=
         ompi_errhandler_request_invoke(count, requests, FUNC_NAME)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_ERR_IN_STATUS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/waitany.c
+++ b/ompi/mpi/c/waitany.c
@@ -79,13 +79,10 @@ int MPI_Waitany(int count, MPI_Request requests[], int *indx, MPI_Status *status
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_wait_any(count, requests, indx, status)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return ompi_errhandler_request_invoke(count, requests, FUNC_NAME);
 }

--- a/ompi/mpi/c/waitsome.c
+++ b/ompi/mpi/c/waitsome.c
@@ -76,20 +76,16 @@ int MPI_Waitsome(int incount, MPI_Request requests[],
         return MPI_SUCCESS;
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     if (OMPI_SUCCESS == ompi_request_wait_some( incount, requests,
                                                 outcount, indices, statuses )) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_SUCCESS;
     }
 
     if (MPI_SUCCESS !=
         ompi_errhandler_request_invoke(incount, requests, FUNC_NAME)) {
-        OPAL_CR_EXIT_LIBRARY();
         return MPI_ERR_IN_STATUS;
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/win_allocate.c
+++ b/ompi/mpi/c/win_allocate.c
@@ -73,17 +73,14 @@ int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* create window and return */
     ret = ompi_win_allocate((size_t)size, disp_unit, info,
                             comm, baseptr, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_WIN, FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/win_allocate_shared.c
+++ b/ompi/mpi/c/win_allocate_shared.c
@@ -74,17 +74,14 @@ int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* create window and return */
     ret = ompi_win_allocate_shared((size_t)size, disp_unit, info,
                                    comm, baseptr, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;
-        OPAL_CR_EXIT_LIBRARY();
         OMPI_ERRHANDLER_RETURN (ret, comm, ret, FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/win_attach.c
+++ b/ompi/mpi/c/win_attach.c
@@ -54,8 +54,6 @@ int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_win_attach(win, base, size);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_c2f.c
+++ b/ompi/mpi/c/win_c2f.c
@@ -40,8 +40,6 @@ static const char FUNC_NAME[] = "MPI_Win_c2f";
 MPI_Fint MPI_Win_c2f(MPI_Win win)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if ( MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/win_call_errhandler.c
+++ b/ompi/mpi/c/win_call_errhandler.c
@@ -38,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Win_call_errhandler";
 int MPI_Win_call_errhandler(MPI_Win win, int errorcode)
 {
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/win_complete.c
+++ b/ompi/mpi/c/win_complete.c
@@ -48,8 +48,6 @@ int MPI_Win_complete(MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_complete(win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_create.c
+++ b/ompi/mpi/c/win_create.c
@@ -73,17 +73,14 @@ int MPI_Win_create(void *base, MPI_Aint size, int disp_unit,
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* create window and return */
     ret = ompi_win_create(base, (size_t)size, disp_unit, comm,
                           info, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_WIN, FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/win_create_dynamic.c
+++ b/ompi/mpi/c/win_create_dynamic.c
@@ -69,16 +69,13 @@ int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win)
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_COMM, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
 
     /* create_dynamic window and return */
     ret = ompi_win_create_dynamic(info, comm, win);
     if (OMPI_SUCCESS != ret) {
         *win = MPI_WIN_NULL;
-        OPAL_CR_EXIT_LIBRARY();
         return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_WIN, FUNC_NAME);
     }
 
-    OPAL_CR_EXIT_LIBRARY();
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/win_create_errhandler.c
+++ b/ompi/mpi/c/win_create_errhandler.c
@@ -50,8 +50,6 @@ int MPI_Win_create_errhandler(MPI_Win_errhandler_function *function,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Create and cache the errhandler.  Sets a refcount of 1. */
     *errhandler =
         ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_WIN,

--- a/ompi/mpi/c/win_create_keyval.c
+++ b/ompi/mpi/c/win_create_keyval.c
@@ -53,8 +53,6 @@ int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn,
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     copy_fn.attr_win_copy_fn = (MPI_Win_internal_copy_attr_function*)win_copy_attr_fn;
     del_fn.attr_win_delete_fn = win_delete_attr_fn;
 

--- a/ompi/mpi/c/win_delete_attr.c
+++ b/ompi/mpi/c/win_delete_attr.c
@@ -48,8 +48,6 @@ int MPI_Win_delete_attr(MPI_Win win, int win_keyval)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_attr_delete(WIN_ATTR, win, win->w_keyhash, win_keyval,
                            false);
     OMPI_ERRHANDLER_RETURN(ret, win, MPI_ERR_OTHER, FUNC_NAME);

--- a/ompi/mpi/c/win_detach.c
+++ b/ompi/mpi/c/win_detach.c
@@ -56,8 +56,6 @@ int MPI_Win_detach(MPI_Win win, const void *base)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_win_detach(win, base);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_f2c.c
+++ b/ompi/mpi/c/win_f2c.c
@@ -40,8 +40,6 @@ MPI_Win MPI_Win_f2c(MPI_Fint win)
 {
     int o_index= OMPI_FINT_2_INT(win);
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
     }

--- a/ompi/mpi/c/win_fence.c
+++ b/ompi/mpi/c/win_fence.c
@@ -54,8 +54,6 @@ int MPI_Win_fence(int assert, MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_fence(assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_flush.c
+++ b/ompi/mpi/c/win_flush.c
@@ -52,8 +52,6 @@ int MPI_Win_flush(int rank, MPI_Win win)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_flush(rank, win);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_flush_all.c
+++ b/ompi/mpi/c/win_flush_all.c
@@ -52,8 +52,6 @@ int MPI_Win_flush_all(MPI_Win win)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_flush_all(win);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_flush_local.c
+++ b/ompi/mpi/c/win_flush_local.c
@@ -52,8 +52,6 @@ int MPI_Win_flush_local(int rank, MPI_Win win)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_flush_local(rank, win);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_flush_local_all.c
+++ b/ompi/mpi/c/win_flush_local_all.c
@@ -52,8 +52,6 @@ int MPI_Win_flush_local_all(MPI_Win win)
         OMPI_ERRHANDLER_CHECK(ret, win, ret, FUNC_NAME);
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* create window and return */
     ret = win->w_osc_module->osc_flush_local_all(win);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);

--- a/ompi/mpi/c/win_free.c
+++ b/ompi/mpi/c/win_free.c
@@ -47,8 +47,6 @@ int MPI_Win_free(MPI_Win *win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_win_free(*win);
     if (OMPI_SUCCESS == ret) {
         *win = MPI_WIN_NULL;

--- a/ompi/mpi/c/win_free_keyval.c
+++ b/ompi/mpi/c/win_free_keyval.c
@@ -49,8 +49,6 @@ int MPI_Win_free_keyval(int *win_keyval)
       }
    }
 
-   OPAL_CR_ENTER_LIBRARY();
-
    ret = ompi_attr_free_keyval(WIN_ATTR, win_keyval, 0);
    OMPI_ERRHANDLER_RETURN(ret, MPI_COMM_WORLD, MPI_ERR_OTHER, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_get_attr.c
+++ b/ompi/mpi/c/win_get_attr.c
@@ -56,8 +56,6 @@ int MPI_Win_get_attr(MPI_Win win, int win_keyval,
        }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* This stuff is very confusing.  Be sure to see
        src/attribute/attribute.c for a lengthy comment explaining Open
        MPI attribute behavior. */

--- a/ompi/mpi/c/win_get_errhandler.c
+++ b/ompi/mpi/c/win_get_errhandler.c
@@ -40,8 +40,6 @@ int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler)
 {
     MPI_Errhandler tmp;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (ompi_win_invalid(win)) {

--- a/ompi/mpi/c/win_get_group.c
+++ b/ompi/mpi/c/win_get_group.c
@@ -49,8 +49,6 @@ int MPI_Win_get_group(MPI_Win win, MPI_Group *group)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_win_group(win, (ompi_group_t**) group);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_get_info.c
+++ b/ompi/mpi/c/win_get_info.c
@@ -48,8 +48,6 @@ int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = win->w_osc_module->osc_get_info(win, info_used);
 
     if (OMPI_SUCCESS == ret && *info_used) {

--- a/ompi/mpi/c/win_get_name.c
+++ b/ompi/mpi/c/win_get_name.c
@@ -50,8 +50,6 @@ int MPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     /* Note that MPI-2.1 requires:
        - terminating the string with a \0
        - name[*resultlen] == '\0'

--- a/ompi/mpi/c/win_lock.c
+++ b/ompi/mpi/c/win_lock.c
@@ -63,8 +63,6 @@ int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
     /* NTH: do not bother keeping track of locking MPI_PROC_NULL. */
     if (MPI_PROC_NULL == rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_lock(lock_type, rank, assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_lock_all.c
+++ b/ompi/mpi/c/win_lock_all.c
@@ -52,8 +52,6 @@ int MPI_Win_lock_all(int assert, MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_lock_all(assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_post.c
+++ b/ompi/mpi/c/win_post.c
@@ -51,8 +51,6 @@ int MPI_Win_post(MPI_Group group, int assert, MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_post(group, assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_set_attr.c
+++ b/ompi/mpi/c/win_set_attr.c
@@ -48,8 +48,6 @@ int MPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_attr_set_c(WIN_ATTR, win, &win->w_keyhash,
                           win_keyval, attribute_val, false);
     OMPI_ERRHANDLER_RETURN(ret, win, MPI_ERR_OTHER, FUNC_NAME);

--- a/ompi/mpi/c/win_set_errhandler.c
+++ b/ompi/mpi/c/win_set_errhandler.c
@@ -40,8 +40,6 @@ int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler)
 {
     MPI_Errhandler tmp;
 
-    OPAL_CR_NOOP_PROGRESS();
-
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 

--- a/ompi/mpi/c/win_set_info.c
+++ b/ompi/mpi/c/win_set_info.c
@@ -42,8 +42,6 @@ int MPI_Win_set_info(MPI_Win win, MPI_Info info)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = win->w_osc_module->osc_set_info(win, info);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_set_name.c
+++ b/ompi/mpi/c/win_set_name.c
@@ -53,8 +53,6 @@ int MPI_Win_set_name(MPI_Win win, const char *win_name)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = ompi_win_set_name(win, win_name);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_shared_query.c
+++ b/ompi/mpi/c/win_shared_query.c
@@ -43,8 +43,6 @@ int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, 
          }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     if (NULL != win->w_osc_module->osc_win_shared_query) {
         rc = win->w_osc_module->osc_win_shared_query(win, rank, &tsize, disp_unit, baseptr);
         *size = tsize;

--- a/ompi/mpi/c/win_start.c
+++ b/ompi/mpi/c/win_start.c
@@ -50,8 +50,6 @@ int MPI_Win_start(MPI_Group group, int assert, MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_start(group, assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_sync.c
+++ b/ompi/mpi/c/win_sync.c
@@ -51,8 +51,6 @@ int MPI_Win_sync(MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     ret = win->w_osc_module->osc_sync(win);
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_test.c
+++ b/ompi/mpi/c/win_test.c
@@ -48,8 +48,6 @@ int MPI_Win_test(MPI_Win win, int *flag)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_test(win, flag);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_unlock.c
+++ b/ompi/mpi/c/win_unlock.c
@@ -56,8 +56,6 @@ int MPI_Win_unlock(int rank, MPI_Win win)
     /* NTH: do not bother keeping track of unlocking MPI_PROC_NULL. */
     if (MPI_PROC_NULL == rank) return MPI_SUCCESS;
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_unlock(rank, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_unlock_all.c
+++ b/ompi/mpi/c/win_unlock_all.c
@@ -48,8 +48,6 @@ int MPI_Win_unlock_all(MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_unlock_all(win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_wait.c
+++ b/ompi/mpi/c/win_wait.c
@@ -48,8 +48,6 @@ int MPI_Win_wait(MPI_Win win)
         }
     }
 
-    OPAL_CR_ENTER_LIBRARY();
-
     rc = win->w_osc_module->osc_wait(win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/wtick.c
+++ b/ompi/mpi/c/wtick.c
@@ -38,8 +38,6 @@
 
 double MPI_Wtick(void)
 {
-    OPAL_CR_NOOP_PROGRESS();
-
 #if OPAL_TIMER_CYCLE_NATIVE
     return opal_timer_base_get_freq();
 #elif OPAL_TIMER_USEC_NATIVE

--- a/ompi/mpi/c/wtime.c
+++ b/ompi/mpi/c/wtime.c
@@ -52,7 +52,5 @@ double MPI_Wtime(void)
     wtime += (double)tv.tv_usec / 1000000.0;
 #endif
 
-    OPAL_CR_NOOP_PROGRESS();
-
     return wtime;
 }


### PR DESCRIPTION
Remove all of the references to OPAL_CR_ENTER_LIBRARY
and OPAL_CR_EXIT_LIBRARY in the 'c' interfaces
to Open MPI.

This commit addresses issue open-mpi/ompi#668

Conflicts:
    ompi/mpi/c/bsend.c
    ompi/mpi/c/cart_rank.c
    ompi/mpi/c/cart_sub.c
    ompi/mpi/c/rsend.c
    ompi/mpi/c/send.c
    ompi/mpi/c/ssend.c
