### PR TITLE
autogen.pl: patch generated configure to fix an other libtool bug.

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -986,6 +986,15 @@ sub patch_autotools_output {
         $c =~ s/ppc\*-\*linux\*\|powerpc\*-\*linux\*\)/$replace_string/g;
     }
 
+    # Fix consequence of broken libtool.m4
+    # see http://lists.gnu.org/archive/html/bug-libtool/2015-07/msg00002.html and
+    # https://github.com/open-mpi/ompi/issues/751
+    verbose "$indent_str"."Patching configure for libtool.m4 bug\n";
+    # patch for libtool < 2.4.3
+    $c =~ s/# Some compilers place space between "-{L,R}" and the path.\n       # Remove the space.\n       if test \$p = \"-L\" \|\|/# Some compilers place space between "-{L,-l,R}" and the path.\n       # Remove the spaces.\n       if test \$p = \"-L\" \|\|\n          test \$p = \"-l\" \|\|/g;
+    # patch for libtool >= 2.4.3
+    $c =~ s/# Some compilers place space between "-{L,R}" and the path.\n       # Remove the space.\n       if test x-L = \"\$p\" \|\|\n          test x-R = \"\$p\"\; then/# Some compilers place space between "-{L,-l,R}" and the path.\n       # Remove the spaces.\n       if test x-L = \"x\$p\" \|\|\n          test x-l = \"x\$p\" \|\|\n          test x-R = \"x\$p\"\; then/g;
+
     open(OUT, ">configure.patched") || my_die "Can't open configure.patched";
     print OUT $c;
     close(OUT);


### PR DESCRIPTION
Thanks to Eric Schnetter for reporting this issue and providing a fix.

This is a v1.10 port of code from master that fixes open-mpi/ompi#576.

(manually cherry picked/ported from master commit open-mpi/ompi@4c15560)

@eschnett Can you confirm that this fixes the issue for you?

@rhc54 This would be nice to be in v1.10.2 since the pressure is off.  But it can certainly wait until v1.10.3 if there's any concern with it.
