### PR TITLE
configury: add support for Fujitsu compilers.

### DIFF
--- a/config/ompi_check_vendor.m4
+++ b/config/ompi_check_vendor.m4
@@ -108,6 +108,11 @@ AC_DEFUN([_OMPI_CHECK_COMPILER_VENDOR], [
           [OMPI_IF_IFELSE([defined(__INTEL_COMPILER) || defined(__ICC)], 
                [ompi_check_compiler_vendor_result="intel"])])
 
+    # Fujitsu
+    AS_IF([test "$ompi_check_compiler_vendor_result" = "unknown"],
+          [OMPI_IF_IFELSE([defined(__FUJITSU)], 
+               [ompi_check_compiler_vendor_result="fujitsu"])])
+
     # GNU
     AS_IF([test "$ompi_check_compiler_vendor_result" = "unknown"],
           [OMPI_IFDEF_IFELSE([__GNUC__], 


### PR DESCRIPTION
Fujitsu compilers used with the GNU compatibility option (-Xg)
do not yet support all the gnu flags (e.g. -pedantic) and that can
cause the linker (and hence configure) crash.
Fujitsu compilers are identified by the __FUJITSU macro.

(back ported from commit open-mpi/ompi@1f525b06f0356b4173e3e5f34c5eff64f42538b2)
