### PR TITLE
v1.10.1.: common_usnic: move fake IBV provider to libmpi

### DIFF
--- a/ompi/mca/common/verbs/Makefile.am
+++ b/ompi/mca/common/verbs/Makefile.am
@@ -17,7 +17,6 @@ headers = \
 sources = \
 	common_verbs_basics.c \
 	common_verbs_devlist.c \
-	common_verbs_fake.c \
 	common_verbs_find_max_inline.c \
 	common_verbs_find_ports.c \
 	common_verbs_mca.c \

--- a/ompi/mca/common/verbs/common_verbs.h
+++ b/ompi/mca/common/verbs/common_verbs.h
@@ -186,11 +186,6 @@ OMPI_DECLSPEC int ompi_common_verbs_qp_test(struct ibv_context *device_context,
  */
 int opal_common_verbs_fork_test(void);
 
-/*
- * Register fake verbs drivers
- */
-void opal_common_verbs_register_fake_drivers(void);
-
 END_C_DECLS
 
 #endif

--- a/ompi/mca/common/verbs/common_verbs_basics.c
+++ b/ompi/mca/common/verbs/common_verbs_basics.c
@@ -21,6 +21,8 @@
 #include <unistd.h>
 #endif
 
+#include "ompi/mca/common/verbs_usnic/common_verbs_usnic.h"
+
 /* This is crummy, but <infiniband/driver.h> doesn't work on all
    platforms with all compilers.  Specifically, trying to include it
    on RHEL4U3 with the PGI 32 bit compiler will cause problems because
@@ -91,10 +93,12 @@ int opal_common_verbs_fork_test(void)
     }
 #endif
 
-    /* Now rgister any necessary fake libibverbs drivers.  We
+    /* Now register any necessary fake libibverbs drivers.  We
        piggyback loading these fake drivers on the fork test because
-       they must be loaded before ibv_get_device_list() is invoked. */
-    opal_common_verbs_register_fake_drivers();
+       they must be loaded before ibv_get_device_list() is invoked.
+       Note that this routine is in a different common component (see
+       comments over there for an explanation why).  */
+    ompi_common_verbs_usnic_register_fake_drivers();
 
     return ret;
 }

--- a/ompi/mca/common/verbs_usnic/Makefile.am
+++ b/ompi/mca/common/verbs_usnic/Makefile.am
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2009-2012 Mellanox Technologies.  All rights reserved.
+# Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = common_verbs_usnic.h
+
+sources = common_verbs_usnic_fake.c
+
+# This component is always linked statically.  It has code that is
+# registered as a driver for libibverbs.  There is no corresponding
+# *un*register API in libibverbs, so this code can never be dlclosed.
+# And therefore it must be in the libopen-pal library, not a DSO or
+# dependent library.
+
+noinst_LTLIBRARIES = libmca_common_verbs_usnic.la
+
+libmca_common_verbs_usnic_la_SOURCES = \
+        $(headers) $(sources)
+libmca_common_verbs_usnic_la_CPPFLAGS = \
+        $(common_verbs_usnic_CPPFLAGS)
+libmca_common_verbs_usnic_la_LDFLAGS =  \
+        $(common_verbs_usnic_LDFLAGS)
+libmca_common_verbs_usnic_la_LIBADD = \
+        $(common_verbs_usnic_LIBS)
+
+# Conditionally install the header files
+
+if WANT_INSTALL_HEADERS
+ompidir = $(ompiincludedir)/ompi/mca/common/verbs_usnic
+ompi_HEADERS = $(headers)
+else
+ompidir = $(includedir)
+endif

--- a/ompi/mca/common/verbs_usnic/common_verbs_usnic.h
+++ b/ompi/mca/common/verbs_usnic/common_verbs_usnic.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _COMMON_VERBS_USNIC_H_
+#define _COMMON_VERBS_USNIC_H_
+
+#include "opal_config.h"
+
+#include <stdint.h>
+#include <infiniband/verbs.h>
+
+BEGIN_C_DECLS
+
+/*
+ * Register fake verbs drivers
+ */
+void ompi_common_verbs_usnic_register_fake_drivers(void);
+
+END_C_DECLS
+
+#endif

--- a/ompi/mca/common/verbs_usnic/common_verbs_usnic_fake.c
+++ b/ompi/mca/common/verbs_usnic/common_verbs_usnic_fake.c
@@ -27,10 +27,18 @@
  * More specifically: the userspace side of usNIC is exposed through
  * libfabric; we don't need libibverbs warnings about not being able
  * to find a usnic driver.
+ *
+ * Note: this code is statically linked into libopen-pal.  It is
+ * registered via ibv_register_driver(), and there is no corresponding
+ * *un*register IBV API.  Hence, we cannot allow this code to be
+ * dlclosed (e.g., if it is a DSO or a dependent common library) -- it
+ * must be in libopen-pal itself, which will stay resident in the MPI
+ * application.
  */
 
-#include "opal_config.h"
+#include "ompi_config.h"
 
+#include <stdio.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <string.h>
@@ -39,7 +47,7 @@
 #include <infiniband/driver.h>
 #endif
 
-#include "common_verbs.h"
+#include "common_verbs_usnic.h"
 
 /***********************************************************************/
 
@@ -82,7 +90,9 @@ static struct ibv_device *fake_driver_init(const char *uverbs_sys_path,
                             value, sizeof(value)) < 0) {
         return NULL;
     }
-    sscanf(value, "%i", &vendor);
+    if (sscanf(value, "%i", &vendor) != 1) {
+        return NULL;
+    }
 
     if (vendor == PCI_VENDOR_ID_CISCO) {
         return &fake_dev;
@@ -93,7 +103,7 @@ static struct ibv_device *fake_driver_init(const char *uverbs_sys_path,
 }
 
 
-void opal_common_verbs_register_fake_drivers(void)
+void ompi_common_verbs_usnic_register_fake_drivers(void)
 {
     /* No need to do this more than once */
     static bool already_done = false;

--- a/ompi/mca/common/verbs_usnic/configure.m4
+++ b/ompi/mca/common/verbs_usnic/configure.m4
@@ -1,0 +1,54 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2012 Mellanox Technologies.  All rights reserved.
+# Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# This component must be linked statically into libopen-pal because it
+# registers a provider for libibverbs at run time, and there's no
+# libibverbs API to *un*register a plugin.  Hence, we can't allow this
+# code to be dlclosed/removed from the process.  Hence: it must be
+# compiled statically into libopen-pal.
+#
+AC_DEFUN([MCA_ompi_common_verbs_usnic_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+# MCA_ompi_common_verbs_usnic_CONFIG([action-if-can-compile],
+#                      [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_common_verbs_usnic_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/common/verbs_usnic/Makefile])
+    common_verbs_usnic_happy="no"
+
+    OMPI_CHECK_OPENFABRICS([common_verbs_usnic],
+                           [common_verbs_usnic_happy="yes"])
+
+    AS_IF([test "$common_verbs_usnic_happy" = "yes"],
+          [$1],
+          [$2])
+
+    # substitute in the things needed to build openib
+    AC_SUBST([common_verbs_usnic_CPPFLAGS])
+    AC_SUBST([common_verbs_usnic_LDFLAGS])
+    AC_SUBST([common_verbs_usnic_LIBS])
+])dnl


### PR DESCRIPTION
Ported from open-mpi/ompi@c28324c5c8e150f16158ae57be6e7fff9ea00978

Move the fake usnic IBV provider out of common/verbs and into a new common/verbs_usnic component that is always statically linked into libmpi.  The fake provider is registered with libibverbs at run time, but there is no _un_register IBV API.  Hence, we can't let the code containing this provider be dlclosed -- which means it needs to be statically linked into libmpi.

@goodell Please review (this is the v1.10.1 version of #721.
