### PR TITLE
Silence libevent reentrant warning when using openib except for debug builds

### DIFF
--- a/opal/mca/event/libevent2022/libevent/event.c
+++ b/opal/mca/event/libevent2022/libevent/event.c
@@ -1566,8 +1566,11 @@ event_base_loop(struct event_base *base, int flags)
 	EVBASE_ACQUIRE_LOCK(base, th_base_lock);
 
 	if (base->running_loop) {
-		event_warnx("%s: reentrant invocation.  Only one event_base_loop"
-		    " can run on each event_base at once.", __func__);
+/*****   OMPI change   ****/
+#if OPAL_ENABLE_DEBUG
+ 		event_warnx("%s: reentrant invocation.  Only one event_base_loop"
+ 		    " can run on each event_base at once.", __func__);
+#endif
 		EVBASE_RELEASE_LOCK(base, th_base_lock);
 		return -1;
 	}


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@7ac5c082ff86be4548da264b835d4af390678c6b)
