### PR TITLE
mlx5: need to set comp_mask to get experimental verbs attributes

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -1650,6 +1650,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
         goto error;
     }
 #if HAVE_DECL_IBV_EXP_QUERY_DEVICE
+    device->ib_exp_dev_attr.comp_mask = IBV_EXP_DEVICE_ATTR_RESERVED - 1;
     if(ibv_exp_query_device(device->ib_dev_context, &device->ib_exp_dev_attr)){
         BTL_ERROR(("error obtaining device attributes for %s errno says %s",
                     ibv_get_device_name(device->ib_dev), strerror(errno)));


### PR DESCRIPTION
Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@c9382f23e9793be415c63a9be123413acff30195)
