### PR TITLE
v2.0.0: fix libevent hwloc includedirs

### DIFF
--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -176,7 +176,7 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
     # Finally, add some flags to the wrapper compiler if we're
     # building with developer headers so that our headers can
     # be found.
-    event_libevent2022_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/openmpi/opal/mca/event/libevent2022/libevent -I${pkgincludedir}/openmpi/opal/mca/event/libevent2022/libevent/include'
+    event_libevent2022_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/opal/mca/event/libevent2022/libevent -I${pkgincludedir}/opal/mca/event/libevent2022/libevent/include'
 
     CFLAGS="$CFLAGS_save"
     CPPFLAGS="$CPPFLAGS_save"

--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
 #
@@ -176,7 +176,7 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
     # Finally, add some flags to the wrapper compiler if we're
     # building with developer headers so that our headers can
     # be found.
-    event_libevent2022_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi/opal/mca/event/libevent2022/libevent -I${includedir}/openmpi/opal/mca/event/libevent2022/libevent/include'
+    event_libevent2022_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/openmpi/opal/mca/event/libevent2022/libevent -I${pkgincludedir}/openmpi/opal/mca/event/libevent2022/libevent/include'
 
     CFLAGS="$CFLAGS_save"
     CPPFLAGS="$CPPFLAGS_save"

--- a/opal/mca/hwloc/hwloc1110/configure.m4
+++ b/opal/mca/hwloc/hwloc1110/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
 #
 # $COPYRIGHT$
@@ -158,7 +158,7 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1110_CONFIG],[
         # headers can be found.
         hwloc_hwloc1110_WRAPPER_EXTRA_LDFLAGS="$HWLOC_EMBEDDED_LDFLAGS"
         hwloc_hwloc1110_WRAPPER_EXTRA_LIBS="$HWLOC_EMBEDDED_LIBS"
-        hwloc_hwloc1110_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi/'"$opal_hwloc_hwloc1110_basedir/hwloc/include"
+        hwloc_hwloc1110_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/'"$opal_hwloc_hwloc1110_basedir/hwloc/include"
     fi
 
     # Done!

--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
@@ -75,6 +75,8 @@ struct options_data_t {
     char *req_file;
     char *path_includedir;
     char *path_libdir;
+    char *path_opalincludedir;
+    char *path_opallibdir;
 };
 
 static struct options_data_t *options_data = NULL;
@@ -124,6 +126,8 @@ options_data_init(struct options_data_t *data)
     data->req_file = NULL;
     data->path_includedir = NULL;
     data->path_libdir = NULL;
+    data->path_opalincludedir = NULL;
+    data->path_opallibdir = NULL;
 }
 
 static void
@@ -150,6 +154,8 @@ options_data_free(struct options_data_t *data)
     if (NULL != data->req_file) free(data->req_file);
     if (NULL != data->path_includedir) free(data->path_includedir);
     if (NULL != data->path_libdir) free(data->path_libdir);
+    if (NULL != data->path_opalincludedir) free(data->path_opalincludedir);
+    if (NULL != data->path_opallibdir) free(data->path_opallibdir);
 }
 
 static void
@@ -325,6 +331,30 @@ data_callback(const char *key, const char *value)
             char *line;
             asprintf(&line, OPAL_LIBDIR_FLAG"%s",
                      options_data[parse_options_idx].path_libdir);
+            opal_argv_append_nosize(&options_data[parse_options_idx].link_flags, line);
+            free(line);
+        }
+    } else if (0 == strcmp(key, "opalincludedir")) {
+        printf("EXPANDING!\n");
+        if (NULL != value) {
+            options_data[parse_options_idx].path_opalincludedir =
+                opal_install_dirs_expand(value);
+            if (0 != strcmp(options_data[parse_options_idx].path_opalincludedir, "/usr/include") ||
+                0 == strncmp(options_data[parse_options_idx].language, "Fortran", strlen("Fortran"))) {
+                char *line;
+                asprintf(&line, OPAL_INCLUDE_FLAG"%s",
+                         options_data[parse_options_idx].path_opalincludedir);
+                opal_argv_append_nosize(&options_data[parse_options_idx].preproc_flags, line);
+                free(line);
+            }
+        }
+    } else if (0 == strcmp(key, "opallibdir")) {
+        if (NULL != value) options_data[parse_options_idx].path_opallibdir =
+                               opal_install_dirs_expand(value);
+        if (0 != strcmp(options_data[parse_options_idx].path_opallibdir, "/usr/lib")) {
+            char *line;
+            asprintf(&line, OPAL_LIBDIR_FLAG"%s",
+                     options_data[parse_options_idx].path_opallibdir);
             opal_argv_append_nosize(&options_data[parse_options_idx].link_flags, line);
             free(line);
         }


### PR DESCRIPTION
This PR corresponds to open-mpi/ompi#1013.  It fixes issues with libevent's and hwloc's includedirs that are given to the wrapper compilers.

Master commits:
- open-mpi/ompi@e8b4a4c 
- open-mpi/ompi@1dfb685
- open-mpi/ompi@12e796d

@rhc54 please verify on the v2.x branch; thanks.
