### PR TITLE
support Cray nativized slurm environment

### DIFF
--- a/config/orte_check_alps.m4
+++ b/config/orte_check_alps.m4
@@ -129,7 +129,18 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                                                        AC_MSG_WARN([on the configure line using --with-alps option.])
                                                        AC_MSG_ERROR([Aborting])],[])]
                                                        )
-
+                               PKG_CHECK_MODULES_STATIC([CRAY_WLM_DETECT], [cray-wlm_detect],
+                                               [orte_check_cray_alps_happy="yes"
+                                                AC_DEFINE_UNQUOTED([CRAY_WLM_DETECT],[1],
+                                                                   [defined to 1 if cray wlm available, 0 otherwise])
+                                               ],
+                                               [orte_check_cray_alps_happy="no"]
+                                               [AS_IF([test "$with_alps" = "yes"],
+                                                      [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
+                                                       AC_MSG_WARN([Need to explicitly indicate ALPS directory])
+                                                       AC_MSG_WARN([on the configure line using --with-alps option.])
+                                                       AC_MSG_ERROR([Aborting])],[])]
+                                                       )
                             ],
                             [AC_MSG_WARN([See ./configure --help for how to control Open MPI])
                              AC_MSG_WARN([configuration for ALPS on CLE 5 and higher systems])
@@ -146,10 +157,10 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
 
         AS_IF([test "$orte_check_cray_alps_happy" = "yes"],
               [$1_LDFLAGS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"
-               $1_CPPFLAGS="$CRAY_ALPSLLI_CFLAGS $CRAY_ALPSUTIL_CFLAGS $CRAY_ALPS_CFLAGS"
-               $1_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"
-               $1_WRAPPER_EXTRA_LDFLAGS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"
-               $1_WRAPPER_EXTRA_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"],
+               $1_CPPFLAGS="$CRAY_ALPSLLI_CFLAGS $CRAY_ALPSUTIL_CFLAGS $CRAY_ALPS_CFLAGS $CRAY_WLM_DETECT_CFLAGS"
+               $1_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"
+               $1_WRAPPER_EXTRA_LDFLAGS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"
+               $1_WRAPPER_EXTRA_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"],
               [])
 
     fi

--- a/orte/mca/plm/alps/Makefile.am
+++ b/orte/mca/plm/alps/Makefile.am
@@ -10,6 +10,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,8 +41,13 @@ endif
 mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_alps_la_SOURCES = $(sources)
-mca_plm_alps_la_LDFLAGS = -module -avoid-version
+mca_plm_alps_la_CPPFLAGS = $(plm_alps_CPPFLAGS)
+mca_plm_alps_la_LDFLAGS = -module -avoid-version $(plm_alps_LDFLAGS)
+mca_plm_alps_la_LIBADD = $(plm_alps_LIBS) \
+    $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_alps_la_SOURCES =$(sources)
-libmca_plm_alps_la_LDFLAGS = -module -avoid-version
+libmca_plm_alps_la_CPPFLAGS = $(plm_alps_CPPFLAGS)
+libmca_plm_alps_la_LDFLAGS = -module -avoid-version $(plm_alps_LDFLAGS)
+libmca_plm_alps_la_LIBADD = $(plm_alps_LIBS)

--- a/orte/mca/plm/alps/configure.m4
+++ b/orte/mca/plm/alps/configure.m4
@@ -27,5 +27,11 @@ AC_DEFUN([MCA_orte_plm_alps_CONFIG],[
 
 	ORTE_CHECK_ALPS([plm_alps], [plm_alps_happy="yes"], [plm_alps_happy="no"])
 
-    AS_IF([test "$plm_alps_happy" = "yes"], [$1], [$2])
+    AS_IF([test "$plm_alps_happy" = "yes"],
+          [$1
+           AC_SUBST([plm_alps_CPPFLAGS])
+           AC_SUBST([plm_alps_LDFLAGS])
+           AC_SUBST([plm_alps_LIBS])],
+          [$2])
+
 ])dnl

--- a/orte/mca/plm/alps/plm_alps.h
+++ b/orte/mca/plm/alps/plm_alps.h
@@ -23,6 +23,9 @@
 
 #include "orte/mca/mca.h"
 #include "orte/mca/plm/plm.h"
+#if CRAY_WLM_DETECT
+#include "wlm_detect.h"
+#endif
 
 BEGIN_C_DECLS
 

--- a/orte/mca/plm/alps/plm_alps_component.c
+++ b/orte/mca/plm/alps/plm_alps_component.c
@@ -136,8 +136,29 @@ static int plm_alps_open(void)
 
 static int orte_plm_alps_component_query(mca_base_module_t **module, int *priority)
 {
-    *priority = mca_plm_alps_component.priority;
-    *module = (mca_base_module_t *) &orte_plm_alps_module;
+    int alps_wlm_active = 1;
+#if CRAY_WLM_DETECT
+    char slurm[]="SLURM";
+
+    if(!strcmp(slurm,wlm_detect_get_active())) {
+        alps_wlm_active = 0;
+    }
+#endif
+
+    if (alps_wlm_active) {
+        *priority = mca_plm_alps_component.priority;
+        *module = (mca_base_module_t *) &orte_plm_alps_module;
+        OPAL_OUTPUT_VERBOSE((1, orte_plm_base_framework.framework_output,
+                            "%s plm:alps: available for selection",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+    } else {
+        *priority = 0;
+        *module = NULL;
+        OPAL_OUTPUT_VERBOSE((1, orte_plm_base_framework.framework_output,
+                            "%s plm:alps: not available, slurm present",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+    }
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/plm/slurm/configure.m4
+++ b/orte/mca/plm/slurm/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2015 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -37,4 +37,11 @@ AC_DEFUN([MCA_orte_plm_slurm_CONFIG],[
     AC_SUBST([plm_slurm_CPPFLAGS])
     AC_SUBST([plm_slurm_LDFLAGS])
     AC_SUBST([plm_slurm_LIBS])
+
+    # check to see if this is a Cray nativized slurm env.
+
+    ORTE_CHECK_ALPS([plm_slurm_cray],
+                    [AC_DEFINE_UNQUOTED([SLURM_CRAY_ENV],[1],
+                    [defined to 1 if slurm cray env, 0 otherwise])])
+
 ])dnl

--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2007-2012 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -27,6 +27,7 @@
  */
 
 #include "orte_config.h"
+#include "orte/runtime/orte_globals.h"
 
 #include <string.h>
 #include <sys/types.h>
@@ -274,6 +275,18 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * bound to only one processor
      */
     opal_argv_append(&argc, &argv, "--cpu_bind=none");
+
+#if SLURM_CRAY_ENV
+    /*
+     * If in a SLURM/Cray env. make sure that Cray PMI is not pulled in,
+     * neither as a constructor run when orteds start, nor selected
+     * when pmix components are registered
+     */
+
+    opal_setenv("PMI_NO_PREINITIALIZE", "1", false, &orte_launch_environ);
+    opal_setenv("PMI_NO_FORK", "1", false, &orte_launch_environ);
+    opal_setenv("OMPI_NO_USE_CRAY_PMI", "1", false, &orte_launch_environ);
+#endif
 
     /* Append user defined arguments to srun */
     if ( NULL != mca_plm_slurm_component.custom_args ) {


### PR DESCRIPTION
This set of commits enables support for orte based job launches on Cray systems using nativized SLURM as the job launcher.

One of the commits toggles off plm/alps component when the cray wlm detection system reports SLURM is the current active job launcher.

The plm/slurm component has to be slightly modified in order to support --disable-dlopen configurations of Open MPI on Cray systems, as well as disabling selection of the 
Cray PMIx component when using an orte based job launch.

Note Cray nativized SLURM is only available on CLE 5 and higher systems.

merge of PR open-mpi/ompi#1195 back to v2.x
@hjelmn 
