### PR TITLE
Fix a few more places that utilized CUDA 4.1 checks

### DIFF
--- a/opal/mca/btl/smcuda/configure.m4
+++ b/opal/mca/btl/smcuda/configure.m4
@@ -4,7 +4,7 @@
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2012-2013 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,8 +21,8 @@ AC_DEFUN([MCA_opal_btl_smcuda_CONFIG],[
     # make sure that CUDA-aware checks have been done
     AC_REQUIRE([OPAL_CHECK_CUDA])
 
-    # Only build if CUDA 4.1 support is available
-    AS_IF([test "x$CUDA_SUPPORT_41" = "x1"],
+    # Only build if CUDA support is available
+    AS_IF([test "x$CUDA_SUPPORT" = "x1"],
           [$1],
           [$2])
 

--- a/opal/mca/common/cuda/common_cuda.c
+++ b/opal/mca/common/cuda/common_cuda.c
@@ -20,9 +20,7 @@
 
 /**
  * This file contains various support functions for doing CUDA
- * operations.  Some of the features are only available in CUDA 4.1
- * and later, so some code is conditionalized around the
- * OPAL_CUDA_SUPPORT_41 macro.
+ * operations.
  */
 #include "opal_config.h"
 

--- a/opal/mca/mpool/gpusm/configure.m4
+++ b/opal/mca/mpool/gpusm/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,7 +18,7 @@ AC_DEFUN([MCA_opal_mpool_gpusm_CONFIG],[
     AC_CONFIG_FILES([opal/mca/mpool/gpusm/Makefile])
 
     # Use CUDA_SUPPORT which was filled in by the opal configure code.
-    AS_IF([test "x$CUDA_SUPPORT_41" = "x1"],
+    AS_IF([test "x$CUDA_SUPPORT" = "x1"],
           [$1],
           [$2])
 

--- a/opal/mca/mpool/rgpusm/configure.m4
+++ b/opal/mca/mpool/rgpusm/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,7 +18,7 @@ AC_DEFUN([MCA_opal_mpool_rgpusm_CONFIG],[
     AC_CONFIG_FILES([opal/mca/mpool/rgpusm/Makefile])
 
     # Use CUDA_SUPPORT which was filled in by the opal configure code.
-    AS_IF([test "x$CUDA_SUPPORT_41" = "x1"],
+    AS_IF([test "x$CUDA_SUPPORT" = "x1"],
           [$1],
           [$2])
 


### PR DESCRIPTION
Missed a few places when I pulled the OPAL_CUDA_SUPPORT_41 macro.  This fixes that.

(cherry picked from commit open-mpi/ompi@2e2e175f139d15c1b89295fb5a7f768402bc113f)
