### PR TITLE
oshmem: minor compiler warning stomp

### DIFF
--- a/oshmem/proc/proc.c
+++ b/oshmem/proc/proc.c
@@ -3,6 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,7 +65,7 @@ int oshmem_proc_group_init(void)
 {
     if (orte_process_info.num_procs != opal_list_get_size(&ompi_proc_list)) {
         opal_output(0,
-                "Error: oshmem_group_all is not created: orte_process_info.num_procs = %d ompi_proc_list = %d",
+                "Error: oshmem_group_all is not created: orte_process_info.num_procs = %d ompi_proc_list = %" PRIsize_t,
 		orte_process_info.num_procs,
 		opal_list_get_size(&ompi_proc_list));
         return OSHMEM_ERROR;


### PR DESCRIPTION
@miked-mellanox Please review.  It's a trivial compiler warning stomp.

(cherry picked from commit open-mpi/ompi@c5eef3c534b98bf0a96dba2fd3cd128c248b46c7)
