### PR TITLE
pmix: fix finalize ordering issue

### DIFF
--- a/opal/mca/pmix/pmix1xx/pmix/src/client/pmix_client.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/client/pmix_client.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -404,10 +405,6 @@ pmix_status_t PMIx_Finalize(void)
     }
 
     pmix_stop_progress_thread(pmix_globals.evbase);
-    event_base_free(pmix_globals.evbase);
-#ifdef HAVE_LIBEVENT_GLOBAL_SHUTDOWN
-    libevent_global_shutdown();
-#endif
 
     pmix_usock_finalize();
     PMIX_DESTRUCT(&pmix_client_globals.myserver);
@@ -416,6 +413,12 @@ pmix_status_t PMIx_Finalize(void)
     if (0 <= pmix_client_globals.myserver.sd) {
         CLOSE_THE_SOCKET(pmix_client_globals.myserver.sd);
     }
+
+    event_base_free(pmix_globals.evbase);
+#ifdef HAVE_LIBEVENT_GLOBAL_SHUTDOWN
+    libevent_global_shutdown();
+#endif
+
     pmix_bfrop_close();
     pmix_sec_finalize();
 


### PR DESCRIPTION
Don't destroy the event base before destroying all objects that contain events (and call event_del(), which uses the event base on which event is enqueued).

This matches the ordering in the Open MPI master.

@rhc54 How do you want to handle this?  Do you want piecemeal PMIx bug fixes like this, or do you want to do a re-sync of PMIx from OMPI master (or PMIx master?)?

This issue was initially found by valgrind on https://github.com/open-mpi/ompi-release/pull/747#issuecomment-155152968, and then had its own issue opened in open-mpi/ompi#1117.

@rhc54 Please review.
