### PR TITLE
Added Intel HF1 default parameters for openib

### DIFF
--- a/ompi/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/ompi/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -278,6 +278,13 @@ mtu = 2048
 receive_queues = P,65536,256,192,128
 max_inline_data = 64
 
+[Intel HFI1]
+vendor_id = 0x1175
+vendor_part_id = 9456,9457
+use_eager_rdma = 1
+mtu = 4096
+max_inline_data = 0
+
 ############################################################################
 
 # Intel has several OUI's, including 0x8086.  Amusing.  :-) Intel has


### PR DESCRIPTION
OmniPath HFI1 device parameters if openib wants to be used. Note, after commit 0cecbbd0d062269a628e28c8968d2e0e7bb587d8, during PML selection, ob1 is evaluated and default (openib) parameters for HFI1 are not found so an ugly warning message is shown. 
