### PR TITLE
v2.x - OSHMEM/ikrit: fix valgrind error

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -405,7 +405,7 @@ int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs)
 {
     spml_ikrit_mxm_ep_conn_info_t *ep_info = NULL;
     spml_ikrit_mxm_ep_conn_info_t *ep_hw_rdma_info = NULL;
-    spml_ikrit_mxm_ep_conn_info_t my_ep_info;
+    spml_ikrit_mxm_ep_conn_info_t my_ep_info = {0,};
 #if MXM_API < MXM_VERSION(2,0)
     mxm_conn_req_t *conn_reqs;
     int timeout;


### PR DESCRIPTION
master commit: https://github.com/open-mpi/ompi/pull/1133
