### PR TITLE
fortran/mpif-h: Insert missing weak symbols & Fix incorrect symbol names.

### DIFF
--- a/ompi/mpi/fortran/mpif-h/improbe_f.c
+++ b/ompi/mpi/fortran/mpif-h/improbe_f.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,9 @@
 #pragma weak pmpi_improbe = ompi_improbe_f
 #pragma weak pmpi_improbe_ = ompi_improbe_f
 #pragma weak pmpi_improbe__ = ompi_improbe_f
+
+#pragma weak PMPI_Improbe_f = ompi_improbe_f
+#pragma weak PMPI_Improbe_f08 = ompi_improbe_f
 #elif OMPI_PROFILE_LAYER
 OMPI_GENERATE_F77_BINDINGS (PMPI_IMPROBE,
                             pmpi_improbe,
@@ -46,6 +50,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_IMPROBE,
 #pragma weak mpi_improbe = ompi_improbe_f
 #pragma weak mpi_improbe_ = ompi_improbe_f
 #pragma weak mpi_improbe__ = ompi_improbe_f
+
+#pragma weak MPI_Improbe_f = ompi_improbe_f
+#pragma weak MPI_Improbe_f08 = ompi_improbe_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER

--- a/ompi/mpi/fortran/mpif-h/imrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/imrecv_f.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +28,9 @@
 #pragma weak pmpi_imrecv = ompi_imrecv_f
 #pragma weak pmpi_imrecv_ = ompi_imrecv_f
 #pragma weak pmpi_imrecv__ = ompi_imrecv_f
+
+#pragma weak PMPI_Imrecv_f = ompi_imrecv_f
+#pragma weak PMPI_Imrecv_f08 = ompi_imrecv_f
 #elif OMPI_PROFILE_LAYER
 OMPI_GENERATE_F77_BINDINGS (PMPI_IMRECV,
                             pmpi_imrecv,
@@ -43,6 +47,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_IMRECV,
 #pragma weak mpi_imrecv = ompi_imrecv_f
 #pragma weak mpi_imrecv_ = ompi_imrecv_f
 #pragma weak mpi_imrecv__ = ompi_imrecv_f
+
+#pragma weak MPI_Imrecv_f = ompi_imrecv_f
+#pragma weak MPI_Imrecv_f08 = ompi_imrecv_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER

--- a/ompi/mpi/fortran/mpif-h/mprobe_f.c
+++ b/ompi/mpi/fortran/mpif-h/mprobe_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,6 +51,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_MPROBE,
 #pragma weak mpi_mprobe = ompi_mprobe_f
 #pragma weak mpi_mprobe_ = ompi_mprobe_f
 #pragma weak mpi_mprobe__ = ompi_mprobe_f
+
+#pragma weak MPI_Mprobe_f = ompi_mprobe_f
+#pragma weak MPI_Mprobe_f08 = ompi_mprobe_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER

--- a/ompi/mpi/fortran/mpif-h/mrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/mrecv_f.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,9 @@
 #pragma weak pmpi_mrecv = ompi_mrecv_f
 #pragma weak pmpi_mrecv_ = ompi_mrecv_f
 #pragma weak pmpi_mrecv__ = ompi_mrecv_f
+
+#pragma weak PMPI_Mrecv_f = ompi_mrecv_f
+#pragma weak PMPI_Mrecv_f08 = ompi_mrecv_f
 #elif OMPI_PROFILE_LAYER
 OMPI_GENERATE_F77_BINDINGS (PMPI_MRECV,
                             pmpi_mrecv,
@@ -46,6 +50,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_MRECV,
 #pragma weak mpi_mrecv = ompi_mrecv_f
 #pragma weak mpi_mrecv_ = ompi_mrecv_f
 #pragma weak mpi_mrecv__ = ompi_mrecv_f
+
+#pragma weak MPI_Mrecv_f = ompi_mrecv_f
+#pragma weak MPI_Mrecv_f08 = ompi_mrecv_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER

--- a/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,8 +33,8 @@
 #pragma weak pmpi_rget_accumulate_ = ompi_rget_accumulate_f
 #pragma weak pmpi_rget_accumulate__ = ompi_rget_accumulate_f
 
-#pragma weak PMPI_Get_accumulate_f = ompi_rget_accumulate_f
-#pragma weak PMPI_Get_accumulate_f08 = ompi_rget_accumulate_f
+#pragma weak PMPI_Rget_accumulate_f = ompi_rget_accumulate_f
+#pragma weak PMPI_Rget_accumulate_f08 = ompi_rget_accumulate_f
 #elif OMPI_PROFILE_LAYER
 OMPI_GENERATE_F77_BINDINGS (PMPI_RGET_ACCUMULATE,
                             pmpi_rget_accumulate,
@@ -50,8 +51,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_RGET_ACCUMULATE,
 #pragma weak mpi_rget_accumulate_ = ompi_rget_accumulate_f
 #pragma weak mpi_rget_accumulate__ = ompi_rget_accumulate_f
 
-#pragma weak MPI_Get_accumulate_f = ompi_rget_accumulate_f
-#pragma weak MPI_Get_accumulate_f08 = ompi_rget_accumulate_f
+#pragma weak MPI_Rget_accumulate_f = ompi_rget_accumulate_f
+#pragma weak MPI_Rget_accumulate_f08 = ompi_rget_accumulate_f
 #endif
 
 #if ! OPAL_HAVE_WEAK_SYMBOLS && ! OMPI_PROFILE_LAYER


### PR DESCRIPTION
PR for v2.0.0

@jsquyres please review

(cherry picked from commit open-mpi/ompi@66a8bc9e4549464535601e8d2918d417da36567b)
