### PR TITLE
btl/openib: fix access flags

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -573,7 +573,7 @@ static int openib_reg_mr(void *reg_data, void *base, size_t size,
     }
 
     if (reg->access_flags & MCA_MPOOL_ACCESS_REMOTE_WRITE) {
-        access_flag |= IBV_ACCESS_REMOTE_WRITE;
+        access_flag |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
     }
 
     if (reg->access_flags & MCA_MPOOL_ACCESS_LOCAL_WRITE) {
@@ -582,7 +582,7 @@ static int openib_reg_mr(void *reg_data, void *base, size_t size,
 
 #if HAVE_DECL_IBV_ATOMIC_HCA
     if (reg->access_flags & MCA_MPOOL_ACCESS_REMOTE_ATOMIC) {
-        access_flag |= IBV_ACCESS_REMOTE_ATOMIC;
+        access_flag |= IBV_ACCESS_REMOTE_ATOMIC | IBV_ACCESS_LOCAL_WRITE;
     }
 #endif
 


### PR DESCRIPTION
Per spec for ibv_reg_mr if remote write or remote atomic is requested also
need to specify local write.

:bot:assign: @miked-mellanox 
:bot:label:bug
:bot:milestone:v2.0.0

(cherry picked from open-mpi/ompi@4ddbdad77218db1bc4b8b2cd65ccc798b2f47707)

Signed-off-by: Nathan Hjelm hjelmn@me.com
