### PR TITLE
correctly set all variables storing information on the file pointer p…

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -52,11 +52,13 @@ int mca_io_ompio_set_view_internal(mca_io_ompio_file_t *fh,
     fh->f_disp        = disp;
     fh->f_offset      = disp;
     fh->f_total_bytes = 0;
-    
-    ompi_io_ompio_decode_datatype (fh, 
-                                   filetype, 
-                                   1, 
-                                   NULL, 
+    fh->f_index_in_file_view=0;
+    fh->f_position_in_file_view=0;
+
+    ompi_io_ompio_decode_datatype (fh,
+                                   filetype,
+                                   1,
+                                   NULL,
                                    &max_data,
                                    &fh->f_decoded_iov, 
                                    &fh->f_iov_count);


### PR DESCRIPTION
…osition  to zero when setting the file view

(back-ported from commit open-mpi/ompi@46c20a1246cc944dbd053edb9545bc10e11ffc54)
