### PR TITLE
opal_free_list: fix strange size check

### DIFF
--- a/opal/class/opal_free_list.c
+++ b/opal/class/opal_free_list.c
@@ -121,6 +121,10 @@ int opal_free_list_init (opal_free_list_t *flist, size_t frag_size, size_t frag_
             return OPAL_ERROR;
     }
 
+    if (frag_class && frag_size < frag_class->cls_sizeof) {
+        frag_size = frag_class->cls_sizeof;
+    }
+
     if (frag_size > flist->fl_frag_size) {
         flist->fl_frag_size = frag_size;
     }
@@ -164,9 +168,7 @@ int opal_free_list_grow_st (opal_free_list_t* flist, size_t num_elements)
         return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
     }
 
-    head_size = (NULL == flist->fl_mpool) ? flist->fl_frag_size:
-        flist->fl_frag_class->cls_sizeof;
-    head_size = OPAL_ALIGN(head_size, flist->fl_frag_alignment, size_t);
+    head_size = OPAL_ALIGN(flist->fl_frag_size, flist->fl_frag_alignment, size_t);
 
     /* calculate head allocation size */
     alloc_size = num_elements * head_size + sizeof(opal_free_list_memory_t) +


### PR DESCRIPTION
OPAL free lists can be initialized with a fragment size that differs
from the size of objects from a class. This allows the free list code
to support OPAL objects that have flexible array members.

Unfortunately the free list code will throw out the desired length in
some cases. The code in question was committed in
open-mpi/ompi@90fb58de. The side effects of this are varied and can
cause segmentation faults, assert failures, hangs, etc. This commit
adds a check to ensure the requested size is at least as large as the
class size and makes opal_free_list allocations always honor the
requested fragment size (as long as it is larger than the class
size).

(cherry picked from open-mpi/ompi@2c022943892c7ef153cbfc293dce25e7c25654ef)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
