### PR TITLE
Fix buffer overrun and double free

### DIFF
--- a/ompi/mpi/c/finalized.c
+++ b/ompi/mpi/c/finalized.c
@@ -36,8 +36,6 @@ static const char FUNC_NAME[] = "MPI_Finalized";
 
 int MPI_Finalized(int *flag) 
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     if (MPI_PARAM_CHECK) {
@@ -51,7 +49,10 @@ int MPI_Finalized(int *flag)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                   directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(13),
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/get_library_version.c
+++ b/ompi/mpi/c/get_library_version.c
@@ -38,7 +38,6 @@ static const char FUNC_NAME[] = "MPI_Get_library_version";
 int MPI_Get_library_version(char *version, int *resultlen) 
 {
     int len_left;
-    MPI_Comm null = MPI_COMM_NULL;
     char *ptr, tmp[MPI_MAX_LIBRARY_VERSION_STRING];
 
     OPAL_CR_NOOP_PROGRESS();
@@ -61,7 +60,10 @@ int MPI_Get_library_version(char *version, int *resultlen)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                   directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(13), 
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/get_version.c
+++ b/ompi/mpi/c/get_version.c
@@ -36,8 +36,6 @@ static const char FUNC_NAME[] = "MPI_Get_version";
 
 int MPI_Get_version(int *version, int *subversion) 
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     if (MPI_PARAM_CHECK) {
@@ -58,7 +56,10 @@ int MPI_Get_version(int *version, int *subversion)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                   directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(13), 
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/initialized.c
+++ b/ompi/mpi/c/initialized.c
@@ -36,8 +36,6 @@ static const char FUNC_NAME[] = "MPI_Initialized";
 
 int MPI_Initialized(int *flag) 
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     if (MPI_PARAM_CHECK) {
@@ -51,7 +49,10 @@ int MPI_Initialized(int *flag)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                   directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(13),
                                               FUNC_NAME);
             }
         }

--- a/opal/mca/db/hash/db_hash.c
+++ b/opal/mca/db/hash/db_hash.c
@@ -627,6 +627,7 @@ static int fetch_multiple(const opal_identifier_t *uid,
             (0 == len && 0 == strcmp(key, kv->key))) {
             if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&kvnew, kv, OPAL_VALUE))) {
                 OPAL_ERROR_LOG(rc);
+                free(srchkey);
                 return rc;
             }
             opal_list_append(kvs, &kvnew->super);

--- a/opal/mca/event/libevent2021/libevent2021_component.c
+++ b/opal/mca/event/libevent2021/libevent2021_component.c
@@ -120,12 +120,14 @@ const opal_event_component_t mca_event_libevent2021_component = {
     }
 };
 
+#define BUFF_SIZE 1024
+
 static int libevent2021_register (void)
-{ 
+{
     const struct eventop** _eventop = eventops;
-    char available_eventops[1024] = "none";
+    char available_eventops[BUFF_SIZE] = "none";
     char *help_msg = NULL;
-    int ret, len = 1024;
+    int ret, len = BUFF_SIZE - 1;
 
     /* Retrieve the upper level specified event system, if any.
      * Default to select() on OS X and poll() everywhere else because
@@ -154,6 +156,7 @@ static int libevent2021_register (void)
 
     if (NULL != (*_eventop)) {
         available_eventops[0] = '\0';
+	len = BUFF_SIZE - strlen(available_eventops) - 1;
     }
 
     while( NULL != (*_eventop) ) {
@@ -163,7 +166,7 @@ static int libevent2021_register (void)
         (void) strncat (available_eventops, (*_eventop)->name,
                         len);
         _eventop++;  /* go to the next available eventop */
-        len = 1024 - strlen(available_eventops);
+        len = BUFF_SIZE - strlen(available_eventops) - 1;
     }
 
 #ifdef __APPLE__

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -91,7 +91,7 @@ static inline bool opal_set_using_threads(bool have)
 #if OMPI_ENABLE_THREAD_MULTIPLE
     opal_uses_threads = have;
 #else
-    have = true;               /* just shut up the compiler */
+    (void)have;               /* just shut up the compiler */
 #endif
     return opal_using_threads();
 }

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -2455,7 +2455,6 @@ static int process(char *orig_line, char *basename, opal_cmd_line_t *cmd_line,
         else {
             goto out;
         }
-        free(tmp);
     }
 
     /* All done -- didn't find it */


### PR DESCRIPTION
Quietens the compiler in a portable way for unused variable.
Fixes a buffer overrun when building output string.
Fixes a double free in orterun.
