### PR TITLE
Fix NBC iGatherv for inter-communicators.

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_igatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_igatherv.c
@@ -118,7 +118,7 @@ int ompi_coll_libnbc_igatherv_inter (const void* sendbuf, int sendcount, MPI_Dat
   NBC_Handle *handle;
   ompi_coll_libnbc_module_t *libnbc_module = (ompi_coll_libnbc_module_t*) module;
 
-  rsize = ompi_comm_size (comm);
+  rsize = ompi_comm_remote_size (comm);
 
   if (MPI_ROOT == root) {
     res = ompi_datatype_type_extent(recvtype, &rcvext);


### PR DESCRIPTION
We need to use remote size to form a schedule.

(cherry picked from commit open-mpi/ompi@2d0919dbdce2f7a1e53a948a544b4034faf7821c)
