### PR TITLE
lanl/platform: fixes to pick up lustre

### DIFF
--- a/contrib/platform/lanl/cray_xc_cle5.2/optimized-lustre
+++ b/contrib/platform/lanl/cray_xc_cle5.2/optimized-lustre
@@ -14,4 +14,7 @@ else
 fi
 
 # enable and Lustre in romio
-with_io_romio_flags="--with-file-system=ufs+nfs+lustre CFLAGS=-I/opt/cray/lustre-cray_gem_s/default/include"
+with_io_romio_flags="--with-file-system=ufs+nfs+lustre CFLAGS=-I/opt/cray/lustre-cray_ari_s/default/include"
+
+# enable Lustre in OMPI I/O
+with_lustre=/opt/cray/lustre-cray_ari_s/default


### PR DESCRIPTION
Fixes to lanl platform files to pick up lustre header
files, etc. for romio and ompi i/o.

Fixes open-mpi/ompi#1033

Thanks to @viennej for spotting this.

@hjelmn please review

Signed-off-by: Howard Pritchard howardp@lanl.gov
(cherry picked from commit open-mpi/ompi@89b9be37328e7e547f9fc9c11f85c7e8ab031b0b)
