### PR TITLE
Silence a couple of warnings from valgrind and compilers

### DIFF
--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -148,12 +148,13 @@ static int ompi_proc_complete_init_single (ompi_proc_t *proc)
     }
 
     /* we can retrieve the hostname at no cost because it
-     * was provided at startup */
+     * was provided at startup - but make it optional so
+     * we don't chase after it if some system doesn't
+     * provide it */
+    proc->super.proc_hostname = NULL;
     OPAL_MODEX_RECV_VALUE_OPTIONAL(ret, OPAL_PMIX_HOSTNAME, &proc->super.proc_name,
-			  (char**)&(proc->super.proc_hostname), OPAL_STRING);
-    if (OPAL_SUCCESS != ret) {
-	return ret;
-    }
+                                   (char**)&(proc->super.proc_hostname), OPAL_STRING);
+
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
     /* get the remote architecture - this might force a modex except
      * for those environments where the RM provides it */
@@ -498,7 +499,7 @@ ompi_proc_t **ompi_proc_world (size_t *size)
          * count which cannot be released until ompi_proc_finalize is
          * called.
          */
-        procs[i] = ompi_proc_for_name (name);
+        procs[i] = (ompi_proc_t*)ompi_proc_for_name (name);
     }
 
     *size = count;

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -140,8 +140,12 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
         _info->data.flag = true;                                                         \
         opal_list_append(&(_ilist), &(_info)->super);                                    \
         if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), &(_ilist), &(_kv)))) {        \
-            (r) = opal_value_unload(_kv, (void**)(d), (t));                              \
-            OBJ_RELEASE(_kv);                                                            \
+            if (NULL == _kv) {                                                           \
+                (r) = OPAL_ERR_NOT_FOUND;                                                \
+            } else {                                                                     \
+                (r) = opal_value_unload(_kv, (void**)(d), (t));                          \
+                OBJ_RELEASE(_kv);                                                        \
+            }                                                                            \
         }                                                                                \
         OPAL_LIST_DESTRUCT(&(_ilist));                                                   \
     } while(0);
@@ -167,8 +171,12 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
                             __FILE__, __LINE__,                                 \
                             OPAL_NAME_PRINT(*(p)), (s)));                       \
         if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), NULL, &(_kv)))) {    \
-            (r) = opal_value_unload(_kv, (void**)(d), (t));                     \
-            OBJ_RELEASE(_kv);                                                   \
+            if (NULL == _kv) {                                                  \
+                (r) = OPAL_ERR_NOT_FOUND;                                       \
+            } else {                                                            \
+                (r) = opal_value_unload(_kv, (void**)(d), (t));                 \
+                OBJ_RELEASE(_kv);                                               \
+           }                                                                    \
         }                                                                       \
     } while(0);
 
@@ -193,12 +201,19 @@ extern int opal_pmix_base_exchange(opal_value_t *info,
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),                 \
                             __FILE__, __LINE__,                                 \
                             OPAL_NAME_PRINT(*(p)), (s)));                       \
-        if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), NULL, &(_kv))) &&    \
-            NULL != _kv) {                                                      \
-            *(d) = _kv->data.bo.bytes;                                          \
-            *(sz) = _kv->data.bo.size;                                          \
-            _kv->data.bo.bytes = NULL; /* protect the data */                   \
-            OBJ_RELEASE(_kv);                                                   \
+        if (OPAL_SUCCESS == ((r) = opal_pmix.get((p), (s), NULL, &(_kv)))) {    \
+            if (NULL == _kv) {                                                  \
+                *(sz) = 0;                                                      \
+                (r) = OPAL_ERR_NOT_FOUND;                                       \
+            } else {                                                            \
+                *(d) = _kv->data.bo.bytes;                                      \
+                *(sz) = _kv->data.bo.size;                                      \
+                _kv->data.bo.bytes = NULL; /* protect the data */               \
+                OBJ_RELEASE(_kv);                                               \
+            }                                                                   \
+        } else {                                                                \
+            *(sz) = 0;                                                          \
+            (r) = OPAL_ERR_NOT_FOUND;                                           \
         }                                                                       \
     } while(0);
 


### PR DESCRIPTION
Since some pmix components may return success with a NULL value from a "get", check for that situation before attempting to unload the data. Preset the hostname before calling modex_recv to get it so unload properly checks for NULL. Cast a returned value to the correct ompi_proc_t pointer

(cherry picked from commit open-mpi/ompi@4c12022a50efb68ea116a3ffeadeb2384bda9024)
