### PR TITLE
osc-portals4: Initialize datatype in MPI_Get_accumulate and MPI_Rget_accumulate

### DIFF
--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -475,6 +475,11 @@ ompi_osc_portals4_rget_accumulate(const void *origin_addr,
                 OMPI_OSC_PORTALS4_REQUEST_RETURN(request);
                 return ret;
             }
+            ret = ompi_osc_portals4_get_dt(origin_dt, &ptl_dt);
+            if (OMPI_SUCCESS != ret) {
+                OMPI_OSC_PORTALS4_REQUEST_RETURN(request);
+                return ret;
+            }
             length *= origin_count;
 
             result_md_offset = (ptl_size_t) result_addr;
@@ -834,6 +839,10 @@ ompi_osc_portals4_get_accumulate(const void *origin_addr,
             ptl_size_t result_md_offset, origin_md_offset;
 
             ret = ompi_datatype_type_size(origin_dt, &length);
+            if (OMPI_SUCCESS != ret) {
+                return ret;
+            }
+            ret = ompi_osc_portals4_get_dt(origin_dt, &ptl_dt);
             if (OMPI_SUCCESS != ret) {
                 return ret;
             }


### PR DESCRIPTION
Fix code paths that didn't convert the MPI datatype to the
corresponding Portals4 datatype.

Thanks to Nicolas Chevalier (@shawone) for finding this bug and
submitting a patch.

(cherry picked from commit open-mpi/ompi@141b20d991f2d3023cfb264cd94dc1b6bd3fde79)

:bot:assign: @regrant 
:bot:label:bug
:bot:milestone:v2.0.0
