### PR TITLE
man: revamp MPI_File_* and MPI_Register_datarep man pages

### DIFF
--- a/ompi/mpi/man/man3/MPI_File_close.3in
+++ b/ompi/mpi/man/man3/MPI_File_close.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_close 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_close(MPI_File \fI*fh\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_close(MPI_File \fI*fh\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_CLOSE(\fIFH\fP,\fI IERROR\fP)
-        	 INTEGER	  FH, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_CLOSE(\fIFH\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_delete.3in
+++ b/ompi/mpi/man/man3/MPI_File_delete.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_delete 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,17 +13,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_delete(const char \fI*filename\fP, MPI_Info \fIinfo\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_delete(const char \fI*filename\fP, MPI_Info \fIinfo\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_DELETE(\fIFILENAME\fP, \fIINFO\fP, \fIIERROR\fP)
-   	 CHARACTER*(*) \fIFILENAME\fP
-    	 INTEGER \fIINFO, IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_DELETE(\fIFILENAME\fP, \fIINFO\fP, \fIIERROR\fP)
+	CHARACTER*(*)	\fIFILENAME\fP
+	INTEGER	\fIINFO, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_amode.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_amode.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_amode 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_amode(MPI_File \fIfh\fP, int \fI*amode\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_amode(MPI_File \fIfh\fP, int \fI*amode\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_AMODE(\fIFH\fP,\fI AMODE\fP, \fI IERROR\fP)
-        	 INTEGER	FH, AMODE, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_AMODE(\fIFH\fP, \fIAMODE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, AMODE, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_atomicity.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_atomicity.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_atomicity 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_atomicity(MPI_File \fIfh\fP, int \fI*flag\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_atomicity(MPI_File \fIfh\fP, int \fI*flag\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_ATOMICITY(\fIFH\fP,\fI FLAG\fP,\fI IERROR\fP)
-	INTEGER \FIFH, IERROR\FP
-	LOGICAL \FIFLAG\FP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_ATOMICITY(\fIFH\fP, \fIFLAG\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	LOGICAL	\fIFLAG\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_byte_offset.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_byte_offset.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_byte_offset 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_byte_offset(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-    	      MPI_Offset \fI*disp\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_byte_offset(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	MPI_Offset \fI*disp\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_BYTE_OFFSET(\fIFH\fP, \fIOFFSET\fP, \fIDISP\fP,\fI IERROR\fP)
-        	INTEGER	\fIFH, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET, DISP\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_BYTE_OFFSET(\fIFH\fP, \fIOFFSET\fP, \fIDISP\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET, DISP\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_group.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_group.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_group 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_group(MPI_File \fIfh\fP, MPI_Group \fI*group\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_group(MPI_File \fIfh\fP, MPI_Group \fI*group\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_GROUP(\fIFH\fP,\fI GROUP\fP, \fI IERROR\fP)
-        	 INTEGER	  FH, GROUP, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_GROUP(\fIFH\fP, \fIGROUP\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, GROUP, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_info.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,16 +13,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_info(MPI_File \fIfh\fP, MPI_Info \fI*info_used\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_info(MPI_File \fIfh\fP, MPI_Info \fI*info_used\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_INFO(\fIFH\fP, \fIINFO_USED\fP, \fIIERROR\fP)
-        	 INTEGER	  FH, INFO_USED, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_INFO(\fIFH\fP, \fIINFO_USED\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, INFO_USED, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_position.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_position.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_position 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_position(MPI_File \fIfh\fP, MPI_Offset \fI*offset\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_position(MPI_File \fIfh\fP, MPI_Offset \fI*offset\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_POSITION(\fIFH\fP,\fI OFFSET\fP,\fI IERROR\fP)
-    	      INTEGER \fIFH, IERROR\fP
-    	      INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_POSITION(\fIFH\fP, \fIOFFSET\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_position_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_position_shared.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_position_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
+.SH C Syntax
     #include <mpi.h>
     int MPI_File_get_position_shared(MPI_File \fIfh\fP, MPI_Offset \fI*offset\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_POSITION_SHARED(\fIFH\fP,\fI OFFSET\fP,\fI IERROR\fP)
-    	      INTEGER \fIFH, IERROR\fP
-    	      INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_POSITION_SHARED(\fIFH\fP, \fIOFFSET\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_size.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_size.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_size(MPI_File \fIfh\fP, MPI_Offset \fI*size\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_size(MPI_File \fIfh\fP, MPI_Offset \fI*size\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_SIZE(\fIFH\fP,\fI SIZE\fP, \fI IERROR\fP)
-	INTEGER \fIFH, ERROR\fP
-	INTEGER(KIND=MPI_OFFSET_KIND) \fISIZE\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_SIZE(\fIFH\fP, \fISIZE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, ERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fISIZE\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_type_extent.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_type_extent.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_type_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_type_extent(MPI_File \fIfh\fP, MPI_Datatype
-    	      \fIdatatype\fP, MPI_Aint \fI*extent\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_type_extent(MPI_File \fIfh\fP, MPI_Datatype
+	\fIdatatype\fP, MPI_Aint \fI*extent\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_TYPE_EXTENT(\fIFH\fP, \fIDATATYPE\fP, \fIEXTENT\fP, \fI IERROR\fP)
-        	INTEGER	\fIFH, DATATYPE, IERROR\fP
-		INTEGER(KIND=MPI_ADDRESS_KIND) \fIEXTENT\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_TYPE_EXTENT(\fIFH\fP, \fIDATATYPE\fP, \fIEXTENT\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, DATATYPE, IERROR\fP
+	INTEGER(KIND=MPI_ADDRESS_KIND)	\fIEXTENT\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_get_view.3in
+++ b/ompi/mpi/man/man3/MPI_File_get_view.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_get_view 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_get_view(MPI_File \fIfh\fP, MPI_Offset \fI*disp\fP,
-    	      MPI_Datatype \fI*etype\fP, MPI_Datatype \fI*filetype\fP,
-              char \fI*datarep\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_get_view(MPI_File \fIfh\fP, MPI_Offset \fI*disp\fP,
+	MPI_Datatype \fI*etype\fP, MPI_Datatype \fI*filetype\fP,
+	char \fI*datarep\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_GET_VIEW(\fIFH\fP,\fI DISP\fP,\fI ETYPE\fP,
-    	      \fI FILETYPE\fP, \fIDATAREP\fP, \fI IERROR\fP)
-    	 INTEGER \fIFH, ETYPE, FILETYPE, IERROR\fP
-	 CHARACTER*(*) \fIDATAREP\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIDISP\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_GET_VIEW(\fIFH\fP, \fIDISP\fP, \fIETYPE\fP,
+	\fIFILETYPE\fP, \fIDATAREP\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, ETYPE, FILETYPE, IERROR\fP
+	CHARACTER*(*)	\fIDATAREP\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIDISP\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iread.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iread 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iread(MPI_File \fIfh\fP, void  \fI*buf\fP, int  \fIcount\fP,
-    	      MPI_Datatype  \fIdatatype\fP, MPI_Request  \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iread(MPI_File \fIfh\fP, void  \fI*buf\fP, int  \fIcount\fP,
+	MPI_Datatype  \fIdatatype\fP, MPI_Request  \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IREAD(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IREAD(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iread_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_all.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iread_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iread_all(MPI_File \fIfh\fP, void  \fI*buf\fP, int  \fIcount\fP,
-    	      MPI_Datatype  \fIdatatype\fP, MPI_Request  \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iread_all(MPI_File \fIfh\fP, void  \fI*buf\fP, int  \fIcount\fP,
+	MPI_Datatype  \fIdatatype\fP, MPI_Request  \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IREAD_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IREAD_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH INPUT/OUTPUT PARAMETER

--- a/ompi/mpi/man/man3/MPI_File_iread_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_at.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iread_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,20 +12,21 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iread_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-    	      void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
-    	      MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iread_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
+	MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IREAD_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
-		<type> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IREAD_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iread_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_at_all.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iread_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,20 +12,21 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iread_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-    	      void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
-    	      MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iread_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
+	MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IREAD_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
-		<type> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IREAD_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH INPUT PARAMETERS

--- a/ompi/mpi/man/man3/MPI_File_iread_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_iread_shared.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iread_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iread_shared(MPI_File \fIfh\fP, void \fI*buf\fP, int \fIcount\fP,
-    	      MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iread_shared(MPI_File \fIfh\fP, void \fI*buf\fP, int \fIcount\fP,
+	MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IREAD_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IREAD_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iwrite.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iwrite 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iwrite(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
-    	      MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iwrite(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
+	MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IWRITE(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<TYPE>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IWRITE(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iwrite_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_all.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iwrite_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iwrite_all(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
-    	      MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iwrite_all(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
+	MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IWRITE_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<TYPE>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IWRITE_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH INPUT/OUTPUT PARAMETER

--- a/ompi/mpi/man/man3/MPI_File_iwrite_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_at.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iwrite_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,19 +13,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iwrite_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-	      const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iwrite_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IWRITE_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
-        	<type> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IWRITE_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_iwrite_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_at_all.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iwrite_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,19 +13,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_iwrite_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-	      const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iwrite_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_IWRITE_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
-        	<type> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IWRITE_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH INPUT/OUTPUT PARAMETER

--- a/ompi/mpi/man/man3/MPI_File_iwrite_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_iwrite_shared.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_iwrite_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -13,18 +15,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype
-    	      \fIdatatype\fP, MPI_Request \fI*request\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_iwrite_shared(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype
+	\fIdatatype\fP, MPI_Request \fI*request\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_File_(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, REQUEST, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_IWRITE_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIREQUEST\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, REQUEST, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_open.3in
+++ b/ompi/mpi/man/man3/MPI_File_open.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_open 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,19 +12,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_open(MPI_Comm \fIcomm\fP, const char \fI*filename\fP,
-    	      int \fIamode\fP, MPI_Info \fIinfo\fP,
-	      MPI_File \fI*fh\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_open(MPI_Comm \fIcomm\fP, const char \fI*filename\fP,
+	int \fIamode\fP, MPI_Info \fIinfo\fP,
+	MPI_File \fI*fh\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_OPEN(\fICOMM\fP,\fI FILENAME\fP,\fI AMODE\fP, \fIINFO\fP,\fI FH\fP,\fI IERROR\fP)
-   	 CHARACTER*(*)    FILENAME
-    	 INTEGER      COMM, AMODE, INFO, FH, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_OPEN(\fICOMM\fP, \fIFILENAME\fP, \fIAMODE\fP, \fIINFO\fP, \fIFH\fP, \fIIERROR\fP)
+	CHARACTER*(*)	\fIFILENAME\fP
+	INTEGER	\fICOMM, AMODE, INFO, FH, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_preallocate.3in
+++ b/ompi/mpi/man/man3/MPI_File_preallocate.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_preallocate 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_preallocate(MPI_File \fIfh\fP, MPI_Offset \fIsize\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_preallocate(MPI_File \fIfh\fP, MPI_Offset \fIsize\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_PREALLOCATE(\fIFH\fP, \fISIZE\fP, \fIIERROR\fP)
-        	 INTEGER \fIFH, IERROR\fP
-		 INTEGER(KIND=MPI_OFFSET_KIND) \fISIZE\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_PREALLOCATE(\fIFH\fP, \fISIZE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fISIZE\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read.3in
+++ b/ompi/mpi/man/man3/MPI_File_read.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,20 +12,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read(MPI_File \fIfh\fP, void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ(\fI FH\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
-	 <type>         BUF(*)
-    	 INTEGER	FH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),
-			IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,20 +12,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_all(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_all(MPI_File \fIfh\fP, void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ALL(\fI FH\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type>		BUF(*)
-    	 INTEGER	FH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),
-			IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all_begin.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_all_begin(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_all_begin(MPI_File \fIfh\fP, void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ALL_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<TYPE>		\fIBUF\fP(*)
-        	INTEGER		\fIFH, COUNT, DATATYPE, IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ALL_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_all_end.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_all_end(MPI_File \fIfh\fP, void \fI*buf\fP,
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_all_end(MPI_File \fIfh\fP, void \fI*buf\fP,
 	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, STATUS(MPI_STATUS_SIZE), IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
 	void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
 	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
-	 <type>	\fIBUF\fP(*)
-    	 INTEGER \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
 	void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
 	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_AT_ALL(\fIFH\fP, \fI OFFSET\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type> \fIBUF\fP(*)
-    	 INTEGER \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_at_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all_begin.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_at_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_at_all_begin(MPI_File \fIfh\fP, MPI_Offset
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_at_all_begin(MPI_File \fIfh\fP, MPI_Offset
 	\fIoffset\fP, void \fI*buf\fP, int \fIcount\fP, MPI_Datatype
 	\fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_AT_ALL_BEGIN(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP,
-	\fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<type> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_AT_ALL_BEGIN(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP,
+	\fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_at_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_at_all_end.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_at_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_at_all_end(MPI_File \fIfh\fP, void \fI*buf\fP,
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_at_all_end(MPI_File \fIfh\fP, void \fI*buf\fP,
 	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_AT_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<TYPE>		BUF(*)
-        	INTEGER		FH, STATUS(MPI_STATUS_SIZE), IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_AT_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_ordered.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_ordered 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -9,21 +11,22 @@
 
 .SH SYNTAX
 .ft R
-C Syntax
+.SH C Syntax
 .nf
-    #include <mpi.h>
-    int MPI_File_read_ordered(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      	   int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
-    	      	   MPI_Status \fI*status\fP)
+#include <mpi.h>
+int MPI_File_read_ordered(MPI_File \fIfh\fP, void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
+	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ORDERED(\fIFH\fP,\fI BUF\fP,\fI COUNT\fP,\fI DATATYPE\fP,
-    	      	   \fISTATUS\fP,\fI IERROR\fP)
-    	      <type>	  \fIBUF\fP(*)
-    	      INTEGER 	  \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ORDERED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,
+	\fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_ordered_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered_begin.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_ordered_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_ordered_begin(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_ordered_begin(MPI_File \fIfh\fP, void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ORDERED_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ORDERED_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_ordered_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_ordered_end.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_ordered_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_ordered_end(MPI_File \fIfh\fP, void \fI*buf\fP,
-    	      MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_ordered_end(MPI_File \fIfh\fP, void \fI*buf\fP,
+	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_ORDERED_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, STATUS(MPI_STATUS_SIZE), IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_ORDERED_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_read_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_read_shared.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_read_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,20 +12,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_read_shared(MPI_File \fIfh\fP, void \fI*buf\fP, int \fIcount\fP,
-MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_read_shared(MPI_File \fIfh\fP, void \fI*buf\fP, int \fIcount\fP,
+	MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_READ_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fISTATUS\fP,
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_READ_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fISTATUS\fP,
 	\fIIERROR\fP)
-		<TYPE>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE,
-				STATUS(MPI_STATUS_SIZE), IERROR
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE,STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_seek.3in
+++ b/ompi/mpi/man/man3/MPI_File_seek.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_seek 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_seek(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-    	      	   int \fIwhence\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_seek(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	int \fIwhence\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SEEK(\fIFH\fP,\fI OFFSET\fP,\fI WHENCE\fP,\fI IERROR\fP)
-    	      INTEGER \fIFH, WHENCE, IERROR\fP
-    	      INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SEEK(\fIFH\fP, \fIOFFSET\fP, \fIWHENCE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, WHENCE, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_seek_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_seek_shared.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_seek_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,18 +12,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_seek_shared(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-    	      	   int \fIwhence\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_seek_shared(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	int \fIwhence\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SEEK_SHARED(\fIFH\fP,\fI OFFSET\fP,\fI WHENCE\fP,\fI IERROR\fP)
-    	      INTEGER \fIFH, WHENCE, IERROR\fP
-    	      INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SEEK_SHARED(\fIFH\fP, \fIOFFSET\fP, \fIWHENCE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, WHENCE, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_set_atomicity.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_atomicity.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_set_atomicity 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_set_atomicity(MPI_File \fIfh\fP, int \fIflag\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_set_atomicity(MPI_File \fIfh\fP, int \fIflag\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SET_ATOMICITY(\fIFH\fP,\fI FLAG\fP,\fI IERROR\fP)
-    	      INTEGER 	  FH, FLAG, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SET_ATOMICITY(\fIFH\fP, \fIFLAG\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, FLAG, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_set_info.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_info.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_set_info 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_set_info(MPI_File \fIfh\fP, MPI_Info \fIinfo\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_set_info(MPI_File \fIfh\fP, MPI_Info \fIinfo\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SET_INFO(\fIFH\fP, \fIINFO\fP, \fIIERROR\fP)
-        	 INTEGER	  FH, INFO, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SET_INFO(\fIFH\fP, \fIINFO\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, INFO, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_set_size.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_size.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_set_size 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,17 +12,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_set_size(MPI_File \fIfh\fP, MPI_Offset \fIsize\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_set_size(MPI_File \fIfh\fP, MPI_Offset \fIsize\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SET_SIZE(\fIFH\fP,\fI SIZE\fP, \fI IERROR\fP)
-        	 INTEGER \fIFH, IERROR\fP
-        	 INTEGER(KIND=MPI_OFFSET_KIND) \fISIZE\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SET_SIZE(\fIFH\fP, \fISIZE\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fISIZE\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_set_view.3in
+++ b/ompi/mpi/man/man3/MPI_File_set_view.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_set_view 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_set_view(MPI_File \fIfh\fP, MPI_Offset \fIdisp\fP,
-    	      MPI_Datatype \fIetype\fP, MPI_Datatype \fIfiletype\fP,
-	      const char \fI*datarep\fP, MPI_Info \fIinfo\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_set_view(MPI_File \fIfh\fP, MPI_Offset \fIdisp\fP,
+	MPI_Datatype \fIetype\fP, MPI_Datatype \fIfiletype\fP,
+	const char \fI*datarep\fP, MPI_Info \fIinfo\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SET_VIEW(\fIFH\fP,\fI DISP\fP,\fI ETYPE\fP,
-    	      \fI FILETYPE\fP, \fIDATAREP\fP, \fIINFO\fP,\fI IERROR\fP)
-    	 INTEGER \fIFH, ETYPE, FILETYPE, INFO, IERROR\fP
-	 CHARACTER*(*) \fIDATAREP\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIDISP\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SET_VIEW(\fIFH\fP, \fIDISP\fP, \fIETYPE\fP,
+	\fIFILETYPE\fP, \fIDATAREP\fP, \fIINFO\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, ETYPE, FILETYPE, INFO, IERROR\fP
+	CHARACTER*(*)	\fIDATAREP\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIDISP\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_sync.3in
+++ b/ompi/mpi/man/man3/MPI_File_sync.3in
@@ -2,6 +2,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_sync 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,16 +12,17 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_sync(MPI_File \fIfh\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_sync(MPI_File \fIfh\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_SYNC(\fIFH\fP, \fIIERROR\fP)
-        	 INTEGER	  FH, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_SYNC(\fIFH\fP, \fIIERROR\fP)
+	INTEGER	\fIFH, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write.3in
+++ b/ompi/mpi/man/man3/MPI_File_write.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,21 +13,21 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write(MPI_File \fIfh\fP, const void \fI*buf\fP,
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write(MPI_File \fIfh\fP, const void \fI*buf\fP,
 	int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
 	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE(\fIFH\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type> \fIBUF\fP(*)
-    	 INTEGER \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),
-		IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,20 +13,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_all(MPI_File \fIfh\fP, const void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_all(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ALL(\fIFH\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type>		BUF(*)
-    	 INTEGER	FH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),
-			IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ALL(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all_begin.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_all_begin(MPI_File \fIfh\fP, const void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_all_begin(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ALL_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ALL_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_all_end.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,17 +13,18 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_all_end(MPI_File \fIfh\fP, const void \fI*buf\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_all_end(MPI_File \fIfh\fP, const void \fI*buf\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, STATUS, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_at.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_at 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,20 +13,21 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP, const void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_at(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_AT(\fIFH\fP, \fI OFFSET\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type>	\fIBUF\fP(*)
-    	 INTEGER \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_AT(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_at_all.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_at_all 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,20 +13,21 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP, const void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_at_all(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_AT_ALL(\fIFH\fP, \fI OFFSET\fP, \fI BUF\fP, \fICOUNT\fP,
-    	      \fI DATATYPE\fP, \fISTATUS\fP, \fI IERROR\fP)
-	 <type> \fIBUF\fP(*)
-    	 INTEGER \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
-    	 INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_AT_ALL(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP,
+	\fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_at_all_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all_begin.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_at_all_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,19 +13,20 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_at_all_begin(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
-	      const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_at_all_begin(MPI_File \fIfh\fP, MPI_Offset \fIoffset\fP,
+	const void \fI*buf\fP, int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax (see FORTRAN 77 NOTES)
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_AT_ALL_BEGIN(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<TYPE> \fIBUF\fP(*)
-        	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
-		INTEGER(KIND=MPI_OFFSET_KIND) \fIOFFSET\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_AT_ALL_BEGIN(\fIFH\fP, \fIOFFSET\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
+	INTEGER(KIND=MPI_OFFSET_KIND)	\fIOFFSET\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_at_all_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_at_all_end.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_at_all_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_at_all_end(MPI_File \fIfh\fP, const void \fI*buf\fP,
-	      MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_at_all_end(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_AT_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, STATUS(MPI_STATUS_SIZE), IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_AT_ALL_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_ordered.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_ordered 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -10,21 +12,22 @@
 
 .SH SYNTAX
 .ft R
-C Syntax
+.SH C Syntax
 .nf
-    #include <mpi.h>
-    int MPI_File_write_ordered(MPI_File \fIfh\fP, const void \fI*buf\fP,
-    	      	   int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
-    	      	   MPI_Status \fI*status\fP)
+#include <mpi.h>
+int MPI_File_write_ordered(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP,
+	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ORDERED(\fIFH\fP,\fI BUF\fP,\fI COUNT\fP,\fI DATATYPE\fP,
-    	      	   \fISTATUS\fP,\fI IERROR\fP)
-    	      <type>	  \fIBUF\fP(*)
-    	      INTEGER 	  \fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ORDERED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,
+	\fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF\fP(*)
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_ordered_begin.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered_begin.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_ordered_begin 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_ordered_begin(MPI_File \fIfh\fP, const void \fI*buf\fP,
-    	      int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_ordered_begin(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	int \fIcount\fP, MPI_Datatype \fIdatatype\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ORDERED_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, COUNT, DATATYPE, IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ORDERED_BEGIN(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_ordered_end.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_ordered_end.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_ordered_end 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,18 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_ordered_end(MPI_File \fIfh\fP, const void \fI*buf\fP,
-    	      MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_ordered_end(MPI_File \fIfh\fP, const void \fI*buf\fP,
+	MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_ORDERED_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		BUF(*)
-        	INTEGER		FH, STATUS(MPI_STATUS_SIZE), IERROR
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_ORDERED_END(\fIFH\fP, \fIBUF\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_File_write_shared.3in
+++ b/ompi/mpi/man/man3/MPI_File_write_shared.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_File_write_shared 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,19 +13,19 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_File_write_shared(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
-    	      MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_File_write_shared(MPI_File \fIfh\fP, const void \fI*buf\fP, int \fIcount\fP,
+	MPI_Datatype \fIdatatype\fP, MPI_Status \fI*status\fP)
 
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_FILE_WRITE_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fISTATUS\fP,\fI IERROR\fP)
-		<type>		\fIBUF(*)\fP
-        	INTEGER		\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE),
-				     IERROR\fP
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_FILE_WRITE_SHARED(\fIFH\fP, \fIBUF\fP, \fICOUNT\fP, \fIDATATYPE\fP, \fISTATUS\fP, \fIIERROR\fP)
+	<type>	\fIBUF(*)\fP
+	INTEGER	\fIFH, COUNT, DATATYPE, STATUS(MPI_STATUS_SIZE), IERROR\fP
 
 .fi
 .SH C++ Syntax

--- a/ompi/mpi/man/man3/MPI_Register_datarep.3in
+++ b/ompi/mpi/man/man3/MPI_Register_datarep.3in
@@ -3,6 +3,8 @@
 .\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright 2015      Research Organization for Information Science
+.\"                     and Technology (RIST). All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_Register_datarep 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -11,25 +13,27 @@
 .SH SYNTAX
 .ft R
 .nf
-C Syntax
-    #include <mpi.h>
-    int MPI_Register_datarep(const char \fI*datarep\fP,
-    	      MPI_Datarep_conversion_function \fI*read_conversion_fn\fP,
-    	      MPI_Datarep_conversion_function \fI*write_conversion_fn\fP,
-    	      MPI_Datarep_extent_function \fI*dtype_file_extent_fn\fP,
-    	      void \fI*extra_state\fP)
+.SH C Syntax
+#include <mpi.h>
+int MPI_Register_datarep(const char \fI*datarep\fP,
+	MPI_Datarep_conversion_function \fI*read_conversion_fn\fP,
+	MPI_Datarep_conversion_function \fI*write_conversion_fn\fP,
+	MPI_Datarep_extent_function \fI*dtype_file_extent_fn\fP,
+	void \fI*extra_state\fP)
+
 .fi
 .SH Fortran Syntax
 .nf
-    INCLUDE 'mpif.h'
-    MPI_REGISTER_DATAREP(\fIDATAREP\fP, \fIREAD_CONVERSION_FN\fP,
+USE MPI
+! or the older form: INCLUDE 'mpif.h'
+MPI_REGISTER_DATAREP(\fIDATAREP\fP, \fIREAD_CONVERSION_FN\fP,
 	\fIWRITE_CONVERSION_FN\fP, \fIDTYPE_FILE_EXTENT_FN\fP,
-	\fIEXTRA_STATE\fP,\fI IERROR\fP)
-		CHARACTER*(*) \fIDATAREP\fP
-		EXTERNAL \fIREAD_CONVERSION_FN, WRITE_CONVERSION_FN,
-		         DTYPE_FILE_EXTENT_FN\fP
-        	INTEGER	\fIIERROR\fP
-		INTEGER(KIND=MPI_ADDRESS_KIND) \fIEXTRA_STATE\fP
+	\fIEXTRA_STATE\fP, \fIIERROR\fP)
+	CHARACTER*(*)	\fIDATAREP\fP
+	EXTERNAL	\fIREAD_CONVERSION_FN, WRITE_CONVERSION_FN, DTYPE_FILE_EXTENT_FN\fP
+	INTEGER	\fIIERROR\fP
+	INTEGER(KIND=MPI_ADDRESS_KIND)	\fIEXTRA_STATE\fP
+
 .fi
 .SH C++ Syntax
 .nf


### PR DESCRIPTION
- suggest USE mpi instead of INCLUDE 'mpif.h'
- fix indentation
  Thanks Jeff for pointing this issue.

(cherry picked from commit open-mpi/ompi@b17c89c1e63d4cc4e9420fc818e0d172156be9c4)
