### PR TITLE
v2.x: usnic: fix error message

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_util.c
+++ b/opal/mca/btl/usnic/btl_usnic_util.c
@@ -65,7 +65,7 @@ void opal_btl_usnic_util_abort(const char *msg, const char *file, int line)
     opal_show_help("help-mpi-btl-usnic.txt", "internal error after init",
                    true,
                    opal_process_info.nodename,
-                   file, line, message);
+                   file, line, msg);
 
     opal_btl_usnic_exit(NULL);
     /* Never returns */

--- a/opal/mca/btl/usnic/btl_usnic_util.c
+++ b/opal/mca/btl/usnic/btl_usnic_util.c
@@ -65,7 +65,7 @@ void opal_btl_usnic_util_abort(const char *msg, const char *file, int line)
     opal_show_help("help-mpi-btl-usnic.txt", "internal error after init",
                    true,
                    opal_process_info.nodename,
-                   msg, file, line);
+                   file, line, message);
 
     opal_btl_usnic_exit(NULL);
     /* Never returns */

--- a/opal/mca/btl/usnic/help-mpi-btl-usnic.txt
+++ b/opal/mca/btl/usnic/help-mpi-btl-usnic.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2012-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -77,10 +77,9 @@ something wrong with the usNIC or OpenFabrics configuration on this
 server.
 
   Server:       %s
-  Message:      %s
   File:         %s
   Line:         %d
-  Error:        %s
+  Message:      %s
 #
 [check_reg_mem_basics fail]
 The usNIC BTL failed to initialize while trying to register some


### PR DESCRIPTION
There were too many "%s" instances.  Re-order the output so that we show file, line, and then the error message.

(cherry picked from commit open-mpi/ompi@c1a6beac8def88db35308777b591162bae01cf56)

@bturrubiates please review (trivial printf-style error); put a thumbs-up comment on this PR if it's ok with you
