### PR TITLE
coll/base: fix an integer overflow in ompi_coll_base_reduce_generic

### DIFF
--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -67,7 +67,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
      */
     ompi_datatype_get_extent( datatype, &lower_bound, &extent );
     ompi_datatype_type_size( datatype, &typelng );
-    num_segments = (original_count + count_by_segment - 1) / count_by_segment;
+    num_segments = (int)(((size_t)original_count + (size_t)count_by_segment - (size_t)1) / (size_t)count_by_segment);
     segment_increment = (ptrdiff_t)count_by_segment * extent;
 
     sendtmpbuf = (char*) sendbuf;


### PR DESCRIPTION
Refs open-mpi/ompi#1198

(back-ported from commit open-mpi/ompi@3a3b13ea12ac9806e1dcf9792711626628a93aff)
