### PR TITLE
Fix intercomm_create by ensuring that both sides know how to translat…

### DIFF
--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -821,7 +821,7 @@ static int cray_store_local(const opal_process_name_t *proc,
 
 static const char *cray_get_nspace(opal_jobid_t jobid)
 {
-    return NULL;
+    return "N/A";
 }
 
 static void cray_register_jobid(opal_jobid_t jobid, const char *nspace)

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -650,7 +650,7 @@ static int s1_store_local(const opal_process_name_t *proc,
 
 static const char *s1_get_nspace(opal_jobid_t jobid)
 {
-    return NULL;
+    return "N/A";
 }
 static void s1_register_jobid(opal_jobid_t jobid, const char *nspace)
 {

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -669,7 +669,7 @@ static int s2_store_local(const opal_process_name_t *proc,
 
 static const char *s2_get_nspace(opal_jobid_t jobid)
 {
-    return NULL;
+    return "N/A";
 }
 static void s2_register_jobid(opal_jobid_t jobid, const char *nspace)
 {


### PR DESCRIPTION
…e jobid to/from nspace

Return something just to ensure that pack is happy

(cherry picked from commit open-mpi/ompi@bfdf08ae86697420f9fa9a848fdd14cafe335806)
