### PR TITLE
configury: fix uninitialized variable in OMPI_FORTRAN_CHECK_USE_ONLY

### DIFF
--- a/config/ompi_fortran_check_use_only.m4
+++ b/config/ompi_fortran_check_use_only.m4
@@ -35,6 +35,7 @@ dnl ----------------------------------------------------
 AC_DEFUN([OMPI_FORTRAN_CHECK_USE_ONLY],[
     AS_VAR_PUSHDEF([use_only_var], [ompi_cv_fortran_use_only])
     OPAL_VAR_SCOPE_PUSH([FCFLAGS_save])
+    FCFLAGS_save=$FCFLAGS
     FCFLAGS="-I. $FCFLAGS"
 
     AC_CACHE_CHECK([if Fortran compiler supports USE...ONLY], use_only_var,


### PR DESCRIPTION
Thanks Paul Hargrove for pointing this issue

(cherry picked from commit open-mpi/ompi@862b12acf98f2bd97d91855a63f3bba908f17b7b)
