### PR TITLE
Resolve a race condition when registering sigchild callbacks

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -1025,7 +1025,7 @@ void orte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             }
 
             if (5 < opal_output_get_verbosity(orte_odls_base_framework.framework_output)) {
-                opal_output(orte_odls_base_framework.framework_output, "%s odls:launch: spawning child %s",
+                opal_output(orte_odls_base_framework.framework_output, "%s odls:launch spawning child %s",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                             ORTE_NAME_PRINT(&child->name));
 


### PR DESCRIPTION
 Resolve a race condition that prevented the sigchild callback from being registered before short-lived apps terminated. Also includes minor cleanup of debug message.

Thanks to Mark Santcroos for the assistance in tracking it down.

(cherry picked from commit open-mpi/ompi@6506b0a5e52157af1abad167dfcd29ef4f929d19)
(cherry picked from commit open-mpi/ompi@30aab75b86bdd83b1c1c452e24d62c751ddd83e5)
