### PR TITLE
Add the ability to empty the rgpusm cache when full if the user requests it

### DIFF
--- a/ompi/mca/mpool/rgpusm/mpool_rgpusm.h
+++ b/ompi/mca/mpool/rgpusm/mpool_rgpusm.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Voltaire. All rights reserved.
- * Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -38,6 +38,7 @@ struct mca_mpool_rgpusm_component_t {
     bool print_stats;
     int leave_pinned;
     int output;
+    bool empty_cache;
 };
 typedef struct mca_mpool_rgpusm_component_t mca_mpool_rgpusm_component_t;
 

--- a/ompi/mca/mpool/rgpusm/mpool_rgpusm_component.c
+++ b/ompi/mca/mpool/rgpusm/mpool_rgpusm_component.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Voltaire. All rights reserved.
  * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -125,6 +125,15 @@ static int rgpusm_register(void)
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &ompi_mpool_rgpusm_verbose);
+
+    /* Force emptying of entire registration cache when it gets full */
+    mca_mpool_rgpusm_component.empty_cache = false;
+    (void) mca_base_component_var_register(&mca_mpool_rgpusm_component.super.mpool_version,
+                                           "empty_cache", "When set, empty entire registration cache when it is full",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_mpool_rgpusm_component.empty_cache);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
This was a user request bug fix as they were running out of memory without this ability. This change has been in 2.x since September, 2015 and I now have a request to get this fix into the 1.10 series. It was originally reviewed by Jeff for both master and 2.x.

https://github.com/open-mpi/ompi/pull/898
https://github.com/open-mpi/ompi-release/pull/595

The change is isolated to code that is only compiled in when --with-cuda so it should be a safe bug fix for the 1.10 series.
