### PR TITLE
btl/openib: use only SRQ on ib by default

### DIFF
--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -663,7 +663,7 @@ int btl_openib_register_mca_params(void)
     }
 
     asprintf(&default_qps,
-            "P,128,256,192,128:S,%u,1024,1008,64:S,%u,1024,1008,64:S,%u,1024,1008,64",
+            "S,128,256,192,128:S,%u,1024,1008,64:S,%u,1024,1008,64:S,%u,1024,1008,64",
             mid_qp_size,
             (uint32_t)mca_btl_openib_module.super.btl_eager_limit,
             (uint32_t)mca_btl_openib_module.super.btl_max_send_size);


### PR DESCRIPTION
It was decided some time ago that there is no benefit to using any
per-peer receive queues on infiniband. At the time we decided not to
change the default but that objection has been dropped. This commit
changes the 128 message queue to use SRQ instead of PP. This has no
impact on iWarp which sets the default in a different way.

Closes open-mpi/ompi#1156

(cherry picked from open-mpi/ompi@b24b3a4ae467b7299b42075ab77981a92532427f)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

:bot:assign: @miked-mellanox 
:bot:label:enhancement
:bot:label:bug
:bot:milestone:v2.0.0
