### PR TITLE
usnic: fix/update the usnic stats

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -82,9 +82,11 @@ void opal_btl_usnic_print_stats(
     char tmp[128], str[2048];
 
     /* The usuals */
-    snprintf(str, sizeof(str), "%s:MCW:%3u, ST(P+D)/F/C/R(T+F)/A:%8lu(%8u+%8u)/%8lu/%8lu/%4lu(%4lu+%4lu)/%8lu, RcvTot/Chk/F/C/L/H/D/BF/A:%8lu/%c%c/%8lu/%8lu/%4lu+%2lu/%4lu/%4lu/%6lu OA/DA %4lu/%4lu CRC:%4lu ",
+    snprintf(str, sizeof(str), "%s:MCW:%3u, %s, ST(P+D)/F/C/R(T+F)/A:%8lu(%8u+%8u)/%8lu/%8lu/%4lu(%4lu+%4lu)/%8lu, RcvTot/Chk/F/C/L/H/D/BF/A:%8lu/%c%c/%8lu/%8lu/%4lu+%2lu/%4lu/%4lu/%6lu OA/DA %4lu/%4lu CRC:%4lu ",
              prefix,
              opal_proc_local_get()->proc_name.vpid,
+
+             module->fabric_info->fabric_attr->name,
 
              module->stats.num_total_sends,
              module->mod_channels[USNIC_PRIORITY_CHANNEL].num_channel_sends,
@@ -194,11 +196,6 @@ static void usnic_stats_callback(int fd, short flags, void *arg)
 
     opal_btl_usnic_print_stats(module, tmp,
                                /*reset=*/mca_btl_usnic_component.stats_relative);
-
-    /* In OMPI v1.6, we have to re-add this event (because there's an
-       old libevent in OMPI v1.6) */
-    opal_event_add(&(module->stats.timer_event),
-                   &(module->stats.timeout));
 }
 
 /*


### PR DESCRIPTION
1. Fix: old v1.6-era code reset the stats-emitting event to fire twice for each time period.
2. Add the usNIC device name to the output for differentiating the output in multi-rail scenarios.

(cherry picked from commit open-mpi/ompi@300cff2b89759048d9360ceca8e45b28b09aba7f)

@goodell Please review.  Pretty simple.
