### PR TITLE
coll-portals4: allreduce: remove extra %d from error message.

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -265,7 +265,7 @@ allreduce_kary_tree_top(const void *sendbuf, void *recvbuf, int count,
                             ompi_coll_portals4_get_peer(comm, child[i]),
                             mca_coll_portals4_component.pt_idx,
                             match_bits_rtr, 0, NULL, 0)) != PTL_OK)
-                        return opal_stderr("Put RTR failed %d", __FILE__, __LINE__, ret);
+                        return opal_stderr("Put RTR failed", __FILE__, __LINE__, ret);
                 }
             }
         }


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@f33b0c1cdf5befff6995bfd8ae4973a8e11febf0)

:bot:assign: @regrant 
:bot:label:code cleanup
:bot:milestone:v2.0.0
