### PR TITLE
mca/base: remove erroneous check in var group register function

### DIFF
--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -274,12 +274,6 @@ static int group_register (const char *project_name, const char *framework_name,
         }
     }
 
-    /* avoid groups of the form opal_opal, ompi_ompi, etc */
-    if (NULL != project_name && NULL != framework_name &&
-        (0 == strcmp (project_name, framework_name))) {
-        project_name = NULL;
-    }
-
     /* build the group name */
     ret = mca_base_var_generate_full_name4 (NULL, project_name, framework_name, component_name,
                                             &group->group_full_name);


### PR DESCRIPTION
This commit removes a check that causes mca_base_group_register to
improperly create a new group instead of using an existing group
when the project and framework names are the same. This check was
originally intended to prevent forming groups with names like
ompi_ompi, opal_opal, etc but there is no reason why we shouldn't
allow that.

Fixes open-mpi/ompi#1155

(cherry picked from commit open-mpi/ompi@772172a99b58348a03118e9434730e3a88910a2c)

Signed-off-by: Nathan Hjelm hjelmn@me.com

:bot:assign: @igor-ivanov 
:bot:label:bug
:bot:milestone:v2.0.0
