### PR TITLE
v2.x: Fortran: add missing MPI_AINT in mpi_f08 module

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/constants.c
+++ b/ompi/mpi/fortran/use-mpi-f08/constants.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -69,6 +69,7 @@ OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_file
 /*
  * common block items from ompi/include/mpif-common.h
  */
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_aint              = {OMPI_MPI_AINT};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_byte              = {OMPI_MPI_BYTE};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_packed            = {OMPI_MPI_PACKED};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_ub                = {OMPI_MPI_UB};

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f08-types.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2015      Research Organization for Information Science
@@ -131,6 +131,7 @@ module mpi_f08_types
   !   They are defined in ompi/runtime/ompi_mpi_init.c
   !
 
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_aint") OMPI_PROTECTED              :: MPI_AINT
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_byte") OMPI_PROTECTED              :: MPI_BYTE
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_packed") OMPI_PROTECTED            :: MPI_PACKED
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_ub") OMPI_PROTECTED                :: MPI_UB


### PR DESCRIPTION
(cherry picked from open-mpi/ompi@2b9c9f3093c7f90121e7453bccce1d7e47a4db21)

@ggouaillardet Please review.
