### PR TITLE
cuda: fix missing #include opal/util/argv.h

### DIFF
--- a/opal/mca/common/cuda/common_cuda.c
+++ b/opal/mca/common/cuda/common_cuda.c
@@ -10,7 +10,9 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +36,7 @@
 #include "opal/util/output.h"
 #include "opal/util/show_help.h"
 #include "opal/util/proc.h"
+#include "opal/util/argv.h"
 
 #include "opal/mca/mpool/base/base.h"
 #include "opal/runtime/opal_params.h"


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@4d2c7f7de1779a9627d397c0ecbaa52c7c5bc802)
