### PR TITLE
fix compilation in heterogeneous mode

### DIFF
--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -267,7 +267,7 @@ int ompi_proc_init(void)
     opal_proc_local_set(&proc->super);
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
     /* add our arch to the modex */
-    OPAL_MODEX_SEND_VALUE(ret, PMIX_GLOBAL,
+    OPAL_MODEX_SEND_VALUE(ret, OPAL_PMIX_GLOBAL,
                           OPAL_PMIX_ARCH, &opal_local_arch, OPAL_UINT32);
     if (OPAL_SUCCESS != ret) {
         return ret;


### PR DESCRIPTION
use OPAL_PMIX_GLOBAL instead of PMIX_GLOBAL

(cherry picked from commit open-mpi/ompi@638a59adf35c1a7d2fdd8e8a86f5096bf7109d9d)
