### PR TITLE
v2.x group updates

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1982,19 +1982,16 @@ static int ompi_comm_fill_rest(ompi_communicator_t *comm,
        count on the proc pointers
        This is just a quick fix, and will be looking for a
        better solution */
-    OBJ_RELEASE( comm->c_local_group );
-    /* silence clang warning about a NULL pointer dereference */
-    assert (NULL != comm->c_local_group);
-    OBJ_RELEASE( comm->c_local_group );
+    if (comm->c_local_group) {
+        OBJ_RELEASE( comm->c_local_group );
+    }
+
+    if (comm->c_remote_group) {
+        OBJ_RELEASE( comm->c_remote_group );
+    }
 
     /* allocate a group structure for the new communicator */
-    comm->c_local_group = ompi_group_allocate(num_procs);
-
-    /* free the malloced  proc pointers */
-    free(comm->c_local_group->grp_proc_pointers);
-
-    /* set the group information */
-    comm->c_local_group->grp_proc_pointers = proc_pointers;
+    comm->c_local_group = ompi_group_allocate_plist_w_procs (proc_pointers, num_procs);
 
     /* set the remote group to be the same as local group */
     comm->c_remote_group = comm->c_local_group;

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -567,7 +567,11 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
             }
         }
 
-        ompi_group_incl(comm->c_local_group, my_size, lranks, &local_group);
+        rc = ompi_group_incl(comm->c_local_group, my_size, lranks, &local_group);
+        if (OMPI_SUCCESS != rc) {
+            goto exit;
+        }
+
         ompi_group_increment_proc_count(local_group);
 
         mode = OMPI_COMM_CID_INTER;
@@ -919,7 +923,7 @@ ompi_comm_split_type(ompi_communicator_t *comm,
                          NULL,               /* local group */
                          NULL );             /* remote group */
 
-    if ( NULL == newcomm ) {
+    if ( NULL == newcomp ) {
         rc =  MPI_ERR_INTERN;
         goto exit;
     }

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -172,7 +172,6 @@ int ompi_comm_set_nb ( ompi_communicator_t **ncomm,
     } else {
         newcomm->c_local_group = local_group;
         OBJ_RETAIN(newcomm->c_local_group);
-        ompi_group_increment_proc_count(newcomm->c_local_group);
     }
     newcomm->c_my_rank = newcomm->c_local_group->grp_my_rank;
 
@@ -189,7 +188,6 @@ int ompi_comm_set_nb ( ompi_communicator_t **ncomm,
         } else {
             newcomm->c_remote_group = remote_group;
             OBJ_RETAIN(newcomm->c_remote_group);
-            ompi_group_increment_proc_count(newcomm->c_remote_group);
         }
 
         newcomm->c_flags |= OMPI_COMM_INTER;
@@ -255,9 +253,6 @@ int ompi_comm_group ( ompi_communicator_t* comm, ompi_group_t **group )
 {
     /* increment reference counters for the group */
     OBJ_RETAIN(comm->c_local_group);
-
-    /* increase also the reference counter for the procs */
-    ompi_group_increment_proc_count(comm->c_local_group);
 
     *group = comm->c_local_group;
     return OMPI_SUCCESS;
@@ -572,8 +567,6 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
             goto exit;
         }
 
-        ompi_group_increment_proc_count(local_group);
-
         mode = OMPI_COMM_CID_INTER;
     } else {
         rranks = NULL;
@@ -605,7 +598,6 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
     }
 
     if ( inter ) {
-        ompi_group_decrement_proc_count (local_group);
         OBJ_RELEASE(local_group);
         if (NULL != newcomp->c_local_comm) {
             snprintf(newcomp->c_local_comm->c_name, MPI_MAX_OBJECT_NAME,
@@ -2007,9 +1999,6 @@ static int ompi_comm_fill_rest(ompi_communicator_t *comm,
     /* set the remote group to be the same as local group */
     comm->c_remote_group = comm->c_local_group;
     OBJ_RETAIN( comm->c_remote_group );
-
-    /* retain these proc pointers */
-    ompi_group_increment_proc_count(comm->c_local_group);
 
     /* set the rank information */
     comm->c_local_group->grp_my_rank = my_rank;

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -425,7 +425,6 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
     }
 
     if (NULL != comm->c_local_group) {
-        ompi_group_decrement_proc_count (comm->c_local_group);
         OBJ_RELEASE ( comm->c_local_group );
         comm->c_local_group = NULL;
         if ( OMPI_COMM_IS_INTRA(comm) ) {
@@ -438,7 +437,6 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
     }
 
     if (NULL != comm->c_remote_group) {
-        ompi_group_decrement_proc_count (comm->c_remote_group);
         OBJ_RELEASE ( comm->c_remote_group );
         comm->c_remote_group = NULL;
     }

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -441,11 +441,10 @@ int ompi_dpm_connect_accept(ompi_communicator_t *comm, int root,
     i=0;
     OPAL_LIST_FOREACH(cd, &rlist, ompi_dpm_proct_caddy_t) {
         new_group_pointer->grp_proc_pointers[i++] = cd->p;
+        /* retain the proc */
+        OBJ_RETAIN(cd->p);
     }
     OPAL_LIST_DESTRUCT(&rlist);
-
-    /* increment proc reference counters */
-    ompi_group_increment_proc_count(new_group_pointer);
 
     /* set up communicator structure */
     rc = ompi_comm_set ( &newcomp,                 /* new comm */
@@ -465,7 +464,6 @@ int ompi_dpm_connect_accept(ompi_communicator_t *comm, int root,
         goto exit;
     }
 
-    ompi_group_decrement_proc_count (new_group_pointer);
     OBJ_RELEASE(new_group_pointer);
     new_group_pointer = MPI_GROUP_NULL;
 

--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -37,7 +37,6 @@ int ompi_group_free ( ompi_group_t **group )
     ompi_group_t *l_group;
 
     l_group = (ompi_group_t *) *group;
-    ompi_group_decrement_proc_count (l_group);
     OBJ_RELEASE(l_group);
 
     *group = MPI_GROUP_NULL;

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -154,6 +154,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_group_t *ompi_mpi_group_null_addr;
  * @return Pointer to new group structure
  */
 OMPI_DECLSPEC ompi_group_t *ompi_group_allocate(int group_size);
+ompi_group_t *ompi_group_allocate_plist_w_procs (ompi_proc_t **procs, int group_size);
 ompi_group_t *ompi_group_allocate_sporadic(int group_size);
 ompi_group_t *ompi_group_allocate_strided(void);
 ompi_group_t *ompi_group_allocate_bmap(int orig_group_size, int group_size);

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -57,6 +57,24 @@ ompi_predefined_group_t *ompi_mpi_group_null_addr = &ompi_mpi_group_null;
 ompi_group_t *ompi_group_allocate(int group_size)
 {
     /* local variables */
+    ompi_proc_t **procs = calloc (group_size, sizeof (ompi_proc_t *));
+    ompi_group_t *new_group;
+
+    if (NULL == procs) {
+        return NULL;
+    }
+
+    new_group = ompi_group_allocate_plist_w_procs (procs, group_size);
+    if (NULL == new_group) {
+        free (procs);
+    }
+
+    return new_group;
+}
+
+ompi_group_t *ompi_group_allocate_plist_w_procs (ompi_proc_t **procs, int group_size)
+{
+    /* local variables */
     ompi_group_t * new_group = NULL;
 
     assert (group_size >= 0);
@@ -65,28 +83,19 @@ ompi_group_t *ompi_group_allocate(int group_size)
     new_group = OBJ_NEW(ompi_group_t);
 
     if (NULL == new_group) {
-        goto error_exit;
+        return NULL;
     }
 
     if (0 > new_group->grp_f_to_c_index) {
         OBJ_RELEASE (new_group);
-        new_group = NULL;
-        goto error_exit;
+        return NULL;
     }
 
     /*
      * Allocate array of (ompi_proc_t *)'s, one for each
      * process in the group.
      */
-    new_group->grp_proc_pointers = (struct ompi_proc_t **)
-        malloc(sizeof(struct ompi_proc_t *) * group_size);
-
-    if (NULL == new_group->grp_proc_pointers) {
-        /* grp_proc_pointers allocation failed */
-        OBJ_RELEASE (new_group);
-        new_group = NULL;
-        goto error_exit;
-    }
+    new_group->grp_proc_pointers = procs;
 
     /* set the group size */
     new_group->grp_proc_count = group_size;
@@ -95,8 +104,8 @@ ompi_group_t *ompi_group_allocate(int group_size)
     new_group->grp_my_rank = MPI_UNDEFINED;
     OMPI_GROUP_SET_DENSE(new_group);
 
- error_exit:
-    /* return */
+    ompi_group_increment_proc_count (new_group);
+
     return new_group;
 }
 

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -266,6 +266,8 @@ static void ompi_group_destruct(ompi_group_t *group)
        the proc counts are not increased during the constructor,
        either). */
 
+    ompi_group_decrement_proc_count (group);
+
     /* release thegrp_proc_pointers memory */
     if (NULL != group->grp_proc_pointers) {
         free(group->grp_proc_pointers);

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -193,7 +193,6 @@ int ompi_osc_rdma_post_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
 
     /* save the group */
     OBJ_RETAIN(group);
-    ompi_group_increment_proc_count(group);
 
     OPAL_THREAD_LOCK(&module->lock);
 
@@ -371,7 +370,6 @@ int ompi_osc_rdma_start_atomic (ompi_group_t *group, int assert, ompi_win_t *win
 
     /* save the group */
     OBJ_RETAIN(group);
-    ompi_group_increment_proc_count(group);
 
     if (!(assert & MPI_MODE_NOCHECK)) {
         /* look through list of pending posts */
@@ -440,7 +438,6 @@ int ompi_osc_rdma_complete_atomic (ompi_win_t *win)
     sync->epoch_active = false;
 
     /* phase 2 cleanup group */
-    ompi_group_decrement_proc_count(group);
     OBJ_RELEASE(group);
 
     peers = sync->peer_list.peers;
@@ -526,7 +523,6 @@ int ompi_osc_rdma_wait_atomic (ompi_win_t *win)
     module->pw_group = NULL;
     OPAL_THREAD_UNLOCK(&module->lock);
 
-    ompi_group_decrement_proc_count(group);
     OBJ_RELEASE(group);
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "wait complete");
@@ -571,7 +567,6 @@ int ompi_osc_rdma_test_atomic (ompi_win_t *win, int *flag)
     module->pw_group = NULL;
     OPAL_THREAD_UNLOCK(&(module->lock));
 
-    ompi_group_decrement_proc_count(group);
     OBJ_RELEASE(group);
 
     return OMPI_SUCCESS;

--- a/ompi/mpi/c/comm_remote_group.c
+++ b/ompi/mpi/c/comm_remote_group.c
@@ -68,6 +68,5 @@ int MPI_Comm_remote_group(MPI_Comm comm, MPI_Group *group)
     }
 
     *group = (MPI_Group) comm->c_remote_group;
-    ompi_group_increment_proc_count(*group);
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/intercomm_create.c
+++ b/ompi/mpi/c/intercomm_create.c
@@ -169,9 +169,8 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
     /* put group elements in the list */
     for (j = 0; j < rsize; j++) {
         new_group_pointer->grp_proc_pointers[j] = rprocs[j];
+        OBJ_RETAIN(rprocs[j]);
     }
-
-    ompi_group_increment_proc_count(new_group_pointer);
 
     rc = ompi_comm_set ( &newcomp,                                     /* new comm */
                          local_comm,                                   /* old comm */
@@ -194,7 +193,6 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
         goto err_exit;
     }
 
-    ompi_group_decrement_proc_count (new_group_pointer);
     OBJ_RELEASE(new_group_pointer);
     new_group_pointer = MPI_GROUP_NULL;
 

--- a/ompi/mpi/c/intercomm_merge.c
+++ b/ompi/mpi/c/intercomm_merge.c
@@ -113,7 +113,6 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
         goto exit;
     }
 
-    ompi_group_decrement_proc_count(new_group_pointer);
     OBJ_RELEASE(new_group_pointer);
     new_group_pointer = MPI_GROUP_NULL;
 

--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -630,8 +630,14 @@ ompi_proc_pack(ompi_proc_t **proclist, int proclistsize,
      * can be sent.
      */
     for (int i = 0 ; i < proclistsize ; ++i) {
+        ompi_proc_t *proc = proclist[i];
+
+        if (ompi_proc_is_sentinel (proc)) {
+            proc = ompi_proc_for_name (ompi_proc_sentinel_to_name ((intptr_t) proc));
+        }
+
         /* send proc name */
-        rc = opal_dss.pack(buf, &(proclist[i]->super.proc_name), 1, OMPI_NAME);
+        rc = opal_dss.pack(buf, &(proc->super.proc_name), 1, OMPI_NAME);
         if(rc != OPAL_SUCCESS) {
             OMPI_ERROR_LOG(rc);
             opal_mutex_unlock (&ompi_proc_lock);
@@ -639,7 +645,7 @@ ompi_proc_pack(ompi_proc_t **proclist, int proclistsize,
         }
         /* retrieve and send the corresponding nspace for this job
          * as the remote side may not know the translation */
-        nspace = (char*)opal_pmix.get_nspace(proclist[i]->super.proc_name.jobid);
+        nspace = (char*)opal_pmix.get_nspace(proc->super.proc_name.jobid);
         rc = opal_dss.pack(buf, &nspace, 1, OPAL_STRING);
         if(rc != OPAL_SUCCESS) {
             OMPI_ERROR_LOG(rc);
@@ -647,14 +653,14 @@ ompi_proc_pack(ompi_proc_t **proclist, int proclistsize,
             return rc;
         }
         /* pack architecture flag */
-        rc = opal_dss.pack(buf, &(proclist[i]->super.proc_arch), 1, OPAL_UINT32);
+        rc = opal_dss.pack(buf, &(proc->super.proc_arch), 1, OPAL_UINT32);
         if(rc != OPAL_SUCCESS) {
             OMPI_ERROR_LOG(rc);
             opal_mutex_unlock (&ompi_proc_lock);
             return rc;
         }
         /* pass the name of the host this proc is on */
-        rc = opal_dss.pack(buf, &(proclist[i]->super.proc_hostname), 1, OPAL_STRING);
+        rc = opal_dss.pack(buf, &(proc->super.proc_hostname), 1, OPAL_STRING);
         if(rc != OPAL_SUCCESS) {
             OMPI_ERROR_LOG(rc);
             opal_mutex_unlock (&ompi_proc_lock);

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -145,7 +145,6 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
     /* setup data that is independent of osc component */
     group = comm->c_local_group;
     OBJ_RETAIN(group);
-    ompi_group_increment_proc_count(group);
     win->w_group = group;
 
     *win_out = win;
@@ -366,7 +365,6 @@ ompi_win_get_name(ompi_win_t *win, char *win_name, int *length)
 int
 ompi_win_group(ompi_win_t *win, ompi_group_t **group) {
     OBJ_RETAIN(win->w_group);
-    ompi_group_increment_proc_count(win->w_group);
     *group = win->w_group;
 
     return OMPI_SUCCESS;
@@ -406,7 +404,6 @@ ompi_win_destruct(ompi_win_t *win)
     }
 
     if (NULL != win->w_group) {
-        ompi_group_decrement_proc_count(win->w_group);
         OBJ_RELEASE(win->w_group);
     }
 


### PR DESCRIPTION
This PR fixes issues with groups that affects the dynamic add_procs support. Before this commit procs in a group are incremented each time the group's reference count is incremented (and similarly decremented on release). After this commit a group holds one reference to any allocated proc in the group. When a group is released that reference is released.

:bot:assign: @bosilca 
:bot:label:bug
:bot:milestone:v2.0.0
