### PR TITLE
Silence coverity warnings

### DIFF
--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$

--- a/orte/mca/plm/base/plm_base_receive.c
+++ b/orte/mca/plm/base/plm_base_receive.c
@@ -221,9 +221,9 @@ void orte_plm_base_recv(int status, orte_process_name_t* sender,
             } else {
                 jdata->bookmark = parent->bookmark;
             }
+            /* provide the parent's last object */
+            jdata->bkmark_obj = parent->bkmark_obj;
         }
-        /* provide the parent's last object */
-        jdata->bkmark_obj = parent->bkmark_obj;
 
         /* launch it */
         OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,

--- a/orte/mca/ras/simulator/ras_sim_module.c
+++ b/orte/mca/ras/simulator/ras_sim_module.c
@@ -220,7 +220,11 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
     if (NULL != node_cnt) {
         opal_argv_free(node_cnt);
     }
-
+#if OPAL_HAVE_HWLOC
+    if (NULL != topos) {
+        opal_argv_free(topos);
+    }
+#endif
     return ORTE_SUCCESS;
 
 error_silent:


### PR DESCRIPTION
pick up some coverity fixes to facilitate merges of subsequent commits in to ompi-release

@rhc54 

(cherry picked from commit open-mpi/ompi@023936e84bce80ab90ae1af5438163432f894d3f)

Conflicts:
    ompi/mca/dpm/orte/dpm_orte.c
