### PR TITLE
PSM2 MLT use PSM2 hashing in message queue

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -419,9 +419,9 @@ int ompi_mtl_psm2_progress( void ) {
 	if (mtl_psm2_request->type == OMPI_mtl_psm2_IRECV) {
 
         mtl_psm2_request->super.ompi_req->req_status.MPI_SOURCE =
-            psm2_status.msg_tag.tag2;
+            psm2_status.msg_tag.tag1;
 	    mtl_psm2_request->super.ompi_req->req_status.MPI_TAG =
-		    psm2_status.msg_tag.tag1;
+		    psm2_status.msg_tag.tag0;
             mtl_psm2_request->super.ompi_req->req_status._ucount =
                 psm2_status.nbytes;
 

--- a/ompi/mca/mtl/psm2/mtl_psm2_probe.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_probe.c
@@ -46,8 +46,8 @@ int ompi_mtl_psm2_iprobe(struct mca_mtl_base_module_t* mtl,
     if (err == PSM2_OK) {
 	*flag = 1;
 	if(MPI_STATUS_IGNORE != status) {
-            status->MPI_SOURCE = mqstat.msg_tag.tag2;
-            status->MPI_TAG = mqstat.msg_tag.tag1;
+            status->MPI_SOURCE = mqstat.msg_tag.tag1;
+            status->MPI_TAG = mqstat.msg_tag.tag0;
             status->_ucount = mqstat.nbytes;
 
             switch (mqstat.error_code) {
@@ -95,8 +95,8 @@ ompi_mtl_psm2_improbe(struct mca_mtl_base_module_t *mtl,
     if (err == PSM2_OK) {
 
 	if(MPI_STATUS_IGNORE != status) {
-            status->MPI_SOURCE = mqstat.msg_tag.tag2;
-            status->MPI_TAG = mqstat.msg_tag.tag1;
+            status->MPI_SOURCE = mqstat.msg_tag.tag1;
+            status->MPI_TAG = mqstat.msg_tag.tag0;
             status->_ucount = mqstat.nbytes;
 
             switch (mqstat.error_code) {
@@ -118,7 +118,7 @@ ompi_mtl_psm2_improbe(struct mca_mtl_base_module_t *mtl,
 
 	msg->comm = comm;
 	msg->req_ptr = mqreq;
-	msg->peer = mqstat.msg_tag.tag2;
+	msg->peer = mqstat.msg_tag.tag1;
 	msg->count = mqstat.nbytes;
 
 	*message = msg;

--- a/ompi/mca/mtl/psm2/mtl_psm2_types.h
+++ b/ompi/mca/mtl/psm2/mtl_psm2_types.h
@@ -62,29 +62,29 @@ typedef struct mca_mtl_psm2_component_t mca_mtl_psm2_component_t;
 
 OMPI_DECLSPEC extern mca_mtl_psm2_component_t mca_mtl_psm2_component;
 
-#define PSM2_MAKE_MQTAG(ctxt,rank,utag,tag)  \
+#define PSM2_MAKE_MQTAG(ctxt,rank,utag,tag) \
     do {                                    \
-      (tag).tag0 = ctxt;                      \
-      (tag).tag1 = utag;                      \
-      (tag).tag2 = rank;                      \
+      (tag).tag0 = utag;                    \
+      (tag).tag1 = rank;                    \
+      (tag).tag2 = ctxt;                    \
     } while (0)
 
-#define PSM2_MAKE_TAGSEL(user_rank, user_tag, user_ctxt, tag, _tagsel)   \
-    do {                                                                \
-        (tag).tag0 = user_ctxt;                                         \
-        (tag).tag1 = user_tag;                                          \
-        (tag).tag2 = user_rank;                                         \
+#define PSM2_MAKE_TAGSEL(user_rank, user_tag, user_ctxt, tag, _tagsel)  \
+	do {								\
+        (tag).tag0 = user_tag;                                          \
+        (tag).tag1 = user_rank;                                         \
+        (tag).tag2 = user_ctxt;                                         \
         (_tagsel).tag0 = 0xffffffffULL;                                 \
         (_tagsel).tag1 = 0xffffffffULL;                                 \
         (_tagsel).tag2 = 0xffffffffULL;                                 \
         if((user_tag) == MPI_ANY_TAG)                                   \
         {                                                               \
-            (_tagsel).tag1 = 0x80000000ULL;                             \
-            (tag).tag1 = 0x00000000ULL;                                 \
+            (_tagsel).tag0 = 0x80000000ULL;                             \
+            (tag).tag0 = 0x00000000ULL;                                 \
         }                                                               \
         if((user_rank) == MPI_ANY_SOURCE)                               \
         {                                                               \
-            (_tagsel).tag2 = 0x00000000ULL;                             \
+            (_tagsel).tag1 = 0x00000000ULL;                             \
         }                                                               \
     } while (0)
 


### PR DESCRIPTION
A new internal feature in PSM2 will use hash tables to accelerate message queue lookups if the lookups have the proper tag&mask layout. OpenMPI should follow PSM2's preferred tag&mask spec, so that PSM2 can provide a performance benefit.
open-mpi/opmi@9a1f9be
