### PR TITLE
Fix the missing resize of the returned type for

### DIFF
--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -278,6 +278,7 @@ int32_t ompi_datatype_create_darray(int size,
             rc = ompi_datatype_create_hindexed( 1, blength_hindexed, displs_hindexed, lastType, newtype);
         }
         ompi_datatype_destroy(&lastType);
+        opal_datatype_resize( &(*newtype)->super, 0, displs[1] );
         /* need to destroy the old type even in error condition, so
            don't check return code from above until after cleanup. */
         if (MPI_SUCCESS != rc) goto cleanup;

--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
  * $COPYRIGHT$
@@ -37,7 +37,7 @@ int32_t ompi_datatype_create_subarray(int ndims,
                                       const ompi_datatype_t* oldtype,
                                       ompi_datatype_t** newtype)
 {
-    MPI_Datatype last_type;
+    ompi_datatype_t *last_type;
     int32_t i, step, end_loop;
     MPI_Aint size, displ, extent;
 
@@ -113,6 +113,7 @@ int32_t ompi_datatype_create_subarray(int ndims,
         ompi_datatype_create_hindexed( 1, blength, displs, last_type, newtype);
     }
     ompi_datatype_destroy( &last_type );
+    opal_datatype_resize( &(*newtype)->super, 0, size * extent );
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
the subarray and darray types.

Thanks Keith Bennett and Dan Garmann for reporting this issue

Fixes open-mpi/ompi#1191

(cherry picked from commit open-mpi/ompi@12dad8b37f3ce4da8bd41e5d4b29abfc9d605b34)
