### PR TITLE
topo/base: correctly free the topo object in mca_topo_base_dist_graph…

### DIFF
--- a/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
@@ -101,7 +101,7 @@ int mca_topo_base_dist_graph_create_adjacent(mca_topo_base_module_t* module,
         if( MPI_UNWEIGHTED != destweights ) {
             if( NULL != topo->outw ) free(topo->outw);
         }
-        free(topo);
+        OBJ_RELEASE(topo);
     }
     ompi_comm_free(newcomm);
     return err;


### PR DESCRIPTION
…_create_adjacent

(cherry picked from commit open-mpi/ompi@80f02518ff7a94ceabefd338ac13128be5b91d8d)
