### PR TITLE
pml/ob1: add missing ompi_request_wait_completion for buffered sends

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -198,7 +198,7 @@ int mca_pml_ob1_send(const void *buf,
             return rc;
         }
 
-        /* free the request and return. don't care if it completes now */
+        ompi_request_wait_completion (brequest);
         ompi_request_free (&brequest);
         return OMPI_SUCCESS;
     }


### PR DESCRIPTION
This commit adds a call to ompi_request_wait_completion for buffered
sends. Without this line it is possible to get into a state where the
data is never sent.

Fixes open-mpi/ompi#1185

(cherry picked from commit open-mpi/ompi@f68c315188369c7169b3f94db92bceec4a9213ba)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

:bot:assign: @artpol84 
:bot:milestone:v2.0.0
:bot:label:bug
:bot:label:critical
