### PR TITLE
Avoiding conditional directives that split up parts of statements.  

### DIFF
--- a/ompi/contrib/vt/vt/vtlib/vt_pform_linux.c
+++ b/ompi/contrib/vt/vt/vtlib/vt_pform_linux.c
@@ -17,6 +17,7 @@
 #include "vt_pform.h"
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -112,6 +113,7 @@ void vt_pform_init()
   FILE *cpuinfofp;
   char line[1024];
   int  hostid_retries;
+  bool test;
 
 #if TIMER == TIMER_CYCLE_COUNTER
     int num_measurements=0, loop;
@@ -142,10 +144,11 @@ void vt_pform_init()
 #if TIMER == TIMER_CYCLE_COUNTER
     {
 # if defined(__ia64__)
-      if (!strncmp("itc MHz", line, 7))
+      test = !strncmp("itc MHz", line, 7);
 # else
-      if (!strncmp("cpu MHz", line, 7))
+      test = !strncmp("cpu MHz", line, 7);
 # endif
+      if (test)
       {
 	strtok(line, ":");
       

--- a/ompi/mca/mtl/mxm/mtl_mxm_component.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm_component.c
@@ -23,6 +23,7 @@
 #include "mtl_mxm_types.h"
 #include "mtl_mxm_request.h"
 
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -148,6 +149,7 @@ static int ompi_mtl_mxm_component_open(void)
     mxm_error_t err;
     unsigned long cur_ver;
     int rc;
+    bool test;
 
     mca_mtl_mxm_output = opal_output_open(NULL);
     opal_output_set_verbosity(mca_mtl_mxm_output, ompi_mtl_mxm.verbose);
@@ -178,13 +180,14 @@ static int ompi_mtl_mxm_component_open(void)
 #endif
 
 #if MXM_API >= MXM_VERSION(2,1)
-    if (MXM_OK != mxm_config_read_opts(&ompi_mtl_mxm.mxm_ctx_opts,
+    test = MXM_OK != mxm_config_read_opts(&ompi_mtl_mxm.mxm_ctx_opts,
                                        &ompi_mtl_mxm.mxm_ep_opts,
-                                       "MPI", NULL, 0))
+                                       "MPI", NULL, 0);
 #else
-    if ((MXM_OK != mxm_config_read_context_opts(&ompi_mtl_mxm.mxm_ctx_opts)) ||
-        (MXM_OK != mxm_config_read_ep_opts(&ompi_mtl_mxm.mxm_ep_opts)))
+    test = (MXM_OK != mxm_config_read_context_opts(&ompi_mtl_mxm.mxm_ctx_opts)) ||
+        (MXM_OK != mxm_config_read_ep_opts(&ompi_mtl_mxm.mxm_ep_opts));
 #endif
+    if (test)
     {
         MXM_ERROR("Failed to parse MXM configuration");
         return OPAL_ERR_BAD_PARAM;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

```
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/
```

It might improve code understanding, maintainability and error-proneness.
