### PR TITLE
Fix NBC iBarrier for inter-communicators.

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ibarrier.c
+++ b/ompi/mca/coll/libnbc/nbc_ibarrier.c
@@ -136,7 +136,7 @@ int ompi_coll_libnbc_ibarrier_inter(struct ompi_communicator_t *comm, ompi_reque
     if (NBC_OK != res) { printf("Error in NBC_Sched_barrier() (%i)\n", res); return res; }
 
     /* inform remote peers that all local peers have entered the barrier */
-    for (peer = 0 ; peer < rsize ; ++peer) {
+    for (peer = 1 ; peer < rsize ; ++peer) {
       res = NBC_Sched_send (0, true, 1, MPI_BYTE, peer, schedule);
       if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
     }


### PR DESCRIPTION
Remove send of the extra message. This bug hase triggered on
MPICH/coll/nbicbarrier test. In this test a series of communicators
are created.
This extre-message was reseived after original communicator was destroyed
and queued into non_existing_communicator_pending. When new completely
unrelated communicator with the same id as original was created this message
was pushed into the frags_cant_match queue and caused seq numbers skew and hang.

(ported from commit open-mpi/ompi@fc17deca43db82cc7b11e2e01257ccb3dc39feb1)
