### PR TITLE
btl/openib: fix argument type for internal atomic function

### DIFF
--- a/opal/mca/btl/openib/btl_openib_atomic.c
+++ b/opal/mca/btl/openib/btl_openib_atomic.c
@@ -22,7 +22,7 @@
 static int mca_btl_openib_atomic_internal (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
 					   void *local_address, uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
 					   mca_btl_base_registration_handle_t *remote_handle, enum ibv_wr_opcode opcode,
-					   int64_t operand, int operand2, int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
+					   int64_t operand, int64_t operand2, int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
 					   void *cbcontext, void *cbdata)
 {
     mca_btl_openib_get_frag_t* frag = NULL;


### PR DESCRIPTION
This was fixed on my btl 3.0 branch but the changeset got lost in a
rebase. Fixes issues with lock ups when using osc/rdma.

References open-mpi/ompi#1010

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@55d24ee7a3ff19f52f2f97df2a67f927005b29ea)
