### PR TITLE
v1.10 MPI_Aint functions

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1166,6 +1166,11 @@ OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
 #define MPI_TYPECLASS_REAL       2
 #define MPI_TYPECLASS_COMPLEX    3
 
+/* Aint helper macros (MPI-3.1) */
+#define MPI_Aint_add(base, disp) ((MPI_Aint) ((char *) (base) + (disp)))
+#define MPI_Aint_diff(addr1, addr2) ((MPI_Aint) ((char *) (addr1) - (char *) (addr2)))
+#define PMPI_Aint_add(base, disp) MPI_Aint_add(base, disp)
+#define PMPI_Aint_diff(addr1, addr2) PMPI_Aint_diff(addr1, addr2)
 
 /*
  * MPI API

--- a/ompi/mpi/fortran/base/f90_accessors.c
+++ b/ompi/mpi/fortran/base/f90_accessors.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -43,6 +46,16 @@ OMPI_DECLSPEC void MPI_WTICK_F90(double *w);
 OMPI_DECLSPEC void mpi_wtick_f90(double *w);
 OMPI_DECLSPEC void mpi_wtick_f90_(double *w);
 OMPI_DECLSPEC void mpi_wtick_f90__(double *w);
+
+OMPI_DECLSPEC void MPI_AINT_ADD_F90(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_add_f90(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_add_f90_(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_add_f90__(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w);
+
+OMPI_DECLSPEC void MPI_AINT_DIFF_F90(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_diff_f90(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_diff_f90_(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w);
+OMPI_DECLSPEC void mpi_aint_diff_f90__(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w);
 
 /**********************************************************************/
 
@@ -88,3 +101,47 @@ void mpi_wtick_f90__(double *w)
     *w = MPI_Wtick();
 }
 
+/**********************************************************************/
+
+void MPI_AINT_ADD_F90(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w)
+{
+    *w = MPI_Aint_add (*base, *diff);
+}
+
+void mpi_aint_add_f90(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w)
+{
+    *w = MPI_Aint_add (*base, *diff);
+}
+
+void mpi_aint_add_f90_(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w)
+{
+    *w = MPI_Aint_add (*base, *diff);
+}
+
+void mpi_aint_add_f90__(MPI_Aint *base, MPI_Aint *diff, MPI_Aint *w)
+{
+    *w = MPI_Aint_add (*base, *diff);
+}
+
+
+/**********************************************************************/
+
+void MPI_AINT_DIFF_F90(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w)
+{
+    *w = MPI_Aint_diff (*addr1, *addr2);
+}
+
+void mpi_aint_diff_f90(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w)
+{
+    *w = MPI_Aint_diff (*addr1, *addr2);
+}
+
+void mpi_aint_diff_f90_(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w)
+{
+    *w = MPI_Aint_diff (*addr1, *addr2);
+}
+
+void mpi_aint_diff_f90__(MPI_Aint *addr1, MPI_Aint *addr2, MPI_Aint *w)
+{
+    *w = MPI_Aint_diff (*addr1, *addr2);
+}

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -144,6 +144,8 @@ libmpi_mpifh_la_SOURCES += \
         add_error_code_f.c \
         add_error_string_f.c \
         address_f.c \
+        aint_add_f.c \
+        aint_diff_f.c \
         allgather_f.c \
         allgatherv_f.c \
         alloc_mem_f.c \

--- a/ompi/mpi/fortran/mpif-h/aint_add_f.c
+++ b/ompi/mpi/fortran/mpif-h/aint_add_f.c
@@ -30,35 +30,35 @@
  * manually.
  */
 #if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILE_LAYER
-#pragma weak PMPI_WTIME = ompi_wtime_f
-#pragma weak pmpi_wtime = ompi_wtime_f
-#pragma weak pmpi_wtime_ = ompi_wtime_f
-#pragma weak pmpi_wtime__ = ompi_wtime_f
+#pragma weak PMPI_AINT_ADD = ompi_aint_add_f
+#pragma weak pmpi_aint_add = ompi_aint_add_f
+#pragma weak pmpi_aint_add_ = ompi_aint_add_f
+#pragma weak pmpi_aint_add__ = ompi_aint_add_f
 
-#pragma weak PMPI_Wtime_f = ompi_wtime_f
-#pragma weak PMPI_Wtime_f08 = ompi_wtime_f
+#pragma weak PMPI_Aint_add_f = ompi_aint_add_f
+#pragma weak PMPI_Aint_add_f08 = ompi_aint_add_f
 #elif OMPI_PROFILE_LAYER
-double PMPI_WTIME(void) { return pompi_wtime_f(); }
-double pmpi_wtime(void) { return pompi_wtime_f(); }
-double pmpi_wtime_(void) { return pompi_wtime_f(); }
-double pmpi_wtime__(void) { return pompi_wtime_f(); }
+MPI_Aint PMPI_AINT_ADD(MPI_Aint *base, MPI_Aint *diff) { return pompi_aint_add_f(base, diff); }
+MPI_Aint pmpi_aint_add(MPI_Aint *base, MPI_Aint *diff) { return pompi_aint_add_f(base, diff); }
+MPI_Aint pmpi_aint_add_(MPI_Aint *base, MPI_Aint *diff) { return pompi_aint_add_f(base, diff); }
+MPI_Aint pmpi_aint_add__(MPI_Aint *base, MPI_Aint *diff) { return pompi_aint_add_f(base, diff); }
 #endif
 
 #if OPAL_HAVE_WEAK_SYMBOLS
-#pragma weak MPI_WTIME = ompi_wtime_f
-#pragma weak mpi_wtime = ompi_wtime_f
-#pragma weak mpi_wtime_ = ompi_wtime_f
-#pragma weak mpi_wtime__ = ompi_wtime_f
+#pragma weak MPI_AINT_ADD = ompi_aint_add_f
+#pragma weak mpi_aint_add = ompi_aint_add_f
+#pragma weak mpi_aint_add_ = ompi_aint_add_f
+#pragma weak mpi_aint_add__ = ompi_aint_add_f
 
-#pragma weak MPI_Wtime_f = ompi_wtime_f
-#pragma weak MPI_Wtime_f08 = ompi_wtime_f
+#pragma weak MPI_Aint_add_f = ompi_aint_add_f
+#pragma weak MPI_Aint_add_f08 = ompi_aint_add_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER
-double MPI_WTIME(void) { return ompi_wtime_f(); }
-double mpi_wtime(void) { return ompi_wtime_f(); }
-double mpi_wtime_(void) { return ompi_wtime_f(); }
-double mpi_wtime__(void) { return ompi_wtime_f(); }
+MPI_Aint MPI_AINT_ADD(MPI_Aint *base, MPI_Aint *diff) { return ompi_aint_add_f(base, diff); }
+MPI_Aint mpi_aint_add(MPI_Aint *base, MPI_Aint *diff) { return ompi_aint_add_f(base, diff); }
+MPI_Aint mpi_aint_add_(MPI_Aint *base, MPI_Aint *diff) { return ompi_aint_add_f(base, diff); }
+MPI_Aint mpi_aint_add__(MPI_Aint *base, MPI_Aint *diff) { return ompi_aint_add_f(base, diff); }
 #endif
 
 
@@ -66,7 +66,7 @@ double mpi_wtime__(void) { return ompi_wtime_f(); }
 #include "ompi/mpi/fortran/mpif-h/profile/defines.h"
 #endif
 
-double ompi_wtime_f(void)
+MPI_Aint ompi_aint_add_f(MPI_Aint *base, MPI_Aint *diff)
 {
-    return MPI_Wtime();
+    return MPI_Aint_add (*base, *diff);
 }

--- a/ompi/mpi/fortran/mpif-h/aint_diff_f.c
+++ b/ompi/mpi/fortran/mpif-h/aint_diff_f.c
@@ -30,35 +30,35 @@
  * manually.
  */
 #if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILE_LAYER
-#pragma weak PMPI_WTIME = ompi_wtime_f
-#pragma weak pmpi_wtime = ompi_wtime_f
-#pragma weak pmpi_wtime_ = ompi_wtime_f
-#pragma weak pmpi_wtime__ = ompi_wtime_f
+#pragma weak PMPI_AINT_DIFF = ompi_aint_diff_f
+#pragma weak pmpi_aint_diff = ompi_aint_diff_f
+#pragma weak pmpi_aint_diff_ = ompi_aint_diff_f
+#pragma weak pmpi_aint_diff__ = ompi_aint_diff_f
 
-#pragma weak PMPI_Wtime_f = ompi_wtime_f
-#pragma weak PMPI_Wtime_f08 = ompi_wtime_f
+#pragma weak PMPI_Aint_diff_f = ompi_aint_diff_f
+#pragma weak PMPI_Aint_diff_f08 = ompi_aint_diff_f
 #elif OMPI_PROFILE_LAYER
-double PMPI_WTIME(void) { return pompi_wtime_f(); }
-double pmpi_wtime(void) { return pompi_wtime_f(); }
-double pmpi_wtime_(void) { return pompi_wtime_f(); }
-double pmpi_wtime__(void) { return pompi_wtime_f(); }
+MPI_Aint PMPI_AINT_DIFF(MPI_Aint *addr1, MPI_Aint *addr2) { return pompi_aint_diff_f(addr1, addr2); }
+MPI_Aint pmpi_aint_diff(MPI_Aint *addr1, MPI_Aint *addr2) { return pompi_aint_diff_f(addr1, addr2); }
+MPI_Aint pmpi_aint_diff_(MPI_Aint *addr1, MPI_Aint *addr2) { return pompi_aint_diff_f(addr1, addr2); }
+MPI_Aint pmpi_aint_diff__(MPI_Aint *addr1, MPI_Aint *addr2) { return pompi_aint_diff_f(addr1, addr2); }
 #endif
 
 #if OPAL_HAVE_WEAK_SYMBOLS
-#pragma weak MPI_WTIME = ompi_wtime_f
-#pragma weak mpi_wtime = ompi_wtime_f
-#pragma weak mpi_wtime_ = ompi_wtime_f
-#pragma weak mpi_wtime__ = ompi_wtime_f
+#pragma weak MPI_AINT_DIFF = ompi_aint_diff_f
+#pragma weak mpi_aint_diff = ompi_aint_diff_f
+#pragma weak mpi_aint_diff_ = ompi_aint_diff_f
+#pragma weak mpi_aint_diff__ = ompi_aint_diff_f
 
-#pragma weak MPI_Wtime_f = ompi_wtime_f
-#pragma weak MPI_Wtime_f08 = ompi_wtime_f
+#pragma weak MPI_Aint_diff_f = ompi_aint_diff_f
+#pragma weak MPI_Aint_diff_f08 = ompi_aint_diff_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER
-double MPI_WTIME(void) { return ompi_wtime_f(); }
-double mpi_wtime(void) { return ompi_wtime_f(); }
-double mpi_wtime_(void) { return ompi_wtime_f(); }
-double mpi_wtime__(void) { return ompi_wtime_f(); }
+MPI_Aint MPI_AINT_DIFF(MPI_Aint *addr1, MPI_Aint *addr2) { return ompi_aint_diff_f(addr1, addr2); }
+MPI_Aint mpi_aint_diff(MPI_Aint *addr1, MPI_Aint *addr2) { return ompi_aint_diff_f(addr1, addr2); }
+MPI_Aint mpi_aint_diff_(MPI_Aint *addr1, MPI_Aint *addr2) { return ompi_aint_diff_f(addr1, addr2); }
+MPI_Aint mpi_aint_diff__(MPI_Aint *addr1, MPI_Aint *addr2) { return ompi_aint_diff_f(addr1, addr2); }
 #endif
 
 
@@ -66,7 +66,7 @@ double mpi_wtime__(void) { return ompi_wtime_f(); }
 #include "ompi/mpi/fortran/mpif-h/profile/defines.h"
 #endif
 
-double ompi_wtime_f(void)
+MPI_Aint ompi_aint_diff_f(MPI_Aint *addr1, MPI_Aint *addr2)
 {
-    return MPI_Wtime();
+    return MPI_Aint_diff (*addr1, *addr2);
 }

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -58,6 +58,8 @@ linked_files = \
         padd_error_code_f.c \
         padd_error_string_f.c \
         paddress_f.c \
+        paint_add_f.c \
+        paint_diff_f.c \
         pallgather_f.c \
         pallgatherv_f.c \
         palloc_mem_f.c \

--- a/ompi/mpi/fortran/mpif-h/profile/defines.h
+++ b/ompi/mpi/fortran/mpif-h/profile/defines.h
@@ -29,6 +29,8 @@
 #define ompi_add_error_code_f pompi_add_error_code_f
 #define ompi_add_error_string_f pompi_add_error_string_f
 #define ompi_address_f pompi_address_f
+#define ompi_aint_add_f pompi_aint_add_f
+#define ompi_aint_diff_f pompi_aint_diff_f
 #define ompi_allgather_f pompi_allgather_f
 #define ompi_allgatherv_f pompi_allgatherv_f
 #define ompi_alloc_mem_f pompi_alloc_mem_f

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2013 Universite Bordeaux 1
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  * 
@@ -85,6 +85,8 @@ PN2(void, MPI_Add_error_class, mpi_add_error_class, MPI_ADD_ERROR_CLASS, (MPI_Fi
 PN2(void, MPI_Add_error_code, mpi_add_error_code, MPI_ADD_ERROR_CODE, (MPI_Fint *errorclass, MPI_Fint *errorcode, MPI_Fint *ierr));
 PN2(void, MPI_Add_error_string, mpi_add_error_string, MPI_ADD_ERROR_STRING, (MPI_Fint *errorcode, char *string, MPI_Fint *ierr, int l));
 PN2(void, MPI_Address, mpi_address, MPI_ADDRESS, (char *location, MPI_Fint *address, MPI_Fint *ierr));
+PN2(MPI_Aint, MPI_Aint_add, mpi_aint_add, MPI_AINT_ADD, (MPI_Aint *base, MPI_Aint *diff));
+PN2(MPI_Aint, MPI_Aint_diff, mpi_aint_diff, MPI_AINT_DIFF, (MPI_Aint *addr1, MPI_Aint *addr2));
 PN2(void, MPI_Allgather, mpi_allgather, MPI_ALLGATHER, (char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype, char *recvbuf, MPI_Fint *recvcount, MPI_Fint *recvtype, MPI_Fint *comm, MPI_Fint *ierr));
 PN2(void, MPI_Allgatherv, mpi_allgatherv, MPI_ALLGATHERV, (char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype, char *recvbuf, MPI_Fint *recvcounts, MPI_Fint *displs, MPI_Fint *recvtype, MPI_Fint *comm, MPI_Fint *ierr));
 PN2(void, MPI_Alloc_mem, mpi_alloc_mem, MPI_ALLOC_MEM, (MPI_Aint *size, MPI_Fint *info, char *baseptr, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/wtick_f.c
+++ b/ompi/mpi/fortran/mpif-h/wtick_f.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -22,8 +25,9 @@
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
 
 /* The OMPI_GENERATE_F77_BINDINGS work only for the most common F77 bindings, the
- * one that does not return any value. There are 2 exceptions MPI_Wtick and MPI_Wtime.
- * For these 2 we can insert the bindings manually.
+ * one that does not return any value. There are 4 exceptions MPI_Wtick, MPI_Wtime,
+ * MPI_Aint_add, and MPI_Aint_diff. For these 4 we can insert the bindings
+ * manually.
  */
 #if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILE_LAYER
 #pragma weak PMPI_WTICK = ompi_wtick_f

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -90,6 +90,8 @@ mpi_api_files = \
         add_error_class_f08.F90 \
         add_error_code_f08.F90 \
         add_error_string_f08.F90 \
+        aint_add_f08.F90 \
+        aint_diff_f08.F90 \
         allgather_f08.F90 \
         allgatherv_f08.F90 \
         alloc_mem_f08.F90 \
@@ -438,6 +440,8 @@ pmpi_api_files = \
         profile/padd_error_class_f08.F90 \
         profile/padd_error_code_f08.F90 \
         profile/padd_error_string_f08.F90 \
+        profile/paint_add_f08.F90 \
+        profile/paint_diff_f08.F90 \
         profile/pallgather_f08.F90 \
         profile/pallgatherv_f08.F90 \
         profile/palloc_mem_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
@@ -1,0 +1,17 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+function MPI_Aint_add_f08(base,diff)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   use :: mpi_f08, only : ompi_aint_add_f
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
+   call ompi_aint_add_f (base, diff)
+end function MPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
@@ -1,17 +1,18 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function MPI_Aint_add_f08(base,diff)
+function MPI_Aint_add_f08(addr1, addr2)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_aint_add_f
    implicit none
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
-   call ompi_aint_add_f (base, diff)
+   INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_add_f08
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
+   MPI_Aint_add_f08 = ompi_aint_add_f(addr1, addr2)
 end function MPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/aint_diff_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/aint_diff_f08.F90
@@ -1,0 +1,17 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+function MPI_Aint_diff_f08(addr1,addr2)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   use :: mpi_f08, only ompi_aint_diff_f
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
+   call ompi_aint_diff_f (base, diff)
+end function MPI_Aint_diff_f08

--- a/ompi/mpi/fortran/use-mpi-f08/aint_diff_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/aint_diff_f08.F90
@@ -1,17 +1,18 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function MPI_Aint_diff_f08(addr1,addr2)
+function MPI_Aint_diff_f08(addr1, addr2)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
-   use :: mpi_f08, only ompi_aint_diff_f
+   use :: mpi_f08, only : ompi_aint_diff_f
    implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_diff_f08
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
-   call ompi_aint_diff_f (base, diff)
+   MPI_Aint_diff_f08 = ompi_aint_diff_f(addr1, addr2)
 end function MPI_Aint_diff_f08

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
@@ -1782,6 +1782,24 @@ function  ompi_wtime_f() &
    DOUBLE PRECISION :: ompi_wtime_f
 end function  ompi_wtime_f
 
+function  ompi_aint_add_f(base,diff) &
+   BIND(C, name="ompi_aint_add_f")
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
+   INTEGER(MPI_ADDRESS_KIND) :: ompi_aint_add_f
+end function  ompi_aint_add_f
+
+function  ompi_aint_diff_f(addr1,addr2) &
+   BIND(C, name="ompi_aint_diff_f")
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
+   INTEGER(MPI_ADDRESS_KIND) :: ompi_aint_diff_f
+end function  ompi_aint_diff_f
+
 subroutine ompi_abort_f(comm,errorcode,ierror) &
    BIND(C, name="ompi_abort_f")
    implicit none

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2012      The University of Tennessee and The University
@@ -1782,23 +1782,23 @@ function  ompi_wtime_f() &
    DOUBLE PRECISION :: ompi_wtime_f
 end function  ompi_wtime_f
 
-function  ompi_aint_add_f(base,diff) &
+function ompi_aint_add_f(base,diff) &
    BIND(C, name="ompi_aint_add_f")
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
    INTEGER(MPI_ADDRESS_KIND) :: ompi_aint_add_f
-end function  ompi_aint_add_f
+end function ompi_aint_add_f
 
-function  ompi_aint_diff_f(addr1,addr2) &
+function ompi_aint_diff_f(addr1,addr2) &
    BIND(C, name="ompi_aint_diff_f")
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
    INTEGER(MPI_ADDRESS_KIND) :: ompi_aint_diff_f
-end function  ompi_aint_diff_f
+end function ompi_aint_diff_f
 
 subroutine ompi_abort_f(comm,errorcode,ierror) &
    BIND(C, name="ompi_abort_f")

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f08-interfaces.F90
@@ -2456,6 +2456,26 @@ function  MPI_Wtime_f08( ) BIND(C,name="MPI_Wtime")
 end function MPI_Wtime_f08
 end interface MPI_Wtime
 
+interface MPI_Aint_add
+function  MPI_Aint_add_f08(base,diff)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: base
+   INTEGER(MPI_ADDRESS_KIND) :: diff
+   INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_add_f08
+end function MPI_Aint_add_f08
+end interface MPI_Aint_add
+
+interface MPI_Aint_diff
+function  MPI_Aint_diff_f08(addr1,addr2)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: addr1
+   INTEGER(MPI_ADDRESS_KIND) :: addr2
+   INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_diff_f08
+end function MPI_Aint_diff_f08
+end interface MPI_Aint_diff
+
 interface  MPI_Abort
 subroutine MPI_Abort_f08(comm,errorcode,ierror)
    use :: mpi_f08_types, only : MPI_Comm

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
@@ -1623,6 +1623,24 @@ end subroutine pompi_topo_test_f
 !   DOUBLE PRECISION :: MPI_Wtime_f
 !end function  MPI_Wtime_f
 
+function  pompi_aint_add_f(base,diff) &
+   BIND(C, name="pompi_aint_add_f")
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
+   INTEGER(MPI_ADDRESS_KIND) :: pompi_aint_add_f
+end function  pompi_aint_add_f
+
+function  pompi_aint_diff_f(addr1,addr2) &
+   BIND(C, name="pompi_aint_diff_f")
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
+   INTEGER(MPI_ADDRESS_KIND) :: pompi_aint_diff_f
+end function  pompi_aint_diff_f
+
 subroutine pompi_abort_f(comm,errorcode,ierror) &
    BIND(C, name="pompi_abort_f")
    implicit none

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2012      The University of Tennessee and The University
@@ -1623,23 +1623,23 @@ end subroutine pompi_topo_test_f
 !   DOUBLE PRECISION :: MPI_Wtime_f
 !end function  MPI_Wtime_f
 
-function  pompi_aint_add_f(base,diff) &
+function pompi_aint_add_f(base,diff) &
    BIND(C, name="pompi_aint_add_f")
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
    INTEGER(MPI_ADDRESS_KIND) :: pompi_aint_add_f
-end function  pompi_aint_add_f
+end function pompi_aint_add_f
 
-function  pompi_aint_diff_f(addr1,addr2) &
+function pompi_aint_diff_f(addr1,addr2) &
    BIND(C, name="pompi_aint_diff_f")
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
    INTEGER(MPI_ADDRESS_KIND) :: pompi_aint_diff_f
-end function  pompi_aint_diff_f
+end function pompi_aint_diff_f
 
 subroutine pompi_abort_f(comm,errorcode,ierror) &
    BIND(C, name="pompi_abort_f")

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2012      The University of Tennessee and The University
@@ -2431,23 +2431,21 @@ end function  PMPI_Wtime_f08
 end interface PMPI_Wtime
 
 interface PMPI_Aint_add
-function  PMPI_Aint_add_f08(base,diff)
+subroutine PMPI_Aint_add_f08(base,diff)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: base
    INTEGER(MPI_ADDRESS_KIND) :: diff
-   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
-end function PMPI_Aint_add_f08
+end subroutine PMPI_Aint_add_f08
 end interface PMPI_Aint_add
 
 interface PMPI_Aint_diff
-function  PMPI_Aint_diff_f08(addr1,addr2)
+subroutine PMPI_Aint_diff_f08(addr1,addr2)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: addr1
    INTEGER(MPI_ADDRESS_KIND) :: addr2
-   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_diff_f08
-end function PMPI_Aint_diff_f08
+end subroutine PMPI_Aint_diff_f08
 end interface PMPI_Aint_diff
 
 interface  PMPI_Abort

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
@@ -2430,6 +2430,26 @@ function  PMPI_Wtime_f08( ) BIND(C,name="PMPI_Wtime")
 end function  PMPI_Wtime_f08
 end interface PMPI_Wtime
 
+interface PMPI_Aint_add
+function  PMPI_Aint_add_f08(base,diff)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: base
+   INTEGER(MPI_ADDRESS_KIND) :: diff
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
+end function PMPI_Aint_add_f08
+end interface PMPI_Aint_add
+
+interface PMPI_Aint_diff
+function  PMPI_Aint_diff_f08(addr1,addr2)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: addr1
+   INTEGER(MPI_ADDRESS_KIND) :: addr2
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_diff_f08
+end function PMPI_Aint_diff_f08
+end interface PMPI_Aint_diff
+
 interface  PMPI_Abort
 subroutine PMPI_Abort_f08(comm,errorcode,ierror)
    use :: mpi_f08_types, only : MPI_Comm

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
@@ -1,17 +1,18 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function PMPI_Aint_add_f08(base,diff)
+function PMPI_Aint_add_f08(base, diff)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
-   use :: mpi_f08, only ompi_aint_add_f
+   use :: mpi_f08, only : ompi_aint_add_f
    implicit none
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
-   call ompi_aint_add_f (base, diff)
+   PMPI_Aint_add_f08 = ompi_aint_add_f(base, diff)
 end function PMPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
@@ -1,0 +1,17 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+function PMPI_Aint_add_f08(base,diff)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   use :: mpi_f08, only ompi_aint_add_f
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
+   call ompi_aint_add_f (base, diff)
+end function PMPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paint_diff_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paint_diff_f08.F90
@@ -1,0 +1,17 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+function PMPI_Aint_add_f08(base,diff)
+   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
+   use :: mpi_f08, only ompi_aint_add_f
+   implicit none
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
+   call ompi_aint_add_f (base, diff)
+end function PMPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paint_diff_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paint_diff_f08.F90
@@ -1,17 +1,18 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function PMPI_Aint_add_f08(base,diff)
+function PMPI_Aint_diff_f08(addr1, addr2)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
-   use :: mpi_f08, only ompi_aint_add_f
+   use :: mpi_f08, only : ompi_aint_diff_f
    implicit none
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
-   call ompi_aint_add_f (base, diff)
-end function PMPI_Aint_add_f08
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_diff_f08
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
+   PMPI_Aint_diff_f08 = ompi_aint_diff_f(addr1, addr2)
+end function PMPI_Aint_diff_f08

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -7,7 +7,7 @@
 !                         of Tennessee Research Foundation.  All rights
 !                         reserved.
 ! Copyright (c) 2012      Inria.  All rights reserved.
-! Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
+! Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
 !                         reserved.
 ! $COPYRIGHT$
 !
@@ -161,6 +161,49 @@ end subroutine PMPI_Address
 
 end interface
 
+interface MPI_Aint_add
+
+function MPI_Aint_add(base, diff)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND) :: base
+  integer(kind=MPI_ADDRESS_KIND) :: diff
+  integer(kind=MPI_ADDRESS_KIND) MPI_Aint_add
+end function MPI_Aint_add
+
+end interface
+
+interface PMPI_Aint_add
+
+function PMPI_Aint_add(base, diff)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND) :: base
+  integer(kind=MPI_ADDRESS_KIND) :: diff
+  integer(kind=MPI_ADDRESS_KIND) PMPI_Aint_add
+end function PMPI_Aint_add
+
+end interface
+
+interface MPI_Aint_diff
+
+function MPI_Aint_diff(addr1, addr2)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND) :: addr1
+  integer(kind=MPI_ADDRESS_KIND) :: addr2
+  integer(kind=MPI_ADDRESS_KIND) MPI_Aint_diff
+end function MPI_Aint_diff
+
+end interface
+
+interface PMPI_Aint_diff
+
+function PMPI_Aint_diff(addr1, addr2)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND) :: addr1
+  integer(kind=MPI_ADDRESS_KIND) :: addr2
+  integer(kind=MPI_ADDRESS_KIND) PMPI_Aint_diff
+end function PMPI_Aint_diff
+
+end interface
 
 interface MPI_Allgather
 

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -67,6 +67,8 @@ mpi.lo: mpi-f90-cptr-interfaces.F90
 
 libmpi_usempi_la_SOURCES = \
      mpi.F90 \
+     mpi_aint_add_f90.f90 \
+     mpi_aint_diff_f90.f90 \
      mpi_comm_spawn_multiple_f90.f90 \
      mpi_testall_f90.f90 \
      mpi_testsome_f90.f90 \

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
@@ -78,6 +78,27 @@ end subroutine MPI_Add_error_string
 
 end interface
 
+interface MPI_Aint_add
+
+function MPI_Aint_add(base, diff)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: base
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: diff
+  integer(kind=MPI_ADDRESS_KIND) MPI_Aint_add
+end function MPI_Aint_add
+
+end interface
+
+interface MPI_Aint_diff
+
+function MPI_Aint_diff(addr1, addr2)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: addr1
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: addr2
+  integer(kind=MPI_ADDRESS_KIND) MPI_Aint_diff
+end function MPI_Aint_diff
+
+end interface
 
 interface MPI_Attr_delete
 

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi_aint_add_f90.f90
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi_aint_add_f90.f90
@@ -1,0 +1,31 @@
+! -*- fortran -*-
+!
+! Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+!                         University Research and Technology
+!                         Corporation.  All rights reserved.
+! Copyright (c) 2004-2005 The University of Tennessee and The University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+!                         University of Stuttgart.  All rights reserved.
+! Copyright (c) 2004-2005 The Regents of the University of California.
+!                         All rights reserved.
+! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+function MPI_Aint_add(base, diff)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: base
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: diff
+  integer(kind=MPI_ADDRESS_KIND) :: MPI_Aint_add,foo
+  call MPI_Aint_add_f90(base,diff,foo)
+  MPI_Aint_add = foo
+end function MPI_Aint_add
+

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi_aint_diff_f90.f90
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi_aint_diff_f90.f90
@@ -1,0 +1,31 @@
+! -*- fortran -*-
+!
+! Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+!                         University Research and Technology
+!                         Corporation.  All rights reserved.
+! Copyright (c) 2004-2005 The University of Tennessee and The University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+!                         University of Stuttgart.  All rights reserved.
+! Copyright (c) 2004-2005 The Regents of the University of California.
+!                         All rights reserved.
+! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+function MPI_Aint_diff(addr1, addr2)
+  include 'mpif-config.h'
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: addr1
+  integer(kind=MPI_ADDRESS_KIND), intent(in) :: addr2
+  integer(kind=MPI_ADDRESS_KIND) :: MPI_Aint_diff,foo
+  call MPI_Aint_diff_f90(addr1,addr2,foo)
+  MPI_Aint_diff = foo
+end function MPI_Aint_diff
+

--- a/ompi/mpi/man/man3/MPI_Aint_add.3in
+++ b/ompi/mpi/man/man3/MPI_Aint_add.3in
@@ -19,7 +19,7 @@ MPI_Aint MPI_Aint_add(MPI_Aint \fIbase\fP, MPI_Aint \fIdisp\fP)
 MPI_Aint MPI_Aint_diff(MPI_Aint \fIaddr1\fP, MPI_Aint \fIaddr2\fP)
 
 .fi
-.SH Fortran Syntax (see FORTRAN 77 NOTES)
+.SH Fortran Syntax
 .nf
 INCLUDE 'mpif.h'
 INTEGER(KIND=MPI_ADDRESS_KIND) MPI_AINT_ADD(\fIBASE, DISP\fP)
@@ -76,22 +76,6 @@ calculated in a manner that results in the signed difference from
 \fIaddr1\fP to \fIaddr2\fP, as if the process that originally produced
 the addresses had called (char *) \fIaddr1\fP - (char *) \fIaddr2\fP
 on the addresses initially passed to \fBMPI_Get_address\fP.
-
-.SH FORTRAN 77 NOTES
-.ft R
-The MPI standard prescribes portable Fortran syntax for all arguments
-only for Fortran 90.  FORTRAN 77 users may use the non-portable
-syntax:
-.sp
-.nf
-     INTEGER*MPI_ADDRESS_KIND \fIBASE\fP
-     INTEGER*MPI_ADDRESS_KIND \fIDISP\fP
-     INTEGER*MPI_ADDRESS_KIND \fIADDR1\fP
-     INTEGER*MPI_ADDRESS_KIND \fIADDR2\fP
-.fi
-.sp
-where MPI_ADDRESS_KIND is a constant defined in mpif.h
-and gives the length of the declared integer in bytes.
 
 .SH SEE ALSO
 .ft R

--- a/ompi/mpi/man/man3/MPI_Aint_add.3in
+++ b/ompi/mpi/man/man3/MPI_Aint_add.3in
@@ -1,0 +1,99 @@
+.\" -*- nroff -*-
+.\" Copyright 2013-2015 Los Alamos National Security, LLC. All rights reserved.
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Aint_add 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Aint_add\fP, \fBMPI_Aint_diff\fP \- Portable functions for
+arithmetic on MPI_Aint values.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+MPI_Aint MPI_Aint_add(MPI_Aint \fIbase\fP, MPI_Aint \fIdisp\fP)
+
+MPI_Aint MPI_Aint_diff(MPI_Aint \fIaddr1\fP, MPI_Aint \fIaddr2\fP)
+
+.fi
+.SH Fortran Syntax (see FORTRAN 77 NOTES)
+.nf
+INCLUDE 'mpif.h'
+INTEGER(KIND=MPI_ADDRESS_KIND) MPI_AINT_ADD(\fIBASE, DISP\fP)
+        INTEGER(KIND=MPI_ADDRESS_KIND) \fIBASE, DISP\fP
+
+INTEGER(KIND=MPI_ADDRESS_KIND) MPI_AINT_DIFF(\fIADDR1, ADDR2\fP)
+        INTEGER(KIND=MPI_ADDRESS_KIND) \fIADDR1, ADDR2\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+base
+Base address (integer).
+.ft R
+.TP 1i
+disp
+Displacement (integer).
+.ft R
+.TP 1i
+addr1
+Minuend address (integer).
+.ft R
+.TP
+addr2
+Subtrahend address (integer).
+
+.SH DESCRIPTION
+.ft R
+\fBMPI_Aint_add\fP produces a new MPI_Aint value that is equivalent to the sum of
+the \fIbase\fP and \fIdisp\fP arguments, where \fIbase\fP represents
+a base address returned by a call to \fBMPI_Get_address\fP and
+\fIdisp\fP represents a signed integer displacement. The resulting
+address is valid only at the process that generated \fIbase\fP, and it
+must correspond to a location in the same object referenced by
+\fIbase\fP, as described in MPI-3.1 \[char167] 4.1.12. The addition is
+performed in a manner that results in the correct MPI_Aint
+representation of the output address, as if the process that
+originally produced \fIbase\fP had called:
+
+.nf
+        \fBMPI_Get_address\fP ((char *) \fIbase\fP + \fIdisp\fP, &\fIresult\fP);
+.fi
+.sp
+.ft R
+\fBMPI_Aint_diff\fP produces a new MPI_Aint value that is equivalent
+to the difference between \fIaddr1\fP and \fIaddr2\fP arguments, where
+\fIaddr1\fP and \fIaddr2\fP represent addresses returned by calls to
+\fBMPI_Get_address\fP. The resulting address is valid only at the
+process that generated \fIaddr1\fP and \fIaddr2\fP, and \fIaddr1\fP
+and \fIaddr2\fP must correspond to locations in the same object in the
+same process, as described in MPI-3.1 \[char167] 4.1.12. The difference is
+calculated in a manner that results in the signed difference from
+\fIaddr1\fP to \fIaddr2\fP, as if the process that originally produced
+the addresses had called (char *) \fIaddr1\fP - (char *) \fIaddr2\fP
+on the addresses initially passed to \fBMPI_Get_address\fP.
+
+.SH FORTRAN 77 NOTES
+.ft R
+The MPI standard prescribes portable Fortran syntax for all arguments
+only for Fortran 90.  FORTRAN 77 users may use the non-portable
+syntax:
+.sp
+.nf
+     INTEGER*MPI_ADDRESS_KIND \fIBASE\fP
+     INTEGER*MPI_ADDRESS_KIND \fIDISP\fP
+     INTEGER*MPI_ADDRESS_KIND \fIADDR1\fP
+     INTEGER*MPI_ADDRESS_KIND \fIADDR2\fP
+.fi
+.sp
+where MPI_ADDRESS_KIND is a constant defined in mpif.h
+and gives the length of the declared integer in bytes.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Get_address

--- a/ompi/mpi/man/man3/MPI_Aint_diff.3in
+++ b/ompi/mpi/man/man3/MPI_Aint_diff.3in
@@ -1,0 +1,1 @@
+.so man3/MPI_Aint_add.3

--- a/ompi/mpi/man/man3/Makefile.extra
+++ b/ompi/mpi/man/man3/Makefile.extra
@@ -19,6 +19,8 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Add_error_code.3 \
         mpi/man/man3/MPI_Add_error_string.3 \
         mpi/man/man3/MPI_Address.3 \
+	mpi/man/man3/MPI_Aint_add.3 \
+	mpi/man/man3/MPI_Aint_diff.3 \
         mpi/man/man3/MPI_Allgather.3 \
         mpi/man/man3/MPI_Iallgather.3 \
         mpi/man/man3/MPI_Allgatherv.3 \


### PR DESCRIPTION
These merged cleanly into v1.10 so there is no reason they shouldn't be included even though they are MPI-3.1.

:bot:assign: @jsquyres 
:bot:milestone:v1.10.1
:bot:label:enhancement
