### PR TITLE
opal/keyval: reset buffer pointer/size in finalize

### DIFF
--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -31,6 +31,8 @@ int
 opal_util_keyval_parse_finalize(void)
 {
     if (NULL != key_buffer) free(key_buffer);
+    key_buffer = NULL;
+    key_buffer_len = 0;
 
     OBJ_DESTRUCT(&keyval_mutex);
 


### PR DESCRIPTION
Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@6d3041335ffa2c427c48e3279a6a4315be5cb643)
