### PR TITLE
v2.x/moar usnic fixes

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_cagent.c
+++ b/opal/mca/btl/usnic/btl_usnic_cagent.c
@@ -298,6 +298,10 @@ static void agent_sendto(int fd, char *buffer, ssize_t numbytes,
         } else if (rc < 0) {
             if (errno == EAGAIN || errno == EINTR) {
                 continue;
+            } else if (errno == EPERM) {
+                // We're sending too fast
+                usleep(5);
+                continue;
             }
 
             char *msg;

--- a/opal/mca/btl/usnic/btl_usnic_cagent.c
+++ b/opal/mca/btl/usnic/btl_usnic_cagent.c
@@ -300,7 +300,10 @@ static void agent_sendto(int fd, char *buffer, ssize_t numbytes,
                 continue;
             }
 
-            ABORT("Unexpected sendto() error");
+            char *msg;
+            asprintf(&msg, "Unexpected sendto() error: errno=%d (%s)",
+                     errno, strerror(errno));
+            ABORT(msg);
             /* Will not return */
         }
 


### PR DESCRIPTION
A pair of usnic fixes:
- improve an error message for when it happens to customers
- slow down our rate of sending UDP messages when `sendto()` returns EPERM

@bturrubiates please review
