### PR TITLE
pml/cm: add missing #include <alloca.h>

### DIFF
--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -15,6 +15,10 @@
 #ifndef PML_CM_H
 #define PML_CM_H
 
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
 #include "ompi_config.h"
 #include "ompi/request/request.h"
 #include "ompi/mca/pml/pml.h"


### PR DESCRIPTION
Thanks Paul Hargrove for reporting this issue

(cherry picked from commit open-mpi/ompi@b38c17dbcbb6c1bbccf32644f3640b2fc1a85620)
