### PR TITLE
opal/mpool: add support for passing access flags to register

### DIFF
--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -247,28 +247,29 @@ typedef uint8_t mca_btl_base_tag_t;
 #define MCA_BTL_ERROR_FLAGS_NONFATAL 0x2
 #define MCA_BTL_ERROR_FLAGS_ADD_CUDA_IPC 0x4
 
-/** registration flags */
+/** registration flags. the access flags are a 1-1 mapping with the mpool
+ * access flags. */
 enum {
     /** Allow local write on the registered region. If a region is registered
      * with this flag the registration can be used as the local handle for a
      * btl_get operation. */
-    MCA_BTL_REG_FLAG_LOCAL_WRITE   = 0x00000001,
+    MCA_BTL_REG_FLAG_LOCAL_WRITE   = MCA_MPOOL_ACCESS_LOCAL_WRITE,
     /** Allow remote read on the registered region. If a region is registered
      * with this flag the registration can be used as the remote handle for a
      * btl_get operation. */
-    MCA_BTL_REG_FLAG_REMOTE_READ   = 0x00000002,
+    MCA_BTL_REG_FLAG_REMOTE_READ   = MCA_MPOOL_ACCESS_REMOTE_READ,
     /** Allow remote write on the registered region. If a region is registered
      * with this flag the registration can be used as the remote handle for a
      * btl_put operation. */
-    MCA_BTL_REG_FLAG_REMOTE_WRITE  = 0x00000004,
+    MCA_BTL_REG_FLAG_REMOTE_WRITE  = MCA_MPOOL_ACCESS_REMOTE_WRITE,
     /** Allow remote atomic operations on the registered region. If a region is
      * registered with this flag the registration can be used as the remote
      * handle for a btl_atomic_op or btl_atomic_fop operation. */
-    MCA_BTL_REG_FLAG_REMOTE_ATOMIC = 0x00000008,
+    MCA_BTL_REG_FLAG_REMOTE_ATOMIC = MCA_MPOOL_ACCESS_REMOTE_ATOMIC,
     /** Allow any btl operation on the registered region. If a region is registered
      * with this flag the registration can be used as the local or remote handle for
      * any btl operation. */
-    MCA_BTL_REG_FLAG_ACCESS_ANY    = 0x0000000f,
+    MCA_BTL_REG_FLAG_ACCESS_ANY    = MCA_MPOOL_ACCESS_ANY,
 #if OPAL_CUDA_GDR_SUPPORT
     /** Region is in GPU memory */
     MCA_BTL_REG_FLAG_CUDA_GPU_MEM  = 0x00010000,

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1705,6 +1705,7 @@ static mca_btl_base_registration_handle_t *mca_btl_openib_register_mem (mca_btl_
 {
     mca_btl_openib_reg_t *reg;
     uint32_t mflags = 0;
+    int access_flags = flags & MCA_BTL_REG_FLAG_ACCESS_ANY;
     int rc;
 
 #if OPAL_CUDA_GDR_SUPPORT
@@ -1713,7 +1714,7 @@ static mca_btl_base_registration_handle_t *mca_btl_openib_register_mem (mca_btl_
     }
 #endif /* OPAL_CUDA_GDR_SUPPORT */
 
-    rc = btl->btl_mpool->mpool_register (btl->btl_mpool, base, size, mflags,
+    rc = btl->btl_mpool->mpool_register (btl->btl_mpool, base, size, mflags, access_flags,
                                          (mca_mpool_base_registration_t **) &reg);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc || NULL == reg)) {
         return NULL;

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -586,11 +586,24 @@ static int openib_reg_mr(void *reg_data, void *base, size_t size,
 {
     mca_btl_openib_device_t *device = (mca_btl_openib_device_t*)reg_data;
     mca_btl_openib_reg_t *openib_reg = (mca_btl_openib_reg_t*)reg;
-    enum ibv_access_flags access_flag = (enum ibv_access_flags) (IBV_ACCESS_LOCAL_WRITE |
-        IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
+    enum ibv_access_flags access_flag = 0;
+
+    if (reg->access_flags & MCA_MPOOL_ACCESS_REMOTE_READ) {
+        access_flag |= IBV_ACCESS_REMOTE_READ;
+    }
+
+    if (reg->access_flags & MCA_MPOOL_ACCESS_REMOTE_WRITE) {
+        access_flag |= IBV_ACCESS_REMOTE_WRITE;
+    }
+
+    if (reg->access_flags & MCA_MPOOL_ACCESS_LOCAL_WRITE) {
+        access_flag |= IBV_ACCESS_LOCAL_WRITE;
+    }
 
 #if HAVE_DECL_IBV_ATOMIC_HCA
-    access_flag |= IBV_ACCESS_REMOTE_ATOMIC;
+    if (reg->access_flags & MCA_MPOOL_ACCESS_REMOTE_ATOMIC) {
+        access_flag |= IBV_ACCESS_REMOTE_ATOMIC;
+    }
 #endif
 
     if (device->mem_reg_max &&

--- a/opal/mca/btl/scif/btl_scif_module.c
+++ b/opal/mca/btl/scif/btl_scif_module.c
@@ -181,6 +181,7 @@ static mca_btl_base_registration_handle_t *mca_btl_scif_register_mem (struct mca
                                                                       void *base, size_t size, uint32_t flags)
 {
     mca_btl_scif_reg_t *scif_reg;
+    int access_flags = flags & MCA_BTL_REG_FLAG_ACCESS_ANY;
     int rc;
 
     if (MCA_BTL_ENDPOINT_ANY == endpoint) {
@@ -199,7 +200,7 @@ static mca_btl_base_registration_handle_t *mca_btl_scif_register_mem (struct mca
         }
     }
 
-    rc = btl->btl_mpool->mpool_register(btl->btl_mpool, base, size, 0,
+    rc = btl->btl_mpool->mpool_register(btl->btl_mpool, base, size, 0, access_flags,
                                         (mca_mpool_base_registration_t **) &scif_reg);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         return NULL;

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -1011,6 +1011,7 @@ static struct mca_btl_base_registration_handle_t *mca_btl_smcuda_register_mem (
     size_t size, uint32_t flags)
 {
     mca_mpool_common_cuda_reg_t *reg;
+    int access_flags = flags & MCA_BTL_REG_FLAG_ACCESS_ANY;
     int mpool_flags = 0;
 
     if (MCA_BTL_REG_FLAG_CUDA_GPU_MEM & flags) {
@@ -1018,7 +1019,7 @@ static struct mca_btl_base_registration_handle_t *mca_btl_smcuda_register_mem (
     }
 
     btl->btl_mpool->mpool_register (btl->btl_mpool, base, size, mpool_flags,
-                                    (mca_mpool_base_registration_t **) &reg);
+                                    access_flags, (mca_mpool_base_registration_t **) &reg);
     if (OPAL_UNLIKELY(NULL == reg)) {
         return NULL;
     }
@@ -1089,6 +1090,7 @@ int mca_btl_smcuda_get_cuda (struct mca_btl_base_module_t *btl,
      * support. */
     rc = ep->mpool->mpool_register(ep->mpool, remote_handle->reg_data.memh_seg_addr.pval,
                                    remote_handle->reg_data.memh_seg_len, ep->peer_smp_rank,
+                                   MCA_MPOOL_ACCESS_LOCAL_WRITE,
                                    (mca_mpool_base_registration_t **)&reg_ptr);
 
     if (OPAL_SUCCESS != rc) {

--- a/opal/mca/btl/ugni/btl_ugni_add_procs.c
+++ b/opal/mca/btl/ugni/btl_ugni_add_procs.c
@@ -230,15 +230,24 @@ static int ugni_reg_rdma_mem (void *reg_data, void *base, size_t size,
     mca_btl_ugni_module_t *ugni_module = (mca_btl_ugni_module_t *) reg_data;
     mca_btl_ugni_reg_t *ugni_reg = (mca_btl_ugni_reg_t *) reg;
     gni_return_t rc;
+    int flags;
 
     if (ugni_module->reg_count >= ugni_module->reg_max) {
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
+    if (reg->access_flags & (MCA_MPOOL_ACCESS_REMOTE_WRITE | MCA_MPOOL_ACCESS_LOCAL_WRITE |
+                             MCA_MPOOL_ACCESS_REMOTE_ATOMIC)) {
+        flags = GNI_MEM_READWRITE;
+    } else {
+        flags = GNI_MEM_READ_ONLY;
+    }
+
+    flags |= GNI_MEM_RELAXED_PI_ORDERING;
+
     OPAL_THREAD_LOCK(&ugni_module->device->dev_lock);
     rc = GNI_MemRegister (ugni_module->device->dev_handle, (uint64_t) base,
-                          size, NULL, GNI_MEM_READWRITE | GNI_MEM_RELAXED_PI_ORDERING,
-                          -1, &(ugni_reg->handle.gni_handle));
+                          size, NULL, flags, -1, &(ugni_reg->handle.gni_handle));
     OPAL_THREAD_UNLOCK(&ugni_module->device->dev_lock);
 
     if (OPAL_UNLIKELY(GNI_RC_SUCCESS != rc)) {

--- a/opal/mca/btl/ugni/btl_ugni_module.c
+++ b/opal/mca/btl/ugni/btl_ugni_module.c
@@ -302,9 +302,10 @@ mca_btl_ugni_register_mem (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *
                            size_t size, uint32_t flags)
 {
     mca_btl_ugni_reg_t *reg;
+    int access_flags = flags & MCA_BTL_REG_FLAG_ACCESS_ANY;
     int rc;
 
-    rc = btl->btl_mpool->mpool_register(btl->btl_mpool, base, size, 0,
+    rc = btl->btl_mpool->mpool_register(btl->btl_mpool, base, size, 0, access_flags,
                                         (mca_mpool_base_registration_t **) &reg);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
         return NULL;

--- a/opal/mca/btl/ugni/btl_ugni_prepare.h
+++ b/opal/mca/btl/ugni/btl_ugni_prepare.h
@@ -75,6 +75,7 @@ mca_btl_ugni_prepare_src_send_inplace (struct mca_btl_base_module_t *btl,
 
     if (OPAL_UNLIKELY(true == use_eager_get)) {
         rc = btl->btl_mpool->mpool_register(btl->btl_mpool, data_ptr, *size, 0,
+                                            MCA_MPOOL_ACCESS_REMOTE_READ,
                                             (mca_mpool_base_registration_t **)&registration);
         if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
             mca_btl_ugni_frag_return (frag);

--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -253,7 +253,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info)
             mpool_tree_item->regs[mpool_tree_item->count++] = registration;
         } else {
             if(mpool->mpool_register(mpool, mem, size, MCA_MPOOL_FLAGS_PERSIST,
-                        &registration) != OPAL_SUCCESS) {
+                                     MCA_MPOOL_ACCESS_ANY, &registration) != OPAL_SUCCESS) {
                 if(mpool_requested) {
                     unregister_tree_item(mpool_tree_item);
                     goto out;

--- a/opal/mca/mpool/gpusm/mpool_gpusm.h
+++ b/opal/mca/mpool/gpusm/mpool_gpusm.h
@@ -75,7 +75,7 @@ void mca_mpool_gpusm_module_init(mca_mpool_gpusm_module_t *mpool);
   * register block of memory
   */
 int mca_mpool_gpusm_register(mca_mpool_base_module_t* mpool, void *addr,
-        size_t size, uint32_t flags, mca_mpool_base_registration_t **reg);
+        size_t size, uint32_t flags, int32_t access_flags, mca_mpool_base_registration_t **reg);
 
 /**
  * deregister memory

--- a/opal/mca/mpool/gpusm/mpool_gpusm_module.c
+++ b/opal/mca/mpool/gpusm/mpool_gpusm_module.c
@@ -109,7 +109,7 @@ int mca_mpool_gpusm_find(mca_mpool_base_module_t *mpool, void *addr,
                          size_t size,
                          mca_mpool_base_registration_t **reg)
 {
-    return mca_mpool_gpusm_register(mpool, addr, size, 0, reg);
+    return mca_mpool_gpusm_register(mpool, addr, size, 0, 0, reg);
 }
 
 /*
@@ -119,7 +119,7 @@ int mca_mpool_gpusm_find(mca_mpool_base_module_t *mpool, void *addr,
  * deregister function is a no-op.
  */
 int mca_mpool_gpusm_register(mca_mpool_base_module_t *mpool, void *addr,
-                             size_t size, uint32_t flags,
+                             size_t size, uint32_t flags, int32_t access_flags,
                              mca_mpool_base_registration_t **reg)
 {
     mca_mpool_gpusm_module_t *mpool_gpusm = (mca_mpool_gpusm_module_t*)mpool;
@@ -147,6 +147,7 @@ int mca_mpool_gpusm_register(mca_mpool_base_module_t *mpool, void *addr,
     gpusm_reg->base = base;
     gpusm_reg->bound = bound;
     gpusm_reg->flags = flags;
+    gpusm_reg->access_flags = access_flags;
 
     rc = mpool_gpusm->resources.register_mem(base, size, gpusm_reg, NULL);
 

--- a/opal/mca/mpool/grdma/mpool_grdma.h
+++ b/opal/mca/mpool/grdma/mpool_grdma.h
@@ -112,7 +112,7 @@ void* mca_mpool_grdma_realloc( mca_mpool_base_module_t *mpool, void* addr,
   * register block of memory
   */
 int mca_mpool_grdma_register(mca_mpool_base_module_t* mpool, void *addr,
-        size_t size, uint32_t flags, mca_mpool_base_registration_t **reg);
+        size_t size, uint32_t flags, int32_t access_flags, mca_mpool_base_registration_t **reg);
 
 /**
  * deregister memory

--- a/opal/mca/mpool/mpool.h
+++ b/opal/mca/mpool/mpool.h
@@ -48,6 +48,14 @@ struct opal_info_t;
  * hooks (ptmalloc2, etc) are required. */
 #define MCA_MPOOL_FLAGS_NO_HOOKS          0x80
 
+/* access flags */
+enum {
+    MCA_MPOOL_ACCESS_LOCAL_WRITE   = 0x01,
+    MCA_MPOOL_ACCESS_REMOTE_READ   = 0x02,
+    MCA_MPOOL_ACCESS_REMOTE_WRITE  = 0x04,
+    MCA_MPOOL_ACCESS_REMOTE_ATOMIC = 0x08,
+    MCA_MPOOL_ACCESS_ANY           = 0x0f,
+};
 
 struct mca_mpool_base_resources_t;
 
@@ -63,6 +71,7 @@ struct mca_mpool_base_registration_t {
 #if OPAL_CUDA_GDR_SUPPORT
     unsigned long long gpu_bufID;
 #endif /* OPAL_CUDA_GDR_SUPPORT */
+    int32_t access_flags;
 };
 
 typedef struct mca_mpool_base_registration_t mca_mpool_base_registration_t;
@@ -110,6 +119,7 @@ typedef int (*mca_mpool_base_module_register_fn_t)(
     void * addr,
     size_t size,
     uint32_t flags,
+    int32_t access_flags,
     mca_mpool_base_registration_t** registration);
 
 /**

--- a/opal/mca/mpool/rgpusm/mpool_rgpusm.h
+++ b/opal/mca/mpool/rgpusm/mpool_rgpusm.h
@@ -79,7 +79,7 @@ void mca_mpool_rgpusm_module_init(mca_mpool_rgpusm_module_t *mpool);
   * register block of memory
   */
 int mca_mpool_rgpusm_register(mca_mpool_base_module_t* mpool, void *addr,
-        size_t size, uint32_t flags, mca_mpool_base_registration_t **reg);
+        size_t size, uint32_t flags, int32_t access_flags, mca_mpool_base_registration_t **reg);
 
 /**
  * deregister memory

--- a/opal/mca/mpool/rgpusm/mpool_rgpusm_module.c
+++ b/opal/mca/mpool/rgpusm/mpool_rgpusm_module.c
@@ -180,9 +180,9 @@ void mca_mpool_rgpusm_module_init(mca_mpool_rgpusm_module_t* mpool)
  * from the remote memory.  It uses the addr and size of the remote
  * memory for caching the registration.
  */
-int mca_mpool_rgpusm_register(mca_mpool_base_module_t *mpool, void *addr,
-                             size_t size, uint32_t flags,
-                             mca_mpool_base_registration_t **reg)
+int mca_mpool_rgpusm_register (mca_mpool_base_module_t *mpool, void *addr,
+                               size_t size, uint32_t flags, int32_t access_flags,
+                               mca_mpool_base_registration_t **reg)
 {
     mca_mpool_rgpusm_module_t *mpool_rgpusm = (mca_mpool_rgpusm_module_t*)mpool;
     mca_mpool_common_cuda_reg_t *rgpusm_reg;

--- a/opal/mca/mpool/udreg/mpool_udreg.h
+++ b/opal/mca/mpool/udreg/mpool_udreg.h
@@ -98,6 +98,9 @@ struct mca_mpool_udreg_module_t {
     mca_mpool_udreg_hugepage_t *huge_page;
     opal_mutex_t lock;
     void *udreg_handle;
+    /** used to communicate the access flags to the underlying registration
+     * function */
+    int requested_access_flags;
 };
 typedef struct mca_mpool_udreg_module_t mca_mpool_udreg_module_t;
 
@@ -129,7 +132,7 @@ void* mca_mpool_udreg_realloc( mca_mpool_base_module_t *mpool, void* addr,
   * register block of memory
   */
 int mca_mpool_udreg_register(mca_mpool_base_module_t* mpool, void *addr,
-        size_t size, uint32_t flags, mca_mpool_base_registration_t **reg);
+        size_t size, uint32_t flags, int32_t access_flags, mca_mpool_base_registration_t **reg);
 
 /**
  * deregister memory


### PR DESCRIPTION
This commit adds a access_flags argument to the mpool registration
function. This flag indicates what kind of access is being requested:
local write, remote read, remote write, and remote atomic. The values
of the registration access flags in the btl are tied to the new flags
in the mpool. All mpools have been updated to include the new argument
but only the grdma and udreg mpools have been updated to make use of
the access flags. In both mpools existing registrations are checked
for sufficient access before being returned. If a registration does
not contain sufficient access it is marked as invalid and a new
registration is generated.

:bot:assign: @bosilca 
:bot:label:enhancement
:bot:milestone:v2.0.0

(cherry-picked from open-mpi/ompi@59aa93e1b6b7e9a3548c4620e9cf031cfc608814)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
