### PR TITLE
btl-portals4: set endpoint rank even if endpoint already exists

### DIFF
--- a/opal/mca/btl/portals4/btl_portals4.c
+++ b/opal/mca/btl/portals4/btl_portals4.c
@@ -292,13 +292,21 @@ create_peer_and_endpoint(int                       interface,
     OPAL_OUTPUT_VERBOSE((90, opal_btl_base_framework.framework_output,
         "btl/portals4: %d NI(s) declared in the modex", (int) (size/sizeof(ptl_process_t))));
 
+    /*
+     * check if create_endpoint() already created the endpoint.
+     * if not, create it here.
+     */
     if (NULL == *endpoint) {
         *endpoint = malloc(sizeof(mca_btl_base_endpoint_t));
         if (NULL == *endpoint) {
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
-        (*endpoint)->ptl_proc.rank = proc->proc_name.vpid;
     }
+    /*
+     * regardless of who created the endpoint, set the rank here
+     * because we are using logical mapping.
+     */
+    (*endpoint)->ptl_proc.rank = proc->proc_name.vpid;
 
     phys_peer->phys.pid = id[interface].phys.pid;
     phys_peer->phys.nid = id[interface].phys.nid;


### PR DESCRIPTION
If btl-portals4 is configured to use logical mapping of ranks to
physical nodes, then the endpoint must have the rank field set.
This commit fixes a bug that caused the endpoint to have the
nid/pid instead of the rank if the endpoint already exists.

(cherry picked from open-mpi/ompi@2b7e983)
