### PR TITLE
win: free windows in ompi_win_finalize

### DIFF
--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -33,6 +33,7 @@
 #include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/osc/osc.h"
 
+#include "ompi/runtime/params.h"
 
 /*
  * Table for Fortran <-> C communicator handle conversion.  Note that
@@ -70,10 +71,29 @@ ompi_win_init(void)
     return OMPI_SUCCESS;
 }
 
-
-int
-ompi_win_finalize(void)
+static void ompi_win_dump (ompi_win_t *win)
 {
+    opal_output(0, "Dumping information for window: %s\n", win->w_name);
+    opal_output(0,"  Fortran window handle: %d, window size: %d\n",
+                win->w_f_to_c_index, ompi_group_size (win->w_group));
+}
+
+int ompi_win_finalize(void)
+{
+    size_t size = opal_pointer_array_get_size (&ompi_mpi_windows);
+    /* start at 1 to skip win null */
+    for (size_t i = 1 ; i < size ; ++i) {
+        ompi_win_t *win =
+            (ompi_win_t *) opal_pointer_array_get_item (&ompi_mpi_windows, i);
+        if (NULL != win) {
+            if (ompi_debug_show_handle_leaks && !ompi_win_invalid(win)){
+                opal_output(0,"WARNING: MPI_Win still allocated in MPI_Finalize\n");
+                ompi_win_dump (win);
+            }
+            ompi_win_free (win);
+        }
+    }
+
     OBJ_DESTRUCT(&ompi_mpi_win_null.win);
     OBJ_DESTRUCT(&ompi_mpi_windows);
 


### PR DESCRIPTION
This commit frees any outstanding windows at ompi_win_finalize. If
ompi_debug_show_handle_leaks is set a warning message is printed out
indicating that a window is still allocated.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@d7205f90f136ee8b9b17e119ed44e0a29c7c1b2c)
