### PR TITLE
oshmem: do not include pml/ob1 headers

### DIFF
--- a/oshmem/mca/spml/base/spml_base_request.h
+++ b/oshmem/mca/spml/base/spml_base_request.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -19,7 +21,6 @@
 #include "opal/datatype/opal_convertor.h"
 
 #include "ompi/class/ompi_free_list.h"
-#include "ompi/mca/pml/ob1/pml_ob1_comm.h"
 
 BEGIN_C_DECLS
 

--- a/oshmem/mca/spml/yoda/spml_yoda_getreq.h
+++ b/oshmem/mca/spml/yoda/spml_yoda_getreq.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -14,7 +16,6 @@
 #include "ompi/mca/btl/btl.h" 
 #include "oshmem/mca/spml/base/spml_base_putreq.h"
 #include "ompi/mca/mpool/base/base.h"
-#include "ompi/mca/pml/ob1/pml_ob1_comm.h"  
 #include "ompi/mca/bml/bml.h" 
 #include "oshmem/mca/spml/yoda/spml_yoda_rdmafrag.h"
 #include "oshmem/mca/spml/yoda/spml_yoda.h"


### PR DESCRIPTION
this is an abstraction violation and that can cause linker failure

(back ported from commit open-mpi/ompi@8f2d3aeb65e6de672ec210ff41f70832f5135ac2)
