### PR TITLE
pml_ucx: fix request construct/destruct.

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -175,6 +175,7 @@ int mca_pml_ucx_init(void)
     OBJ_CONSTRUCT(&ompi_pml_ucx.convs,           mca_pml_ucx_freelist_t);
 
     /* Create a completed request to be returned from isend */
+    OBJ_CONSTRUCT(&ompi_pml_ucx.completed_send_req, ompi_request_t);
     mca_pml_ucx_completed_request_init(&ompi_pml_ucx.completed_send_req);
 
     opal_progress_register(mca_pml_ucx_progress);
@@ -191,7 +192,10 @@ int mca_pml_ucx_cleanup(void)
 
     opal_progress_unregister(mca_pml_ucx_progress);
 
+    ompi_pml_ucx.completed_send_req.req_state = OMPI_REQUEST_INVALID;
     OMPI_REQUEST_FINI(&ompi_pml_ucx.completed_send_req);
+    OBJ_DESTRUCT(&ompi_pml_ucx.completed_send_req);
+
     OBJ_DESTRUCT(&ompi_pml_ucx.convs);
     OBJ_DESTRUCT(&ompi_pml_ucx.persistent_reqs);
 
@@ -558,7 +562,7 @@ int mca_pml_ucx_improbe(int src, int tag, struct ompi_communicator_t* comm,
                                1, &info);
     if (ucp_msg != NULL) {
         PML_UCX_MESSAGE_NEW(comm, ucp_msg, &info, message);
-        PML_UCX_VERBOSE(8, "got message %p (%p)", (void*)*message, ucp_msg);
+        PML_UCX_VERBOSE(8, "got message %p (%p)", (void*)*message, (void*)ucp_msg);
         *matched         = 1;
         mca_pml_ucx_set_recv_status_safe(mpi_status, UCS_OK, &info);
     } else if (UCS_PTR_STATUS(ucp_msg) == UCS_ERR_NO_MESSAGE) {
@@ -583,7 +587,7 @@ int mca_pml_ucx_mprobe(int src, int tag, struct ompi_communicator_t* comm,
                                    1, &info);
         if (ucp_msg != NULL) {
             PML_UCX_MESSAGE_NEW(comm, ucp_msg, &info, message);
-            PML_UCX_VERBOSE(8, "got message %p (%p)", (void*)*message, ucp_msg);
+            PML_UCX_VERBOSE(8, "got message %p (%p)", (void*)*message, (void*)ucp_msg);
             mca_pml_ucx_set_recv_status_safe(mpi_status, UCS_OK, &info);
             return OMPI_SUCCESS;
         }

--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -108,7 +108,6 @@ static void mca_pml_ucx_request_init_common(ompi_request_t* ompi_req,
                                             ompi_request_free_fn_t req_free,
                                             ompi_request_cancel_fn_t req_cancel)
 {
-    OBJ_CONSTRUCT(ompi_req, ompi_request_t);
     OMPI_REQUEST_INIT(ompi_req, req_persistent);
     ompi_req->req_type             = OMPI_REQUEST_PML;
     ompi_req->req_state            = state;
@@ -119,6 +118,7 @@ static void mca_pml_ucx_request_init_common(ompi_request_t* ompi_req,
 void mca_pml_ucx_request_init(void *request)
 {
     ompi_request_t* ompi_req = request;
+    OBJ_CONSTRUCT(ompi_req, ompi_request_t);
     mca_pml_ucx_request_init_common(ompi_req, false, OMPI_REQUEST_ACTIVE,
                                     mca_pml_ucx_request_free, NULL);
 }
@@ -126,6 +126,7 @@ void mca_pml_ucx_request_init(void *request)
 void mca_pml_ucx_request_cleanup(void *request)
 {
     ompi_request_t* ompi_req = request;
+    ompi_req->req_state = OMPI_REQUEST_INVALID;
     OMPI_REQUEST_FINI(ompi_req);
     OBJ_DESTRUCT(ompi_req);
 }
@@ -148,6 +149,7 @@ static void mca_pml_ucx_persisternt_request_construct(mca_pml_ucx_persistent_req
 
 static void mca_pml_ucx_persisternt_request_destruct(mca_pml_ucx_persistent_request_t* req)
 {
+    req->ompi.req_state = OMPI_REQUEST_INVALID;
     OMPI_REQUEST_FINI(&req->ompi);
 }
 


### PR DESCRIPTION
We should invoke OBJ_CONTRUCT/OBJ_DESTRUCT only on regular requests
(which are embedded inside UCX requests) and for the completed request.
Persistent requests are already constructed/destructed by the free list.
This fixes an assertion in ompi_request_destruct.

https://github.com/open-mpi/ompi/pull/1099
