### PR TITLE
yalla: fix valgrind error due to uninitialized status field.

### DIFF
--- a/ompi/mca/pml/yalla/pml_yalla_request.h
+++ b/ompi/mca/pml/yalla/pml_yalla_request.h
@@ -184,6 +184,7 @@ void mca_pml_yalla_init_reqs(void);
                 (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
                 break; \
             case MXM_ERR_CANCELED: \
+                (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
                 (_mpi_status)->_cancelled = true; \
                 break; \
             case MXM_ERR_MESSAGE_TRUNCATED: \

--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -381,7 +381,7 @@ int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs)
 {
     spml_ikrit_mxm_ep_conn_info_t *ep_info = NULL;
     spml_ikrit_mxm_ep_conn_info_t *ep_hw_rdma_info = NULL;
-    spml_ikrit_mxm_ep_conn_info_t my_ep_info;
+    spml_ikrit_mxm_ep_conn_info_t my_ep_info = {0,};
 #if MXM_API < MXM_VERSION(2,0)
     mxm_conn_req_t *conn_reqs;
     int timeout;


### PR DESCRIPTION
port from v1.10 
https://github.com/open-mpi/ompi-release/commit/76053c1786d4bde3df65da430f50ab468b998657
https://github.com/open-mpi/ompi-release/commit/b0bedf6f5c94a6157ae3380968e58690040aa22a

:bot:label:bug
:bot:milestone:v2.0.0
