### PR TITLE
orterun.c: fix parse of user environment variables

### DIFF
--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -1736,17 +1736,11 @@ static int create_app(int argc, char* argv[],
             } else {
                 value = getenv(param);
                 if (NULL != value) {
-                    if (NULL != strchr(value, '=')) {
-                        opal_argv_append_nosize(&app->env, value);
-                        /* save it for any comm_spawn'd apps */
-                        opal_argv_append_nosize(&orte_forwarded_envars, value);
-                    } else {
                         asprintf(&value2, "%s=%s", param, value);
                         opal_argv_append_nosize(&app->env, value2);
                         /* save it for any comm_spawn'd apps */
                         opal_argv_append_nosize(&orte_forwarded_envars, value2);
                         free(value2);
-                    }
                 } else {
                     opal_output(0, "Warning: could not find environment variable \"%s\"\n", param);
                 }


### PR DESCRIPTION
When I launch mpirun, I need to pass some (ompss/nanos++) environment variable
like NX_ARGS in the following way:
export NX_ARGS="--verbose --cluster --cluster-network=mpi"
mpirun -np 2 -hostfile myhostfile -x NX_ARGS -x LD_PRELOAD testapp

I saw that NX_ARGS is not passed and I found the problem in the orte/tools/orterun/orterun.c file.
In line 1739, after use getenv(), you check if there is '=' in the string. If it's true,
you assumed that the string is in the form 'param'='value', but in this case fails, because
getenv() POSIX specification always returns a pointer to the value
in the environment, without "param=".

getenv() POSIX specification always returns a pointer to the value
in the environment.
