### PR TITLE
oshmem: do not include pml/ob1 headers

### DIFF
--- a/oshmem/mca/spml/base/spml_base_request.h
+++ b/oshmem/mca/spml/base/spml_base_request.h
@@ -4,6 +4,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +24,6 @@
 #include "opal/datatype/opal_convertor.h"
 
 #include "opal/class/opal_free_list.h"
-#include "ompi/mca/pml/ob1/pml_ob1_comm.h"
 
 BEGIN_C_DECLS
 

--- a/oshmem/mca/spml/yoda/spml_yoda_getreq.h
+++ b/oshmem/mca/spml/yoda/spml_yoda_getreq.h
@@ -4,6 +4,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,7 +19,6 @@
 #include "opal/mca/btl/btl.h"
 #include "oshmem/mca/spml/base/spml_base_putreq.h"
 #include "opal/mca/mpool/base/base.h"
-#include "ompi/mca/pml/ob1/pml_ob1_comm.h"
 #include "ompi/mca/bml/bml.h"
 #include "oshmem/mca/spml/yoda/spml_yoda_rdmafrag.h"
 #include "oshmem/mca/spml/yoda/spml_yoda.h"


### PR DESCRIPTION
this is an abstraction violation and that can cause linker failure

(cherry picked from commit open-mpi/ompi@8f2d3aeb65e6de672ec210ff41f70832f5135ac2)
