### PR TITLE
Bring over opal_progress_thread from master

### DIFF
--- a/ompi/mca/crcp/bkmrk/crcp_bkmrk_pml.c
+++ b/ompi/mca/crcp/bkmrk/crcp_bkmrk_pml.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,6 @@
 
 #include "opal/util/opal_environ.h"
 #include "ompi/mca/mca.h"
-#include "opal/mca/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 
 #include "ompi/request/request.h"
@@ -4440,7 +4440,7 @@ static int ft_event_exchange_bookmarks(void)
     /* Wait for all bookmarks to arrive */
     START_TIMER(CRCP_TIMER_CKPT_EX_WAIT);
     while( total_recv_bookmarks > 0 ) {
-        opal_event_loop(opal_event_base, OPAL_EVLOOP_NONBLOCK);
+        opal_event_loop(opal_sync_event_base, OPAL_EVLOOP_NONBLOCK);
     }
     total_recv_bookmarks = 0;
     END_TIMER(CRCP_TIMER_CKPT_EX_WAIT);
@@ -5227,7 +5227,7 @@ static int wait_quiesce_drain_ack(void)
             }
         }
 
-        opal_event_loop(opal_event_base, OPAL_EVLOOP_NONBLOCK);
+        opal_event_loop(opal_sync_event_base, OPAL_EVLOOP_NONBLOCK);
     }
 
     /* Clear the ack queue if it isn't already clear (it should already be) */

--- a/opal/mca/btl/openib/btl_openib_fd.c
+++ b/opal/mca/btl/openib/btl_openib_fd.c
@@ -175,7 +175,7 @@ static int service_pipe_cmd_add_fd(bool use_libevent, cmd_t *cmd)
     if (use_libevent) {
         /* Make an event for this fd */
         ri->ri_event_used = true;
-        opal_event_set(opal_event_base, &ri->ri_event, ri->ri_fd,
+        opal_event_set(opal_sync_event_base, &ri->ri_event, ri->ri_fd,
                        ri->ri_flags | OPAL_EV_PERSIST, service_fd_callback,
                        ri);
         opal_event_add(&ri->ri_event, 0);
@@ -501,7 +501,7 @@ int opal_btl_openib_fd_init(void)
 
         /* Create a libevent event that is used in the main thread
            to watch its pipe */
-        opal_event_set(opal_event_base, &main_thread_event, pipe_to_main_thread[0],
+        opal_event_set(opal_sync_event_base, &main_thread_event, pipe_to_main_thread[0],
                        OPAL_EV_READ | OPAL_EV_PERSIST,
                        main_thread_event_callback, NULL);
         opal_event_add(&main_thread_event, 0);

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -2207,7 +2207,7 @@ static void udcm_sent_message_constructor (udcm_message_sent_t *message)
 {
     memset ((char *)message + sizeof (message->super), 0,
             sizeof (*message) - sizeof (message->super));
-    opal_event_evtimer_set(opal_event_base, &message->event, udcm_send_timeout, message);
+    opal_event_evtimer_set(opal_sync_event_base, &message->event, udcm_send_timeout, message);
 }
 
 static void udcm_sent_message_destructor (udcm_message_sent_t *message)

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -819,7 +819,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     /* register listen port */
 #if OPAL_ENABLE_IPV6
     if (AF_INET6 == af_family) {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp6_recv_event,
+        opal_event_set(opal_sync_event_base, &mca_btl_tcp_component.tcp6_recv_event,
                         mca_btl_tcp_component.tcp6_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -828,7 +828,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     } else
 #endif
     {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp_recv_event,
+        opal_event_set(opal_sync_event_base, &mca_btl_tcp_component.tcp_recv_event,
                         mca_btl_tcp_component.tcp_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -1050,7 +1050,7 @@ static void mca_btl_tcp_component_accept_handler( int incoming_sd,
 
         /* wait for receipt of peers process identifier to complete this connection */
         event = OBJ_NEW(mca_btl_tcp_event_t);
-        opal_event_set(opal_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
+        opal_event_set(opal_sync_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
         opal_event_add(&event->event, 0);
     }
 }

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -309,7 +309,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
     btl_endpoint->endpoint_cache_pos = btl_endpoint->endpoint_cache;
 #endif  /* MCA_BTL_TCP_ENDPOINT_CACHE */
 
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_recv_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_recv_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_READ|OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_recv_handler,
@@ -320,7 +320,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
      * will be fired only once, and when the endpoint is marked as
      * CONNECTED the event should be recreated with the correct flags.
      */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE,
                     mca_btl_tcp_endpoint_send_handler,
@@ -509,7 +509,7 @@ void mca_btl_tcp_endpoint_accept(mca_btl_base_endpoint_t* btl_endpoint,
     assert(btl_endpoint->endpoint_sd_next == -1);
     btl_endpoint->endpoint_sd_next = sd;
 
-    opal_event_evtimer_set(opal_event_base, &btl_endpoint->endpoint_accept_event,
+    opal_event_evtimer_set(opal_sync_event_base, &btl_endpoint->endpoint_accept_event,
                            mca_btl_tcp_endpoint_complete_accept, btl_endpoint);
     opal_event_add(&btl_endpoint->endpoint_accept_event, &now);
 }
@@ -570,7 +570,7 @@ static void mca_btl_tcp_endpoint_connected(mca_btl_base_endpoint_t* btl_endpoint
     MCA_BTL_TCP_ENDPOINT_DUMP(1, btl_endpoint, true, "READY [endpoint_connected]");
 
     /* Create the send event in a persistent manner. */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_sync_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE | OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_send_handler,

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -1018,7 +1018,7 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
     }
 
     /* start timer to guarantee synthetic clock advances */
-    opal_event_set(opal_event_base, &usnic_clock_timer_event,
+    opal_event_set(opal_sync_event_base, &usnic_clock_timer_event,
                    -1, 0, usnic_clock_callback,
                    &usnic_clock_timeout);
     usnic_clock_timer_event_set = true;

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.c
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.c
@@ -86,6 +86,7 @@ static void endpoint_construct(mca_btl_base_endpoint_t* endpoint)
     OBJ_CONSTRUCT(&endpoint->endpoint_hotel, opal_hotel_t);
     opal_hotel_init(&endpoint->endpoint_hotel,
                     WINDOW_SIZE,
+                    opal_sync_event_base,
                     mca_btl_usnic_component.retrans_timeout,
                     0,
                     opal_btl_usnic_ack_timeout);

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -2102,7 +2102,7 @@ static void init_async_event(opal_btl_usnic_module_t *module)
     }
 
     /* Get the fd to receive events on this device */
-    opal_event_set(opal_event_base, &(module->device_async_event), fd,
+    opal_event_set(opal_sync_event_base, &(module->device_async_event), fd,
                    OPAL_EV_READ | OPAL_EV_PERSIST,
                    module_async_event_callback, module);
     opal_event_add(&(module->device_async_event), NULL);

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -212,7 +212,7 @@ int opal_btl_usnic_stats_init(opal_btl_usnic_module_t *module)
         module->stats.timeout.tv_sec = mca_btl_usnic_component.stats_frequency;
         module->stats.timeout.tv_usec = 0;
 
-        opal_event_set(opal_event_base, &(module->stats.timer_event),
+        opal_event_set(opal_sync_event_base, &(module->stats.timer_event),
                        -1, EV_TIMEOUT | EV_PERSIST,
                        &usnic_stats_callback, module);
         opal_event_add(&(module->stats.timer_event),

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -65,7 +65,6 @@ static int opal_event_base_close(void)
  * Globals
  */
 opal_event_base_t *opal_sync_event_base=NULL;
-opal_event_base_t *opal_async_event_base=NULL;
 
 static int opal_event_base_open(mca_base_open_flag_t flags)
 {

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -64,7 +64,7 @@ static int opal_event_base_close(void)
 /*
  * Globals
  */
-opal_event_base_t *opal_event_base=NULL;
+opal_event_base_t *opal_sync_event_base=NULL;
 
 static int opal_event_base_open(mca_base_open_flag_t flags)
 {
@@ -84,13 +84,13 @@ static int opal_event_base_open(mca_base_open_flag_t flags)
     opal_event_use_threads();
 
     /* get our event base */
-    if (NULL == (opal_event_base = opal_event_base_create())) {
+    if (NULL == (opal_sync_event_base = opal_event_base_create())) {
         return OPAL_ERROR;
     }
 
     /* set the number of priorities */
     if (0 < OPAL_EVENT_NUM_PRI) {
-        opal_event_base_priority_init(opal_event_base, OPAL_EVENT_NUM_PRI);
+        opal_event_base_priority_init(opal_sync_event_base, OPAL_EVENT_NUM_PRI);
     }
 
     return rc;

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,7 @@ static int opal_event_base_close(void)
  * Globals
  */
 opal_event_base_t *opal_sync_event_base=NULL;
+opal_event_base_t *opal_async_event_base=NULL;
 
 static int opal_event_base_open(mca_base_open_flag_t flags)
 {

--- a/opal/mca/event/event.h
+++ b/opal/mca/event/event.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  *
@@ -29,7 +29,6 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
-OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -27,7 +28,7 @@ BEGIN_C_DECLS
 typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
-OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -29,6 +29,7 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -68,7 +68,6 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
-OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -68,6 +68,7 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_async_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -67,7 +67,7 @@ BEGIN_C_DECLS
 typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
-OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_sync_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -811,7 +811,7 @@ int opal_cr_coord(int state)
          * Otherwise it may/will use stale file descriptors which will disrupt
          * the intended users of the soon-to-be newly assigned file descriptors.
          */
-        opal_event_reinit(opal_event_base);
+        opal_event_reinit(opal_sync_event_base);
 
         /*
          * Flush if() functionality, since it caches system specific info.

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -168,7 +168,7 @@ opal_progress(void)
                 event_progress_last_time = (num_event_users > 0) ?
                     now - event_progress_delta : now;
 
-                events += opal_event_loop(opal_event_base, opal_progress_event_flag);
+                events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
 
 #else /* OPAL_PROGRESS_USE_TIMERS */
@@ -177,7 +177,7 @@ opal_progress(void)
         if (OPAL_THREAD_ADD32(&event_progress_counter, -1) <= 0 ) {
                 event_progress_counter =
                     (num_event_users > 0) ? 0 : event_progress_delta;
-                events += opal_event_loop(opal_event_base, opal_progress_event_flag);
+                events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
 #endif /* OPAL_PROGRESS_USE_TIMERS */
 

--- a/opal/runtime/opal_progress_threads.c
+++ b/opal/runtime/opal_progress_threads.c
@@ -132,7 +132,6 @@ static int start_progress_engine(opal_progress_tracker_t *trk)
     int rc = opal_thread_start(&trk->engine);
     if (OPAL_SUCCESS != rc) {
         OPAL_ERROR_LOG(rc);
-        OBJ_RELEASE(trk);
     }
 
     return rc;

--- a/opal/runtime/opal_progress_threads.c
+++ b/opal/runtime/opal_progress_threads.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,66 +23,79 @@
 
 #include "opal/runtime/opal_progress_threads.h"
 
+
 /* create a tracking object for progress threads */
 typedef struct {
     opal_list_item_t super;
+
     int refcount;
     char *name;
+
     opal_event_base_t *ev_base;
+
+    /* This will be set to false when it is time for the progress
+       thread to exit */
     volatile bool ev_active;
-    bool block_active;
+
+    /* This event will always be set on the ev_base (so that the
+       ev_base is not empty!) */
     opal_event_t block;
-    bool engine_defined;
+
+    bool engine_constructed;
     opal_thread_t engine;
-    int pipe[2];
 } opal_progress_tracker_t;
-static void trkcon(opal_progress_tracker_t *p)
+
+static void tracker_constructor(opal_progress_tracker_t *p)
 {
     p->refcount = 1;  // start at one since someone created it
     p->name = NULL;
     p->ev_base = NULL;
-    p->ev_active = true;
-    p->block_active = false;
-    p->engine_defined = false;
-    p->pipe[0] = -1;
-    p->pipe[1] = -1;
+    p->ev_active = false;
+    p->engine_constructed = false;
 }
-static void trkdes(opal_progress_tracker_t *p)
+
+static void tracker_destructor(opal_progress_tracker_t *p)
 {
+    opal_event_del(&p->block);
+
     if (NULL != p->name) {
         free(p->name);
-    }
-    if (p->block_active) {
-        opal_event_del(&p->block);
     }
     if (NULL != p->ev_base) {
         opal_event_base_free(p->ev_base);
     }
-    if (0 <= p->pipe[0]) {
-        close(p->pipe[0]);
-    }
-    if (0 <= p->pipe[1]) {
-        close(p->pipe[1]);
-    }
-    if (p->engine_defined) {
+    if (p->engine_constructed) {
         OBJ_DESTRUCT(&p->engine);
     }
 }
+
 static OBJ_CLASS_INSTANCE(opal_progress_tracker_t,
                           opal_list_item_t,
-                          trkcon, trkdes);
+                          tracker_constructor,
+                          tracker_destructor);
 
-static opal_list_t tracking;
 static bool inited = false;
-static void wakeup(int fd, short args, void *cbdata)
+static opal_list_t tracking;
+static struct timeval long_timeout = {
+    .tv_sec = 3600,
+    .tv_usec = 0
+};
+static const char *shared_thread_name = "OPAL-wide async progress thread";
+
+/*
+ * If this event is fired, just restart it so that this event base
+ * continues to have something to block on.
+ */
+static void dummy_timeout_cb(int fd, short args, void *cbdata)
 {
     opal_progress_tracker_t *trk = (opal_progress_tracker_t*)cbdata;
 
-    /* if this event fired, then the blocker event will
-     * be deleted from the event base by libevent, so flag
-     * it so we don't try to delete it again */
-    trk->block_active = false;
+    opal_event_add(&trk->block, &long_timeout);
 }
+
+/*
+ * Main for the progress thread
+ */
 static void* progress_engine(opal_object_t *obj)
 {
     opal_thread_t *t = (opal_thread_t*)obj;
@@ -90,11 +104,41 @@ static void* progress_engine(opal_object_t *obj)
     while (trk->ev_active) {
         opal_event_loop(trk->ev_base, OPAL_EVLOOP_ONCE);
     }
+
     return OPAL_THREAD_CANCELLED;
 }
 
-opal_event_base_t *opal_start_progress_thread(char *name,
-                                              bool create_block)
+static void stop_progress_engine(opal_progress_tracker_t *trk)
+{
+    assert(trk->ev_active);
+    trk->ev_active = false;
+
+    /* break the event loop - this will cause the loop to exit upon
+       completion of any current event */
+    opal_event_base_loopbreak(trk->ev_base);
+
+    opal_thread_join(&trk->engine, NULL);
+}
+
+static int start_progress_engine(opal_progress_tracker_t *trk)
+{
+    assert(!trk->ev_active);
+    trk->ev_active = true;
+
+    /* fork off a thread to progress it */
+    trk->engine.t_run = progress_engine;
+    trk->engine.t_arg = trk;
+
+    int rc = opal_thread_start(&trk->engine);
+    if (OPAL_SUCCESS != rc) {
+        OPAL_ERROR_LOG(rc);
+        OBJ_RELEASE(trk);
+    }
+
+    return rc;
+}
+
+opal_event_base_t *opal_progress_thread_init(const char *name)
 {
     opal_progress_tracker_t *trk;
     int rc;
@@ -102,6 +146,10 @@ opal_event_base_t *opal_start_progress_thread(char *name,
     if (!inited) {
         OBJ_CONSTRUCT(&tracking, opal_list_t);
         inited = true;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
     }
 
     /* check if we already have this thread */
@@ -115,129 +163,132 @@ opal_event_base_t *opal_start_progress_thread(char *name,
     }
 
     trk = OBJ_NEW(opal_progress_tracker_t);
+    if (NULL == trk) {
+        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+        return NULL;
+    }
+
     trk->name = strdup(name);
+    if (NULL == trk->name) {
+        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+        OBJ_RELEASE(trk);
+        return NULL;
+    }
+
     if (NULL == (trk->ev_base = opal_event_base_create())) {
         OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
         OBJ_RELEASE(trk);
         return NULL;
     }
 
-    if (create_block) {
-        /* add an event it can block on */
-        if (0 > pipe(trk->pipe)) {
-            OPAL_ERROR_LOG(OPAL_ERR_IN_ERRNO);
-            OBJ_RELEASE(trk);
-            return NULL;
-        }
-        /* Make sure the pipe FDs are set to close-on-exec so that
-           they don't leak into children */
-        if (opal_fd_set_cloexec(trk->pipe[0]) != OPAL_SUCCESS ||
-            opal_fd_set_cloexec(trk->pipe[1]) != OPAL_SUCCESS) {
-            OPAL_ERROR_LOG(OPAL_ERR_IN_ERRNO);
-            OBJ_RELEASE(trk);
-            return NULL;
-        }
-        opal_event_set(trk->ev_base, &trk->block, trk->pipe[0], OPAL_EV_READ, wakeup, trk);
-        opal_event_add(&trk->block, 0);
-        trk->block_active = true;
-    }
+    /* add an event to the new event base (if there are no events,
+       opal_event_loop() will return immediately) */
+    opal_event_set(trk->ev_base, &trk->block, -1, OPAL_EV_PERSIST,
+                   dummy_timeout_cb, trk);
+    opal_event_add(&trk->block, &long_timeout);
 
     /* construct the thread object */
     OBJ_CONSTRUCT(&trk->engine, opal_thread_t);
-    trk->engine_defined = true;
-    /* fork off a thread to progress it */
-    trk->engine.t_run = progress_engine;
-    trk->engine.t_arg = trk;
-    if (OPAL_SUCCESS != (rc = opal_thread_start(&trk->engine))) {
+    trk->engine_constructed = true;
+    if (OPAL_SUCCESS != (rc = start_progress_engine(trk))) {
         OPAL_ERROR_LOG(rc);
         OBJ_RELEASE(trk);
         return NULL;
     }
     opal_list_append(&tracking, &trk->super);
+
     return trk->ev_base;
 }
 
-void opal_stop_progress_thread(char *name, bool cleanup)
+int opal_progress_thread_finalize(const char *name)
 {
     opal_progress_tracker_t *trk;
-    int i;
 
     if (!inited) {
         /* nothing we can do */
-        return;
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
     }
 
     /* find the specified engine */
     OPAL_LIST_FOREACH(trk, &tracking, opal_progress_tracker_t) {
         if (0 == strcmp(name, trk->name)) {
-            /* if it is already inactive, then just cleanup if that
-             * is the request */
-            if (!trk->ev_active) {
-                if (cleanup) {
-                    opal_list_remove_item(&tracking, &trk->super);
-                    OBJ_RELEASE(trk);
-                }
-                return;
-            }
             /* decrement the refcount */
             --trk->refcount;
-            /* if we have reached zero, then it's time to stop it */
-            if (0 < trk->refcount) {
-                return;
+
+            /* If the refcount is still above 0, we're done here */
+            if (trk->refcount > 0) {
+                return OPAL_SUCCESS;
             }
-            /* mark it as inactive */
-            trk->ev_active = false;
-            /* break the event loop - this will cause the loop to exit
-             * upon completion of any current event */
-            opal_event_base_loopbreak(trk->ev_base);
-            /* if present, use the block to break it loose just in
-             * case the thread is blocked in a call to select for
-             * a long time */
-            if (trk->block_active) {
-                i=1;
-                write(trk->pipe[1], &i, sizeof(int));
+
+            /* If the progress thread is active, stop it */
+            if (trk->ev_active) {
+                stop_progress_engine(trk);
             }
-            /* wait for thread to exit */
-            opal_thread_join(&trk->engine, NULL);
-            /* cleanup, if they indicated they are done with this event base */
-            if (cleanup) {
-                opal_list_remove_item(&tracking, &trk->super);
-                OBJ_RELEASE(trk);
-            }
-            return;
+
+            opal_list_remove_item(&tracking, &trk->super);
+            OBJ_RELEASE(trk);
+            return OPAL_SUCCESS;
         }
     }
+
+    return OPAL_ERR_NOT_FOUND;
 }
 
-int opal_restart_progress_thread(char *name)
+/*
+ * Stop the progress thread, but don't delete the tracker (or event base)
+ */
+int opal_progress_thread_pause(const char *name)
 {
     opal_progress_tracker_t *trk;
-    int rc;
 
     if (!inited) {
         /* nothing we can do */
-        return OPAL_ERROR;
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
     }
 
     /* find the specified engine */
     OPAL_LIST_FOREACH(trk, &tracking, opal_progress_tracker_t) {
         if (0 == strcmp(name, trk->name)) {
-            if (!trk->engine_defined) {
-                OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
-                return OPAL_ERR_NOT_SUPPORTED;
+            if (trk->ev_active) {
+                stop_progress_engine(trk);
             }
-            /* up the refcount */
-            ++trk->refcount;
-            /* ensure the block is set, if requested */
-            if (0 <= trk->pipe[0] && !trk->block_active) {
-                opal_event_add(&trk->block, 0);
-                trk->block_active = true;
+
+            return OPAL_SUCCESS;
+        }
+    }
+
+    return OPAL_ERR_NOT_FOUND;
+}
+
+int opal_progress_thread_resume(const char *name)
+{
+    opal_progress_tracker_t *trk;
+
+    if (!inited) {
+        /* nothing we can do */
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    OPAL_LIST_FOREACH(trk, &tracking, opal_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            if (trk->ev_active) {
+                return OPAL_ERR_RESOURCE_BUSY;
             }
-            /* start the thread again */
-            if (OPAL_SUCCESS != (rc = opal_thread_start(&trk->engine))) {
-                OPAL_ERROR_LOG(rc);
-                return rc;
-            }
+
+            return start_progress_engine(trk);
         }
     }
 

--- a/opal/runtime/opal_progress_threads.h
+++ b/opal/runtime/opal_progress_threads.h
@@ -26,7 +26,7 @@
  * to glom on to the general OPAL-wide progress thread.
  *
  * If a name is passed that was already used in a prior call to
- * opal_start_progress_thread(), the event base associated with that
+ * opal_progress_thread_init(), the event base associated with that
  * already-running progress thread will be returned (i.e., no new
  * progress thread will be started).
  */

--- a/opal/runtime/opal_progress_threads.h
+++ b/opal/runtime/opal_progress_threads.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,20 +15,56 @@
 
 #include "opal/mca/event/event.h"
 
-/* start a progress thread, assigning it the provided name for
- * tracking purposes. If create_block is true, then this function
- * will also create a pipe so that libevent has something to block
- * against, thus keeping the thread from free-running
+
+/**
+ * Initialize a progress thread name; if a progress thread is not
+ * already associated with that name, start a progress thread.
+ *
+ * If you have general events that need to run in *a* progress thread
+ * (but not necessarily a your own, dedicated progress thread), pass
+ * NULL the "name" argument to the opal_progress_thead_init() function
+ * to glom on to the general OPAL-wide progress thread.
+ *
+ * If a name is passed that was already used in a prior call to
+ * opal_start_progress_thread(), the event base associated with that
+ * already-running progress thread will be returned (i.e., no new
+ * progress thread will be started).
  */
-OPAL_DECLSPEC opal_event_base_t *opal_start_progress_thread(char *name,
-                                                            bool create_block);
+OPAL_DECLSPEC opal_event_base_t *opal_progress_thread_init(const char *name);
 
-/* stop the progress thread of the provided name. This function will
- * also cleanup the blocking pipes and release the event base if
- * the cleanup param is true */
-OPAL_DECLSPEC void opal_stop_progress_thread(char *name, bool cleanup);
+/**
+ * Finalize a progress thread name (reference counted).
+ *
+ * Once this function is invoked as many times as
+ * opal_progress_thread_init() was invoked on this name (or NULL), the
+ * progress function is shut down and the event base associated with
+ * it is destroyed.
+ *
+ * Will return OPAL_ERR_NOT_FOUND if the progress thread name does not
+ * exist; OPAL_SUCCESS otherwise.
+ */
+OPAL_DECLSPEC int opal_progress_thread_finalize(const char *name);
 
-/* restart the progress thread of the provided name */
-OPAL_DECLSPEC int opal_restart_progress_thread(char *name);
+/**
+ * Temporarily pause the progress thread associated with this name.
+ *
+ * This function does not destroy the event base associated with this
+ * progress thread name, but it does stop processing all events on
+ * that event base until opal_progress_thread_resume() is invoked on
+ * that name.
+ *
+ * Will return OPAL_ERR_NOT_FOUND if the progress thread name does not
+ * exist; OPAL_SUCCESS otherwise.
+ */
+OPAL_DECLSPEC int opal_progress_thread_pause(const char *name);
+
+/**
+ * Restart a previously-paused progress thread associated with this
+ * name.
+ *
+ * Will return OPAL_ERR_NOT_FOUND if the progress thread name does not
+ * exist; OPAL_SUCCESS otherwise.
+ */
+OPAL_DECLSPEC int opal_progress_thread_resume(const char *name);
 
 #endif

--- a/orte/mca/ess/base/ess_base_std_app.c
+++ b/orte/mca/ess/base/ess_base_std_app.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +110,7 @@ int orte_ess_base_app_setup(bool db_restrict_local)
 
     /* get an async event base - we use the opal_async one so
      * we don't startup extra threads if not needed */
-    orte_event_base = opal_start_progress_thread("opal_async", true);
+    orte_event_base = opal_progress_thread_init(NULL);
     progress_thread_running = true;
 
     /* open and setup the state machine */
@@ -262,7 +263,7 @@ int orte_ess_base_app_finalize(void)
 
     /* release the event base */
     if (progress_thread_running) {
-        opal_stop_progress_thread("opal_async", true);
+        opal_progress_thread_finalize(NULL);
         progress_thread_running = false;
     }
 

--- a/orte/mca/ess/base/ess_base_std_app.c
+++ b/orte/mca/ess/base/ess_base_std_app.c
@@ -107,8 +107,9 @@ int orte_ess_base_app_setup(bool db_restrict_local)
         opal_proc_local_set(&orte_process_info.super);
     }
 
-    /* get a separate orte event base */
-    orte_event_base = opal_start_progress_thread("orte", true);
+    /* get an async event base - we use the opal_async one so
+     * we don't startup extra threads if not needed */
+    orte_event_base = opal_start_progress_thread("opal_async", true);
     progress_thread_running = true;
 
     /* open and setup the state machine */
@@ -245,13 +246,6 @@ int orte_ess_base_app_setup(bool db_restrict_local)
 int orte_ess_base_app_finalize(void)
 {
 
-    /* release the event base so we stop all potential
-     * race conditions in the messaging teardown */
-    if (progress_thread_running) {
-        opal_stop_progress_thread("orte", false);
-        progress_thread_running = false;
-    }
-
 #if OPAL_ENABLE_FT_CR == 1
     (void) mca_base_framework_close(&orte_snapc_base_framework);
     (void) mca_base_framework_close(&orte_sstore_base_framework);
@@ -266,8 +260,12 @@ int orte_ess_base_app_finalize(void)
 
     orte_session_dir_finalize(ORTE_PROC_MY_NAME);
 
-    /* free the event base to cleanup memory */
-    opal_stop_progress_thread("orte", true);
+    /* release the event base */
+    if (progress_thread_running) {
+        opal_stop_progress_thread("opal_async", true);
+        progress_thread_running = false;
+    }
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/ess/base/ess_base_std_tool.c
+++ b/orte/mca/ess/base/ess_base_std_tool.c
@@ -58,8 +58,6 @@
 
 #include "orte/mca/ess/base/base.h"
 
-static bool progress_thread_running = false;
-
 int orte_ess_base_tool_setup(void)
 {
     int ret;
@@ -71,19 +69,6 @@ int orte_ess_base_tool_setup(void)
     orte_process_info.super.proc_flags = OPAL_PROC_ALL_LOCAL;
     orte_process_info.super.proc_arch = opal_local_arch;
     opal_proc_local_set(&orte_process_info.super);
-
-    if (NULL != orte_process_info.my_hnp_uri) {
-        /* if we were given an HNP, then we want
-         * to look like an application as well as being a tool.
-         * Need to do this before opening the routed framework
-         * so it will do the right things.
-         */
-        orte_process_info.proc_type |= ORTE_PROC_NON_MPI;
-        /* get a separate orte event base */
-        orte_event_base = opal_start_progress_thread("orte", true);
-        progress_thread_running = true;
-        orte_event_base_active = true;
-    }
 
     /* open and setup the state machine */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_state_base_framework, 0))) {
@@ -242,10 +227,5 @@ int orte_ess_base_tool_finalize(void)
     (void) mca_base_framework_close(&orte_schizo_base_framework);
     (void) mca_base_framework_close(&orte_errmgr_base_framework);
 
-    /* release the event base */
-    if (progress_thread_running) {
-        opal_progress_thread_finalize("orte");
-        progress_thread_running = false;
-    }
     return ORTE_SUCCESS;
 }

--- a/orte/mca/ess/base/ess_base_std_tool.c
+++ b/orte/mca/ess/base/ess_base_std_tool.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
  *
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -243,7 +244,7 @@ int orte_ess_base_tool_finalize(void)
 
     /* release the event base */
     if (progress_thread_running) {
-        opal_stop_progress_thread("orte", true);
+        opal_progress_thread_finalize("orte");
         progress_thread_running = false;
     }
     return ORTE_SUCCESS;

--- a/orte/mca/notifier/base/notifier_base_frame.c
+++ b/orte/mca/notifier/base/notifier_base_frame.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -195,7 +195,7 @@ static int orte_notifier_base_close(void)
 
     if (orte_notifier_base.ev_base_active) {
         orte_notifier_base.ev_base_active = false;
-        opal_stop_progress_thread("notifier", true);
+        opal_progress_thread_finalize("notifier");
     }
 
     OPAL_LIST_FOREACH(i_module, &orte_notifier_base.modules, orte_notifier_active_module_t) {
@@ -224,7 +224,7 @@ static int orte_notifier_base_open(mca_base_open_flag_t flags)
     if (use_progress_thread) {
         orte_notifier_base.ev_base_active = true;
         if (NULL == (orte_notifier_base.ev_base =
-                     opal_start_progress_thread("notifier", true))) {
+                     opal_progress_thread_init("notifier"))) {
             orte_notifier_base.ev_base_active = false;
             return ORTE_ERROR;
         }

--- a/orte/runtime/orte_init.c
+++ b/orte/runtime/orte_init.c
@@ -229,7 +229,7 @@ int orte_init(int* pargc, char*** pargv, orte_proc_type_t flags)
          * start their progress thread in ess_base_std_app.c
          * at the appropriate point
          */
-        orte_event_base = opal_event_base;
+        orte_event_base = opal_sync_event_base;
     }
 
     /* initialize the RTE for this environment */

--- a/orte/tools/orte-server/orte-server.c
+++ b/orte/tools/orte-server/orte-server.c
@@ -238,10 +238,10 @@ int main(int argc, char *argv[])
     /* Set signal handlers to catch kill signals so we can properly clean up
      * after ourselves.
      */
-    opal_event_set(opal_event_base, &term_handler, SIGTERM, OPAL_EV_SIGNAL,
+    opal_event_set(orte_event_base, &term_handler, SIGTERM, OPAL_EV_SIGNAL,
                    shutdown_callback, NULL);
     opal_event_add(&term_handler, NULL);
-    opal_event_set(opal_event_base, &int_handler, SIGINT, OPAL_EV_SIGNAL,
+    opal_event_set(orte_event_base, &int_handler, SIGINT, OPAL_EV_SIGNAL,
                    shutdown_callback, NULL);
     opal_event_add(&int_handler, NULL);
 

--- a/orte/tools/orte-submit/orte-submit.c
+++ b/orte/tools/orte-submit/orte-submit.c
@@ -317,7 +317,7 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       &myglobals.run_as_root, OPAL_CMD_LINE_TYPE_BOOL,
       "Allow execution as root (STRONGLY DISCOURAGED)" },
 
-/* End of list */
+    /* End of list */
     { NULL, '\0', NULL, NULL, 0,
       NULL, OPAL_CMD_LINE_TYPE_NULL, NULL }
 };
@@ -408,8 +408,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         exit(1);
     }
-
-    /*
+ 
+     /*
      * Since this process can now handle MCA/GMCA parameters, make sure to
      * process them.
      */
@@ -714,12 +714,16 @@ int main(int argc, char *argv[])
     orte_rml.send_buffer_nb(ORTE_PROC_MY_HNP, req, ORTE_RML_TAG_DAEMON, orte_rml_send_callback, NULL);
 
     // wait for response and unpack the status, jobid
-    ORTE_WAIT_FOR_COMPLETION(myspawn);
+    while (myspawn) {
+      opal_event_loop(orte_event_base, OPAL_EVLOOP_ONCE);
+    }
     opal_output(0, "Job %s has launched", ORTE_JOBID_PRINT(jdata->jobid));
 
  waiting:
-    ORTE_WAIT_FOR_COMPLETION(mywait);
-
+    while (mywait) {
+      opal_event_loop(orte_event_base, OPAL_EVLOOP_ONCE);
+    }
+ 
  DONE:
     /* cleanup and leave */
     orte_finalize();


### PR DESCRIPTION
This is several commits from master: see the individual commit messages.

@rhc54 Note that I had to bring over open-mpi/ompi@836f49597d215fe1911bbb00e0ccad039611a61a, which removed the progress thread from ess_base_std_tool.c.  Please review the whole sequence, but with particular attention to this last commit.

Thanks.
