### PR TITLE
ompi: initialize ompi_proc_list common symbol

### DIFF
--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -42,7 +42,7 @@
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/runtime/params.h"
 
-opal_list_t  ompi_proc_list;
+opal_list_t  ompi_proc_list = {{0}};
 static opal_mutex_t ompi_proc_lock;
 static opal_hash_table_t ompi_proc_hash;
 


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@f241475db9c7d89041983752c7764a7b740f8e1d)
