### PR TITLE
btl/sm: fix race condition

### DIFF
--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -593,6 +593,7 @@ create_rndv_file(mca_btl_sm_component_t *comp_ptr,
     int rc = OPAL_SUCCESS;
     int fd = -1;
     char *fname = NULL;
+    char *tmpfname = NULL;
     /* used as a temporary store so we can extract shmem_ds info */
     mca_common_sm_module_t *tmp_modp = NULL;
 
@@ -650,7 +651,12 @@ create_rndv_file(mca_btl_sm_component_t *comp_ptr,
 
     /* now just write the contents of tmp_modp->shmem_ds to the full
      * sizeof(opal_shmem_ds_t), so we know where the mpool_res_size starts. */
-    if (-1 == (fd = open(fname, O_CREAT | O_RDWR, 0600))) {
+    asprintf(&tmpfname, "%s.tmp", fname);
+    if (NULL == tmpfname) {
+        rc = OPAL_ERR_OUT_OF_RESOURCE;
+        goto out;
+    }
+    if (-1 == (fd = open(tmpfname, O_CREAT | O_RDWR, 0600))) {
         int err = errno;
         opal_show_help("help-mpi-btl-sm.txt", "sys call fail", true,
                        "open(2)", strerror(err), err);
@@ -676,10 +682,17 @@ create_rndv_file(mca_btl_sm_component_t *comp_ptr,
         /* only do this for the mpool case */
         OBJ_RELEASE(tmp_modp);
     }
+    if (0 != rename(tmpfname, fname)) {
+        rc = OPAL_ERR_IN_ERRNO;
+        goto out;
+    }
 
 out:
     if (-1 != fd) {
         (void)close(fd);
+    }
+    if (NULL != tmpfname) {
+        free(tmpfname);
     }
     return rc;
 }

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -682,6 +682,8 @@ create_rndv_file(mca_btl_sm_component_t *comp_ptr,
         /* only do this for the mpool case */
         OBJ_RELEASE(tmp_modp);
     }
+    (void)close(fd);
+    fd = -1;
     if (0 != rename(tmpfname, fname)) {
         rc = OPAL_ERR_IN_ERRNO;
         goto out;


### PR DESCRIPTION
write to file and then rename, so when the file is open for read, its content is known to have been written.

Fixes open-mpi/ompi#1230

(cherry picked from commit open-mpi/ompi@db4f483653c52d678b764cae82c9d243142a7791)
