### PR TITLE
Cleanup some cruft and update to coordinate with CM operations:

### DIFF
--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -602,6 +602,13 @@ static int rte_init(void)
     orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD, ORTE_RML_TAG_SHOW_HELP,
                             ORTE_RML_PERSISTENT, orte_show_help_recv, NULL);
 
+    /* setup the data server */
+    if (ORTE_SUCCESS != (ret = orte_data_server_init())) {
+        ORTE_ERROR_LOG(ret);
+        error = "orte_data_server_init";
+        goto error;
+    }
+
     if (orte_create_session_dirs) {
         /* set the opal_output hnp file location to be in the
          * proc-specific session directory. */
@@ -773,6 +780,8 @@ static int rte_finalize(void)
     /* shutdown the pmix server */
     pmix_server_finalize();
     (void) mca_base_framework_close(&opal_pmix_base_framework);
+    /* cleanup our data server */
+    orte_data_server_finalize();
 
     (void) mca_base_framework_close(&orte_schizo_base_framework);
     (void) mca_base_framework_close(&orte_dfs_base_framework);

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1265,9 +1265,11 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         opal_argv_append(argc, argv, "orte_report_bindings");
         opal_argv_append(argc, argv, "1");
     }
-    /* pass our topology signature */
-    opal_argv_append(argc, argv, "--hnp-topo-sig");
-    opal_argv_append(argc, argv, orte_topo_signature);
+    if (!ORTE_PROC_IS_CM) {
+       /* pass our topology signature */
+        opal_argv_append(argc, argv, "--hnp-topo-sig");
+        opal_argv_append(argc, argv, orte_topo_signature);
+    }
     if (orte_hetero_nodes) {
         opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
         opal_argv_append(argc, argv, "orte_hetero_nodes");
@@ -1307,7 +1309,7 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
 
     /* pass the daemon jobid */
     opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
-    opal_argv_append(argc, argv, "orte_ess_jobid");
+    opal_argv_append(argc, argv, "ess_base_jobid");
     if (ORTE_SUCCESS != (rc = orte_util_convert_jobid_to_string(&param, ORTE_PROC_MY_NAME->jobid))) {
         ORTE_ERROR_LOG(rc);
         return rc;
@@ -1318,7 +1320,7 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
     /* setup to pass the vpid */
     if (NULL != proc_vpid_index) {
         opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
-        opal_argv_append(argc, argv, "orte_ess_vpid");
+        opal_argv_append(argc, argv, "ess_base_vpid");
         *proc_vpid_index = *argc;
         opal_argv_append(argc, argv, "<template>");
     }
@@ -1331,7 +1333,7 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         num_procs = orte_process_info.num_procs;
     }
     opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
-    opal_argv_append(argc, argv, "orte_ess_num_procs");
+    opal_argv_append(argc, argv, "ess_base_num_procs");
     asprintf(&param, "%lu", num_procs);
     opal_argv_append(argc, argv, param);
     free(param);
@@ -1364,13 +1366,6 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         opal_argv_append(argc, argv, "orte_node_regex");
         opal_argv_append(argc, argv, param);
         free(param);
-    }
-
-    /* warn the daemons if we are using a tree spawn pattern so they
-     * know they shouldn't do a rollup on their callback
-     */
-    if (NULL != orte_tree_launch_cmd) {
-        opal_argv_append(argc, argv, "--tree-spawn");
     }
 
     /* if output-filename was specified, pass that along */

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -560,10 +560,17 @@ static int setup_launch(int *argcptr, char ***argvptr,
      * Add the basic arguments to the orted command line, including
      * all debug options
      */
-    orte_plm_base_orted_append_basic_args(&argc, &argv,
-                                          "env",
-                                          proc_vpid_index,
-                                          NULL);
+    if (ORTE_PROC_IS_CM) {
+        orte_plm_base_orted_append_basic_args(&argc, &argv,
+                                              NULL,
+                                              proc_vpid_index,
+                                              NULL);
+    } else {
+        orte_plm_base_orted_append_basic_args(&argc, &argv,
+                                              "env",
+                                              proc_vpid_index,
+                                              NULL);
+    }
 
     /* ensure that only the ssh plm is selected on the remote daemon */
     opal_argv_append_nosize(&argv, "-"OPAL_MCA_CMD_LINE_ID);
@@ -613,9 +620,6 @@ static int setup_launch(int *argcptr, char ***argvptr,
 
     /* protect the params */
     mca_base_cmd_line_wrap_args(argv);
-
-    /* tell the daemon we are in a tree spawn */
-    opal_argv_append(&argc, &argv, "--tree-spawn");
 
     value = opal_argv_join(argv, ' ');
     if (sysconf(_SC_ARG_MAX) < (int)strlen(value)) {

--- a/orte/mca/state/dvm/state_dvm_component.c
+++ b/orte/mca/state/dvm/state_dvm_component.c
@@ -70,9 +70,14 @@ static int state_dvm_close(void)
 
 static int state_dvm_component_query(mca_base_module_t **module, int *priority)
 {
-    /* we are only used when an envar is set directing it,
-     * so set our priority very low */
+    /* used by DVM masters */
+    if (ORTE_PROC_IS_MASTER) {
+        *priority = 100;
+        *module = (mca_base_module_t *)&orte_state_dvm_module;
+        return ORTE_SUCCESS;
+    }
+
     *priority = 0;
-    *module = (mca_base_module_t *)&orte_state_dvm_module;
-    return ORTE_SUCCESS;
+    *module = NULL;
+    return ORTE_ERR_NOT_AVAILABLE;
 }

--- a/orte/mca/state/hnp/state_hnp_component.c
+++ b/orte/mca/state/hnp/state_hnp_component.c
@@ -71,7 +71,7 @@ static int state_hnp_close(void)
 
 static int state_hnp_component_query(mca_base_module_t **module, int *priority)
 {
-    if (ORTE_PROC_IS_HNP) {
+    if (ORTE_PROC_IS_HNP && !ORTE_PROC_IS_MASTER) {
         /* set our priority high as we are the default for hnps */
         *priority = my_priority;
         *module = (mca_base_module_t *)&orte_state_hnp_module;

--- a/orte/mca/state/orted/state_orted_component.c
+++ b/orte/mca/state/orted/state_orted_component.c
@@ -71,7 +71,7 @@ static int state_orted_close(void)
 
 static int state_orted_component_query(mca_base_module_t **module, int *priority)
 {
-    if (ORTE_PROC_IS_DAEMON) {
+    if (ORTE_PROC_IS_DAEMON && !ORTE_PROC_IS_CM) {
         /* set our priority high as we are the default for orteds */
         *priority = my_priority;
         *module = (mca_base_module_t *)&orte_state_orted_module;

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -179,10 +179,6 @@ opal_cmd_line_init_t orte_cmd_line_opts[] = {
       NULL, OPAL_CMD_LINE_TYPE_STRING,
       "URI for the parent if tree launch is enabled."},
 
-    { NULL, '\0', NULL, "tree-spawn", 0,
-      &orted_globals.tree_spawn, OPAL_CMD_LINE_TYPE_BOOL,
-      "Tree spawn is underway"},
-
     { NULL, '\0', NULL, "set-sid", 0,
       &orted_globals.set_sid, OPAL_CMD_LINE_TYPE_BOOL,
       "Direct the orted to separate from the current session"},

--- a/orte/runtime/orte_data_server.c
+++ b/orte/runtime/orte_data_server.c
@@ -104,10 +104,16 @@ OBJ_CLASS_INSTANCE(orte_data_req_t,
 /* local globals */
 static opal_pointer_array_t orte_data_server_store;
 static opal_list_t pending;
+static bool initialized = false;
 
 int orte_data_server_init(void)
 {
     int rc;
+
+    if (initialized) {
+        return ORTE_SUCCESS;
+    }
+    initialized = true;
 
     OBJ_CONSTRUCT(&orte_data_server_store, opal_pointer_array_t);
     if (ORTE_SUCCESS != (rc = opal_pointer_array_init(&orte_data_server_store,
@@ -133,6 +139,11 @@ void orte_data_server_finalize(void)
 {
     orte_std_cntr_t i;
     orte_data_object_t *data;
+
+    if (!initialized) {
+        return;
+    }
+    initialized = false;
 
     orte_rml.recv_cancel(ORTE_NAME_WILDCARD, ORTE_RML_TAG_DATA_SERVER);
 

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -105,7 +105,6 @@
 #include "orte/runtime/runtime.h"
 #include "orte/runtime/orte_globals.h"
 #include "orte/runtime/orte_wait.h"
-#include "orte/runtime/orte_data_server.h"
 #include "orte/runtime/orte_locks.h"
 #include "orte/runtime/orte_quit.h"
 
@@ -1026,13 +1025,6 @@ int orterun(int argc, char *argv[])
      */
     orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD, ORTE_RML_TAG_DAEMON,
                             ORTE_RML_PERSISTENT, orte_daemon_recv, NULL);
-
-    /* setup the data server */
-    if (ORTE_SUCCESS != (rc = orte_data_server_init())) {
-        ORTE_ERROR_LOG(rc);
-        ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
-        goto DONE;
-    }
 
     /* setup for debugging */
     orte_debugger_init_before_spawn(jdata);

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -58,9 +58,10 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_APP           0x0030
 #define ORTE_PROC_CM            0x0040
 #define ORTE_PROC_AGGREGATOR    0x0080
+#define ORTE_PROC_DVM           0x0102   // DVM + daemon
 #define ORTE_PROC_IOF_ENDPT     0x1000
 #define ORTE_PROC_SCHEDULER     0x2000
-#define ORTE_PROC_MASTER        0x4000
+#define ORTE_PROC_MASTER        0x4004   // Master + HNP
 
 #define ORTE_PROC_IS_SINGLETON      (ORTE_PROC_SINGLETON & orte_process_info.proc_type)
 #define ORTE_PROC_IS_DAEMON         (ORTE_PROC_DAEMON & orte_process_info.proc_type)
@@ -71,6 +72,7 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_IS_APP            (ORTE_PROC_APP & orte_process_info.proc_type)
 #define ORTE_PROC_IS_CM             (ORTE_PROC_CM & orte_process_info.proc_type)
 #define ORTE_PROC_IS_AGGREGATOR     (ORTE_PROC_AGGREGATOR & orte_process_info.proc_type)
+#define ORTE_PROC_IS_DVM            (ORTE_PROC_DVM & orte_process_info.proc_type)
 #define ORTE_PROC_IS_IOF_ENDPT      (ORTE_PROC_IOF_ENDPT & orte_process_info.proc_type)
 #define ORTE_PROC_IS_SCHEDULER      (ORTE_PROC_SCHEDULER & orte_process_info.proc_type)
 #define ORTE_PROC_IS_MASTER         (ORTE_PROC_MASTER & orte_process_info.proc_type)


### PR DESCRIPTION
- don't pass --tree-spawn to the orted cmd line. If someone doesn't want tree-spawn, it shows up as an MCA param anyway
- ensure state/orted component disqualifies itself from CM operations
- clarify the DVM proc_type definitions
- ensure we stop littering the tmp dir with session directories

(cherry picked from commit open-mpi/ompi@0b1d4b62be0ba6fd66f7876a843fcf28b1337d70)

Fix orte-submit so it allows application procs to select the correct ess component. Protect orte_data_server from multiple calls to finalize.

(cherry picked from commit open-mpi/ompi@f872e99315a74afed468b20411c9d200052ba5ed)

Adjust the process type flags to remove confusion between orted and dvm state machines

(cherry picked from commit open-mpi/ompi@bc7815e1785c34bdc13097373b69a669ab08acd0)
