### PR TITLE
Fix relative node syntax for dash-host option

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1730,7 +1730,7 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
                 OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
                                      "%s using dash_host",
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-                if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&tnodes, hosts))) {
+                if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&tnodes, hosts, false))) {
                     ORTE_ERROR_LOG(rc);
                     free(hosts);
                     return rc;

--- a/orte/mca/ras/base/ras_base_allocate.c
+++ b/orte/mca/ras/base/ras_base_allocate.c
@@ -312,7 +312,7 @@ void orte_ras_base_allocate(int fd, short args, void *cbdata)
             OPAL_OUTPUT_VERBOSE((5, orte_ras_base_framework.framework_output,
                                  "%s ras:base:allocate adding dash_hosts",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts))) {
+            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts, true))) {
                 free(hosts);
                 OBJ_DESTRUCT(&nodes);
                 ORTE_FORCED_TERMINATE(ORTE_ERROR_DEFAULT_EXIT_CODE);
@@ -511,7 +511,7 @@ int orte_ras_base_add_hosts(orte_job_t *jdata)
             opal_output_verbose(5, orte_ras_base_framework.framework_output,
                                 "%s ras:base:add_hosts checking add-host %s",
                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), hosts);
-            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts))) {
+            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts, true))) {
                 ORTE_ERROR_LOG(rc);
                 OBJ_DESTRUCT(&nodes);
                 free(hosts);

--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -171,7 +171,7 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
             OPAL_OUTPUT_VERBOSE((5, orte_rmaps_base_framework.framework_output,
                                  "%s using dash_host %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), hosts));
-            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts))) {
+            if (ORTE_SUCCESS != (rc = orte_util_add_dash_host_nodes(&nodes, hosts, false))) {
                 ORTE_ERROR_LOG(rc);
                 free(hosts);
                 return rc;

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -155,6 +155,7 @@ bool orte_default_hostfile_given = false;
 char *orte_rankfile = NULL;
 int orte_num_allocated_nodes = 0;
 char *orte_node_regex = NULL;
+char *orte_default_dash_host = NULL;
 
 /* tool communication controls */
 bool orte_report_events = false;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -546,6 +546,7 @@ ORTE_DECLSPEC extern bool orte_default_hostfile_given;
 ORTE_DECLSPEC extern char *orte_rankfile;
 ORTE_DECLSPEC extern int orte_num_allocated_nodes;
 ORTE_DECLSPEC extern char *orte_node_regex;
+ORTE_DECLSPEC extern char *orte_default_dash_host;
 
 /* PMI version control */
 ORTE_DECLSPEC extern int orted_pmi_version;

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -362,6 +362,19 @@ int orte_register_params(void)
         orte_default_hostfile_given = true;
     }
 
+    /* default dash-host */
+    orte_default_dash_host = NULL;
+    (void) mca_base_var_register ("orte", "orte", NULL, "default_dash_host",
+                                  "Default -host setting (specify \"none\" to ignore environmental or default MCA param setting)",
+                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                  &orte_default_dash_host);
+    if (NULL != orte_default_dash_host &&
+        0 == strcmp(orte_default_dash_host, "none")) {
+        free(orte_default_dash_host);
+        orte_default_dash_host = NULL;
+    }
+
     /* regex of nodes in system */
     orte_node_regex = NULL;
     (void) mca_base_var_register ("orte", "orte", NULL, "node_regex",

--- a/orte/tools/orte-submit/orte-submit.c
+++ b/orte/tools/orte-submit/orte-submit.c
@@ -1183,6 +1183,9 @@ static int create_app(int argc, char* argv[],
         orte_set_attribute(&app->attributes, ORTE_APP_DASH_HOST, ORTE_ATTR_GLOBAL, tval, OPAL_STRING);
         opal_argv_free(targ);
         free(tval);
+    } else if (NULL != orte_default_dash_host) {
+        orte_set_attribute(&app->attributes, ORTE_APP_DASH_HOST, ORTE_ATTR_LOCAL,
+                           orte_default_dash_host, OPAL_STRING);
     }
 
     /* check for bozo error */

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -1602,6 +1602,9 @@ static int create_app(int argc, char* argv[],
         orte_set_attribute(&app->attributes, ORTE_APP_DASH_HOST, ORTE_ATTR_LOCAL, tval, OPAL_STRING);
         opal_argv_free(targ);
         free(tval);
+    } else if (NULL != orte_default_dash_host) {
+        orte_set_attribute(&app->attributes, ORTE_APP_DASH_HOST, ORTE_ATTR_LOCAL,
+                           orte_default_dash_host, OPAL_STRING);
     }
 
     /* check for bozo error */

--- a/orte/util/dash_host/dash_host.h
+++ b/orte/util/dash_host/dash_host.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +31,8 @@
 BEGIN_C_DECLS
 
 ORTE_DECLSPEC int orte_util_add_dash_host_nodes(opal_list_t *nodes,
-                                                char *hosts);
+                                                char *hosts,
+                                                bool allocating);
 
 ORTE_DECLSPEC int orte_util_filter_dash_host_nodes(opal_list_t *nodes,
                                                    char *hosts,


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@24419b6523260d0e35e49408b52c660875bb78a9)

Add a new MCA parameter for default_dash_host to offer a mirror of the default_hostfile

(cherry picked from commit open-mpi/ompi@8bfbe7f16cfd62f565c66e88c8c03f2d481795b8)
