### PR TITLE
configury: test portability

### DIFF
--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -13,6 +13,8 @@
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
 # Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel Corporation. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,9 +42,9 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
     ompi_check_psm2_$1_save_LIBS="$LIBS"
 
     AS_IF([test "$with_psm2" != "no"],
-          [AS_IF([test ! -z "$with_psm2" -a "$with_psm2" != "yes"],
+          [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "yes"],
                  [ompi_check_psm2_dir="$with_psm2"])
-           AS_IF([test ! -z "$with_psm2_libdir" -a "$with_psm2_libdir" != "yes"],
+           AS_IF([test ! -z "$with_psm2_libdir" && test "$with_psm2_libdir" != "yes"],
                  [ompi_check_psm2_libdir="$with_psm2_libdir"])
 
            OPAL_CHECK_PACKAGE([$1],
@@ -60,13 +62,13 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
     LDFLAGS="$ompi_check_psm2_$1_save_LDFLAGS"
     LIBS="$ompi_check_psm2_$1_save_LIBS"
 
-    AS_IF([test "$ompi_check_psm2_happy" = "yes" -a "$enable_progress_threads" = "yes"],
+    AS_IF([test "$ompi_check_psm2_happy" = "yes" && test "$enable_progress_threads" = "yes"],
           [AC_MSG_WARN([PSM2 driver does not currently support progress threads.  Disabling MTL.])
            ompi_check_psm2_happy="no"])
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],
           [$2],
-          [AS_IF([test ! -z "$with_psm2" -a "$with_psm2" != "no"],
+          [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "no"],
                  [AC_MSG_ERROR([PSM2 support requested but not found.  Aborting])])
            $3])
 ])

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (C) Mellanox Technologies Ltd. 2015.  ALL RIGHTS RESERVED.
+# Copyright (C) 2015      Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,12 +30,12 @@ AC_DEFUN([OMPI_CHECK_UCX],[
     ompi_check_ucx_$1_save_LIBS="$LIBS"
 
     AS_IF([test "$with_ucx" != "no"],
-          [AS_IF([test ! -z "$with_ucx" -a "$with_ucx" != "yes"],
+          [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
                  [
                     ompi_check_ucx_dir="$with_ucx"
                     ompi_check_ucx_libdir="$with_ucx/lib"
                  ])
-           AS_IF([test ! -z "$with_ucx_libdir" -a "$with_ucx_libdir" != "yes"],
+           AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
                  [ompi_check_ucx_libdir="$with_ucx_libdir"])
 
            ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
@@ -73,7 +75,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 
     AS_IF([test "$ompi_check_ucx_happy" = "yes"],
           [$2],
-          [AS_IF([test ! -z "$with_ucx" -a "$with_ucx" != "no"],
+          [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "no"],
                  [AC_MSG_ERROR([UCX support requested but not found.  Aborting])])
            $3])
 ])

--- a/config/ompi_fortran_check_real16_c_equiv.m4
+++ b/config/ompi_fortran_check_real16_c_equiv.m4
@@ -57,7 +57,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                                     [CFLAGS="$CFLAGS_save"
                                      AC_MSG_RESULT([does not work])])
                              ])
-                       AS_IF([test "$opal_cv_c_compiler_vendor" = "gnu" -a "$ac_cv_type___float128" = "yes"],
+                       AS_IF([test "$opal_cv_c_compiler_vendor" = "gnu" && test "$ac_cv_type___float128" = "yes"],
                              [AC_MSG_CHECKING([if gnu compiler __float128 == REAL*16])
                               OPAL_UNIQ([CFLAGS])
                               OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([__float128], [q])

--- a/config/opal_check_cray_xpmem.m4
+++ b/config/opal_check_cray_xpmem.m4
@@ -14,7 +14,7 @@
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
-# Copyright (c) 2014      Research Organization for Information Science
+# Copyright (c) 2014-2015 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -38,7 +38,7 @@ AC_DEFUN([OPAL_CHECK_CRAY_XPMEM],[
    AS_IF([test "$with_cray_xpmem" = "no"],
          [AC_MSG_RESULT([no])
           $3],
-         [AS_IF([test "$with_cray_xpmem" = "auto" -o "$with_cray_xpmem" = "yes"],
+         [AS_IF([test "$with_cray_xpmem" = "auto" || test "$with_cray_xpmem" = "yes"],
                  [PKG_CHECK_MODULES_STATIC([CRAY_XPMEM], [cray-xpmem],
                                     [opal_check_cray_xpmem_happy="yes"],
                                     [opal_check_cray_xpmem_happy="no"]
@@ -49,7 +49,7 @@ AC_DEFUN([OPAL_CHECK_CRAY_XPMEM],[
                  [])
          ])
 
-    AS_IF([test "$opal_check_cray_xpmem_happy" = "yes" -a "$enable_static" = "yes"],
+    AS_IF([test "$opal_check_cray_xpmem_happy" = "yes" && test "$enable_static" = "yes"],
           [CRAY_XPMEM_LIBS = $CRAY_XPMEM_STATIC_LIBS],[])
 
     AS_IF([test "$opal_check_cray_xpmem_happy" = "yes"],

--- a/config/opal_check_withdir.m4
+++ b/config/opal_check_withdir.m4
@@ -6,6 +6,8 @@ dnl                         Corporation.  All rights reserved.
 dnl Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -17,7 +19,7 @@ dnl
 # ----------------------------------------------------
 AC_DEFUN([OPAL_CHECK_WITHDIR],[
     AC_MSG_CHECKING([--with-$1 value])
-    AS_IF([test "$2" = "yes" -o "$2" = "no" -o "x$2" = "x"],
+    AS_IF([test "$2" = "yes" || test "$2" = "no" || test "x$2" = "x"],
           [AC_MSG_RESULT([simple ok (unspecified)])],
           [AS_IF([test ! -d "$2"],
                  [AC_MSG_RESULT([not found])

--- a/ompi/mca/io/romio314/configure.m4
+++ b/ompi/mca/io/romio314/configure.m4
@@ -52,7 +52,7 @@ AC_DEFUN([MCA_ompi_io_romio314_CONFIG],[
                    $2],
                   [AC_MSG_RESULT([yes])
 
-                   AS_IF([test -n "$with_io_romio_flags" -a "$with_io_romio_flags" != "no"],
+                   AS_IF([test -n "$with_io_romio_flags" && test "$with_io_romio_flags" != "no"],
                          [io_romio314_flags="$with_io_romio_flags $io_romio314_flags"],
                          [io_romio314_flags=])
                    # If ROMIO is going to end up in a DSO, all we need is
@@ -69,7 +69,7 @@ AC_DEFUN([MCA_ompi_io_romio314_CONFIG],[
                           AS_IF([test "$enable_static" = "yes"],
                                 [io_romio314_static=enable],
                                 [io_romio314_static=disable])])
-                   AS_IF([test -n "$prefix" -a "$prefix" != "NONE"],
+                   AS_IF([test -n "$prefix" && test "$prefix" != "NONE"],
                          [io_romio314_prefix_arg="--prefix=$prefix"],
                          [io_romio314_prefix_arg=])
 

--- a/opal/mca/btl/openib/configure.m4
+++ b/opal/mca/btl/openib/configure.m4
@@ -26,10 +26,10 @@
 # MCA_btl_openib_POST_CONFIG([should_build])
 # ------------------------------------------
 AC_DEFUN([MCA_opal_btl_openib_POST_CONFIG], [
-    AM_CONDITIONAL([MCA_btl_openib_have_xrc], [test $1 -eq 1 -a "x$btl_openib_have_xrc" = "x1"])
-    AM_CONDITIONAL([MCA_btl_openib_have_rdmacm], [test $1 -eq 1 -a "x$btl_openib_have_rdmacm" = "x1"])
-    AM_CONDITIONAL([MCA_btl_openib_have_dynamic_sl], [test $1 -eq 1 -a "x$btl_openib_have_opensm_devel" = "x1"])
-    AM_CONDITIONAL([MCA_btl_openib_have_udcm], [test $1 -eq 1 -a "x$btl_openib_have_udcm" = "x1"])
+    AM_CONDITIONAL([MCA_btl_openib_have_xrc], [test $1 -eq 1 && test "x$btl_openib_have_xrc" = "x1"])
+    AM_CONDITIONAL([MCA_btl_openib_have_rdmacm], [test $1 -eq 1 && test "x$btl_openib_have_rdmacm" = "x1"])
+    AM_CONDITIONAL([MCA_btl_openib_have_dynamic_sl], [test $1 -eq 1 && test "x$btl_openib_have_opensm_devel" = "x1"])
+    AM_CONDITIONAL([MCA_btl_openib_have_udcm], [test $1 -eq 1 && test "x$btl_openib_have_udcm" = "x1"])
 ])
 
 
@@ -132,7 +132,7 @@ AC_DEFUN([MCA_opal_btl_openib_CONFIG],[
                        [AC_CHECK_FUNC([__free_hook],
                             [btl_openib_malloc_hooks_enabled=1])])])])])
 
-    AS_IF([test "$enable_btl_openib_malloc_alignment" = "yes" -a "$btl_openib_malloc_hooks_enabled" = "0"],
+    AS_IF([test "$enable_btl_openib_malloc_alignment" = "yes" && test "$btl_openib_malloc_hooks_enabled" = "0"],
           [AC_MSG_ERROR([openib malloc alignment is requested but __malloc_hook is not available])])
     AC_MSG_CHECKING([whether the openib BTL will use malloc hooks])
     AS_IF([test "$btl_openib_malloc_hooks_enabled" = "0"],

--- a/opal/mca/btl/scif/configure.m4
+++ b/opal/mca/btl/scif/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,14 +22,14 @@ AC_DEFUN([MCA_opal_btl_scif_CONFIG],[
     opal_btl_scif_happy="no"
 
     if test "$with_scif" != "no" ; then
-	if test -n "$with_scif" -a "$with_scif" != "yes" ; then
+	if test -n "$with_scif" && test "$with_scif" != "yes" ; then
 	    opal_check_scif_dir=$with_scif
 	fi
 
 	OPAL_CHECK_PACKAGE([btl_scif], [scif.h], [scif], [scif_open], [],
 	                   [$opal_check_scif_dir], [], [opal_btl_scif_happy="yes"], [])
 
-	if test "$opal_btl_scif_happy" != "yes" -a -n "$with_scif" ; then
+	if test "$opal_btl_scif_happy" != "yes" && test -n "$with_scif" ; then
 	    AC_MSG_ERROR([SCIF support requested but not found.  Aborting])
 	fi
     fi

--- a/opal/mca/btl/vader/configure.m4
+++ b/opal/mca/btl/vader/configure.m4
@@ -6,6 +6,8 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,18 +35,18 @@ AC_DEFUN([OPAL_CHECK_XPMEM], [
     opal_check_xpmem_happy="no"
 
     if test ! "$with_xpmem" = "no" ; then
-	if test ! -z "$with_xpmem" -a "$with_xpmem" != "yes" ; then
+	if test ! -z "$with_xpmem" && test "$with_xpmem" != "yes" ; then
 	    opal_check_xpmem_dir="$with_xpmem"
 	fi
 
-	if test ! -z "$with_xpmem_libdir" -a "$with_xpmem_libdir" != "yes" ; then
+	if test ! -z "$with_xpmem_libdir" && test "$with_xpmem_libdir" != "yes" ; then
 	    opal_check_xpmem_libdir="$with_xpmem_libdir"
 	fi
 
 	OPAL_CHECK_PACKAGE([$1],[xpmem.h],[xpmem],[xpmem_make],[],
 	    [$opal_check_xpmem_dir],[$opal_check_xpmem_libdir], [opal_check_xpmem_happy="yes"], [])
 
-	if test "$opal_check_xpmem_happy" = "no" -a -n "$with_xpmem" -a "$with_xpmem" != "yes" ; then
+	if test "$opal_check_xpmem_happy" = "no" && test -n "$with_xpmem" && test "$with_xpmem" != "yes" ; then
 	    AC_MSG_ERROR([XPMEM support requested but not found.  Aborting])
 	fi
     fi

--- a/opal/mca/event/external/configure.m4
+++ b/opal/mca/event/external/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -71,7 +73,7 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
     # Make sure the user didn't specify --with-libevent=internal and
     # --with-libevent-libdir=whatever (because you can only specify
     # --with-libevent-libdir when external libevent is being used).
-    AS_IF([test "$with_libevent" = "internal" -a "$with_libevent_libdir" != ""],
+    AS_IF([test "$with_libevent" = "internal" && test -n "$with_libevent_libdir"],
           [AC_MSG_WARN([Both --with-libevent=internal and --with-libevent-libdir=DIR])
            AC_MSG_WARN([were specified, which does not make sense.])
            AC_MSG_ERROR([Cannot continue])])
@@ -80,8 +82,8 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
     # but hopefully slightly more clear...)
     opal_event_external_want=no
     AS_IF([test "$with_libevent" = "external"], [opal_event_external_want=yes])
-    AS_IF([test "$with_libevent_libdir" != ""], [opal_event_external_want=yes])
-    AS_IF([test "$with_libevent" != "" -a "$with_libevent" != "no" -a "$with_libevent" != "internal"], [opal_event_external_want=yes])
+    AS_IF([test -n "$with_libevent_libdir"], [opal_event_external_want=yes])
+    AS_IF([test -n "$with_libevent" && test "$with_libevent" != "no" && test "$with_libevent" != "internal"], [opal_event_external_want=yes])
 
     # If we want external support, try it
     AS_IF([test "$opal_event_external_want" = "yes"],
@@ -90,14 +92,14 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
                               [libevent.*])
 
            AC_MSG_CHECKING([for external libevent in])
-           AS_IF([test "$with_libevent" != "external" -a "$with_libevent" != "yes"],
+           AS_IF([test "$with_libevent" != "external" && test "$with_libevent" != "yes"],
                  [opal_event_dir=$with_libevent
                   AC_MSG_RESULT([$opal_event_dir])
                   OPAL_CHECK_WITHDIR([libevent], [$with_libdir],
                                      [include/event.h])
                  ],
                  [AC_MSG_RESULT([(default search paths)])])
-           AS_IF([test ! -z "$with_libevent_libdir" -a "$with_libevent_libdir" != "yes"],
+           AS_IF([test ! -z "$with_libevent_libdir" && test "$with_libevent_libdir" != "yes"],
                  [opal_event_libdir="$with_libevent_libdir"])
 
            opal_event_external_CPPFLAGS_save=$CPPFLAGS

--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -3,6 +3,8 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -90,7 +92,7 @@ AC_DEFUN([MCA_opal_event_libevent2022_CONFIG],[
     libevent_basedir="opal/mca/event/libevent2022"
 
     # If we're not building externally, configure this component
-    AS_IF([test "$with_libevent" = "internal" -o "$with_libevent" = "" -o "$with_libevent" = "yes"],
+    AS_IF([test "$with_libevent" = "internal" || test -z "$with_libevent" || test "$with_libevent" = "yes"],
           [MCA_opal_event_libevent2022_DO_THE_CONFIG],
           [AC_MSG_WARN([using an external libevent; disqualifiying this component])
            $2])
@@ -186,7 +188,7 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
     # libevent/include/event2/event-config.h!).  Otherwise, set it to
     # 0.
     libevent_file=$libevent_basedir/libevent/config.h
-    AS_IF([test "$libevent_happy" = "yes" -a -r $libevent_file],
+    AS_IF([test "$libevent_happy" = "yes" && test -r $libevent_file],
           [OPAL_HAVE_WORKING_EVENTOPS=`grep HAVE_WORKING_EVENTOPS $libevent_file | awk '{print [$]3 }'`
            $1],
           [$2

--- a/opal/mca/hwloc/hwloc1111/configure.m4
+++ b/opal/mca/hwloc/hwloc1111/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -74,7 +76,7 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1111_CONFIG],[
     opal_hwloc_hwloc1111_basedir=opal/mca/hwloc/hwloc1111
     opal_hwloc_hwloc1111_support=no
 
-    if test "$with_hwloc" = "internal" -o "$with_hwloc" = "" -o "$with_hwloc" = "yes"; then
+    if test "$with_hwloc" = "internal" || test -z "$with_hwloc" || test "$with_hwloc" = "yes"; then
         opal_hwloc_hwloc1111_save_CPPFLAGS=$CPPFLAGS
         opal_hwloc_hwloc1111_save_LDFLAGS=$LDFLAGS
         opal_hwloc_hwloc1111_save_LIBS=$LIBS

--- a/opal/mca/if/bsdx_ipv4/configure.m4
+++ b/opal/mca/if/bsdx_ipv4/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +32,10 @@ AC_DEFUN([MCA_opal_if_bsdx_ipv4_CONFIG], [
     AS_IF([test "$opal_found_sockaddr" = "yes"],
           [AC_MSG_RESULT([yes (cached)])
            AC_MSG_CHECKING([NetBSD, FreeBSD, OpenBSD, or DragonFly])
-           AS_IF([test "$opal_found_netbsd" = "yes" -o "$opal_found_freebsd" = "yes" -o "$opal_found_openbsd" = "yes" -o "$opal_found_dragonfly" = "yes"],
+           AS_IF([test "$opal_found_netbsd" = "yes" || \
+                  test "$opal_found_freebsd" = "yes" || \
+                  test "$opal_found_openbsd" = "yes" || \
+                  test "$opal_found_dragonfly" = "yes"],
                  [AC_MSG_RESULT([yes])
                   $1],
                  [AC_MSG_RESULT([no])

--- a/opal/mca/if/bsdx_ipv6/configure.m4
+++ b/opal/mca/if/bsdx_ipv6/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +32,12 @@ AC_DEFUN([MCA_opal_if_bsdx_ipv6_CONFIG], [
     AS_IF([test "$opal_found_sockaddr" = "yes"],
           [AC_MSG_RESULT([yes (cached)])
            AC_MSG_CHECKING([some flavor of BSD])
-           AS_IF([test "$opal_found_netbsd" = "yes" -o "$opal_found_freebsd" = "yes" -o "$opal_found_openbsd" = "yes" -o "$opal_found_386bsd" = "yes" -o "$opal_found_bsdi" = "yes" -o "$opal_found_apple" = "yes"],
+           AS_IF([test "$opal_found_netbsd" = "yes" || \
+                  test "$opal_found_freebsd" = "yes" || \
+                  test "$opal_found_openbsd" = "yes" || \
+                  test "$opal_found_386bsd" = "yes" || \
+                  test "$opal_found_bsdi" = "yes" ||
+                  test "$opal_found_apple" = "yes"],
                  [AC_MSG_RESULT([yes])
                   $1],
                  [AC_MSG_RESULT([no])

--- a/opal/mca/if/linux_ipv6/configure.m4
+++ b/opal/mca/if/linux_ipv6/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,7 +27,7 @@ AC_DEFUN([MCA_opal_if_linux_ipv6_CONFIG], [
     AC_MSG_CHECKING([if we are on Linux with TCP])
     # If we have struct sockaddr and we're on Linux, then we're
     # happy.
-    AS_IF([test "$opal_found_sockaddr" = "yes" -a "$opal_found_linux" = "yes"],
+    AS_IF([test "$opal_found_sockaddr" = "yes" && test "$opal_found_linux" = "yes"],
           [AC_MSG_RESULT([yes])
            $1],
           [AC_MSG_RESULT([no])

--- a/opal/mca/if/posix_ipv4/configure.m4
+++ b/opal/mca/if/posix_ipv4/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +35,7 @@ AC_DEFUN([MCA_opal_if_posix_ipv4_CONFIG], [
     AS_IF([test "$opal_found_sockaddr" = "yes"],
           [AC_MSG_RESULT([yes (cached)])
            AC_MSG_CHECKING([not NetBSD, FreeBSD, OpenBSD, or DragonFly])
-           AS_IF([test "$opal_found_netbsd" = "no" -a "$opal_found_freebsd" = "no" -a "$opal_found_openbsd" = "no" -a "$opal_found_dragonfly" = "no"],
+           AS_IF([test "$opal_found_netbsd" = "no" && test "$opal_found_freebsd" = "no" && test "$opal_found_openbsd" = "no" && test "$opal_found_dragonfly" = "no"],
                  [AC_MSG_RESULT([yes])
                   opal_if_posix_ipv4_happy=yes],
                  [AC_MSG_RESULT([no])]

--- a/opal/mca/memchecker/configure.m4
+++ b/opal/mca/memchecker/configure.m4
@@ -3,6 +3,8 @@ dnl
 dnl Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -43,10 +45,10 @@ AC_DEFUN([MCA_opal_memchecker_CONFIG],[
     # first, compile all the components
     MCA_CONFIGURE_FRAMEWORK($1, $2, 1)
 
-    AS_IF([test "$MCA_opal_memchecker_STATIC_COMPONENTS" != "" -o "$MCA_opal_memchecker_DSO_COMPONENTS" != ""],
+    AS_IF([test "$MCA_opal_memchecker_STATIC_COMPONENTS" != "" || test "$MCA_opal_memchecker_DSO_COMPONENTS" != ""],
           [memchecker_base_found=1],
           [memchecker_base_found=0])
-    AS_IF([test $WANT_MEMCHECKER -eq 1 -a $memchecker_base_found -eq 0],
+    AS_IF([test $WANT_MEMCHECKER -eq 1 && test $memchecker_base_found -eq 0],
           [AC_MSG_WARN([Memchecker support requested, but no memchecker])
            AC_MSG_WARN([components configured successfully.  Did you])
            AC_MSG_WARN([forget --with-valgrind?])

--- a/opal/mca/memchecker/valgrind/configure.m4
+++ b/opal/mca/memchecker/valgrind/configure.m4
@@ -3,6 +3,8 @@
 # Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,7 +37,7 @@ AC_DEFUN([MCA_opal_memchecker_valgrind_CONFIG],[
     opal_memchecker_valgrind_save_CPPFLAGS="$CPPFLAGS"
     opal_memchecker_valgrind_happy=no
     AS_IF([test "$with_valgrind" != "no"],
-          [AS_IF([test ! -z "$with_valgrind" -a "$with_valgrind" != "yes"],
+          [AS_IF([test -n "$with_valgrind" && test "$with_valgrind" != "yes"],
                  [opal_memchecker_valgrind_CPPFLAGS="-I$with_valgrind/include"
                   # We need this -I to stay in CPPFLAGS when we're done
                   CPPFLAGS="$CPPFLAGS -I$with_valgrind/include"
@@ -60,7 +62,7 @@ AC_DEFUN([MCA_opal_memchecker_valgrind_CONFIG],[
     CPPFLAGS="$opal_memchecker_valgrind_save_CPPFLAGS"
 
     # If we specifically requested this component and can't build it, error
-    AS_IF([test "$with_valgrind" != "no" -a "$with_valgrind" != "" -a "$opal_memchecker_valgrind_happy" != "yes"],
+    AS_IF([test "$with_valgrind" != "no" && test -n "$with_valgrind" && test "$opal_memchecker_valgrind_happy" != "yes"],
           [AC_MSG_ERROR([Cannot continue])])
 
     AS_IF([test "$opal_memchecker_valgrind_happy" = "yes"],

--- a/opal/mca/memory/linux/configure.m4
+++ b/opal/mca/memory/linux/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,7 +57,7 @@ AC_DEFUN([MCA_opal_memory_linux_CONFIG],[
            memory_linux_ummu_happy=yes
            memory_linux_requested=1],
           [memory_linux_requested=0
-           AS_IF([test "$with_memory_manager" = "" -o "$with_memory_manager" = "yes"],
+           AS_IF([test -z "$with_memory_manager" || test "$with_memory_manager" = "yes"],
                  [memory_linux_ptmalloc2_happy=yes
                   memory_linux_ummu_happy=yes],
                  [memory_linux_ptmalloc2_happy=no
@@ -82,7 +84,7 @@ AC_DEFUN([MCA_opal_memory_linux_CONFIG],[
                       [# check for v9.0 <= 20051201
                        icc_major_ver="`$CC --version | head -n 1 | awk '{ print [$]3 }'`"
                        icc_minor_ver="`$CC --version | head -n 1 | awk '{ print [$]4 }'`"
-                       AS_IF([test "$icc_major_ver" = "9.0" -a "`expr $icc_minor_ver \<= 20051201`" = "1"],
+                       AS_IF([test "$icc_major_ver" = "9.0" && test "`expr $icc_minor_ver \<= 20051201`" = "1"],
                              [memory_linux_ptmalloc2_happy=no
                               AC_MSG_WARN([*** Detected Intel C compiler v9.0 <= 20051201 on ia64])
                               AC_MSG_WARN([*** This compiler/platform combination has known problems with ptmalloc2])
@@ -139,7 +141,7 @@ AC_DEFUN([MCA_opal_memory_linux_CONFIG],[
                   AC_CHECK_FUNCS([dlsym])
                   LIBS="$memory_linux_LIBS_SAVE"])
 
-           AS_IF([test "$memory_linux_mmap" = "0" -a "$memory_linux_munmap" = "0"],
+           AS_IF([test "$memory_linux_mmap" = "0" && test "$memory_linux_munmap" = "0"],
                  [memory_linux_ptmalloc2_happy=no])])
 
     # If all is good, save the extra libs for the wrapper
@@ -180,14 +182,14 @@ AC_DEFUN([MCA_opal_memory_linux_CONFIG],[
     # post processing
     ######################################################################
 
-    AS_IF([test "$memory_malloc_hooks_requested" = 1 -a \
-                "$memory_linux_ptmalloc2_happy" = no -a \
-                "$memory_linux_ummu_happy" = no],
+    AS_IF([test "$memory_malloc_hooks_requested" = 1 && \
+           test "$memory_linux_ptmalloc2_happy" = no && \
+           test "$memory_linux_ummu_happy" = no],
           [AC_MSG_ERROR([linux memory management requested but neither ptmalloc2 nor ummunotify are available.  Aborting.])])
     AC_SUBST([memory_linux_LIBS])
 
-    AS_IF([test "$memory_linux_ptmalloc2_happy" = yes -o \
-                "$memory_linux_ummu_happy" = yes],
+    AS_IF([test "$memory_linux_ptmalloc2_happy" = yes || \
+           test "$memory_linux_ummu_happy" = yes],
           [memory_base_found=1
            $1],
           [memory_base_found=0

--- a/opal/mca/memory/malloc_solaris/configure.m4
+++ b/opal/mca/memory/malloc_solaris/configure.m4
@@ -12,6 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2007-2011 Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -93,8 +95,8 @@ AC_DEFUN([MCA_opal_memory_malloc_solaris_CONFIG],[
                                   [Whether to use the legacy Solaris munmap prototype or not])
                ])
 
-        AS_IF([test "$memory_malloc_solaris_happy" = "no" -a \
-                "$memory_malloc_solaris_should_use" = "1"],
+        AS_IF([test "$memory_malloc_solaris_happy" = "no" && \
+               test "$memory_malloc_solaris_should_use" = "1"],
               [AC_MSG_ERROR([malloc_solaris memory management requested but not available.  Aborting.])])
 
         AC_SUBST(memory_malloc_solaris_LIBS)

--- a/opal/mca/sec/keystone/configure.m4
+++ b/opal/mca/sec/keystone/configure.m4
@@ -1,6 +1,8 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -22,7 +24,7 @@ AC_DEFUN([MCA_opal_sec_keystone_CONFIG], [
     AC_MSG_CHECKING([want keystone security])
     AS_IF([test "$with_keystone" != "no"],
           [AC_MSG_RESULT([yes])
-           AS_IF([test ! -z "$with_keystone" -a "$with_keystone" != "yes"],
+           AS_IF([test ! -z "$with_keystone" && test "$with_keystone" != "yes"],
                  [opal_check_keystone_dir="$with_keystone"])
            OPAL_CHECK_PACKAGE([sec_keystone],
                               [curl/curl.h],

--- a/opal/mca/sec/munge/configure.m4
+++ b/opal/mca/sec/munge/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2015      Intel, Inc. All rights reserved
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,7 +28,7 @@ AC_DEFUN([MCA_opal_sec_munge_CONFIG],[
     sec_munge_support=0
     if test "$with_munge" != "no"; then
         AC_MSG_CHECKING([for munge in])
-        if test ! -z "$with_munge" -a "$with_munge" != "yes"; then
+        if test -n "$with_munge" && test "$with_munge" != "yes"; then
             if test -d $with_munge/include/munge; then
                 sec_munge_dir=$with_munge/include/munge
             else
@@ -45,7 +47,7 @@ AC_DEFUN([MCA_opal_sec_munge_CONFIG],[
             AC_MSG_RESULT([(default search paths)])
             sec_munge_dir=
         fi
-        AS_IF([test ! -z "$with_munge_libdir" && test "$with_munge_libdir" != "yes"],
+        AS_IF([test -n "$with_munge_libdir" && test "$with_munge_libdir" != "yes"],
               [sec_munge_libdir="$with_munge_libdir"])
 
         save_cpp=$CPPFLAGS
@@ -65,7 +67,7 @@ AC_DEFUN([MCA_opal_sec_munge_CONFIG],[
         LDFLAGS=$save_ld
     fi
 
-    if test ! -z "$with_munge" && test "$with_munge" != "no" && test "$sec_munge_support" != "1"; then
+    if test -n "$with_munge" && test "$with_munge" != "no" && test "$sec_munge_support" != "1"; then
         AC_MSG_WARN([MUNGE SUPPORT REQUESTED AND NOT FOUND.])
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi

--- a/opal/mca/shmem/mmap/configure.m4
+++ b/opal/mca/shmem/mmap/configure.m4
@@ -13,6 +13,8 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +40,7 @@ AC_DEFUN([MCA_opal_shmem_mmap_CONFIG],[
            AC_SEARCH_LIBS([mmap], [c],
                   [shmem_mmap_sm_build_mmap=1],
                   [shmem_mmap_sm_build_mmap=0])])
-    AS_IF([test "$enable_mmap_shmem" = "yes" -a "$shmem_mmap_sm_build_mmap" = "0"],
+    AS_IF([test "$enable_mmap_shmem" = "yes" && test "$shmem_mmap_sm_build_mmap" = "0"],
           [AC_MSG_WARN([mmap shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 

--- a/opal/mca/shmem/posix/configure.m4
+++ b/opal/mca/shmem/posix/configure.m4
@@ -13,6 +13,8 @@
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +40,7 @@ AC_DEFUN([MCA_opal_shmem_posix_CONFIG],[
            OPAL_SEARCH_LIBS_COMPONENT([shmem_posix], [shm_open], [rt],
                   [shmem_posix_sm_build_posix=1],
                   [shmem_posix_sm_build_posix=0])])
-    AS_IF([test "$enable_posix_shmem" = "yes" -a "$shmem_posix_sm_build_posix" = "0"],
+    AS_IF([test "$enable_posix_shmem" = "yes" && test "$shmem_posix_sm_build_posix" = "0"],
           [AC_MSG_WARN([POSIX shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 

--- a/opal/mca/shmem/sysv/configure.m4
+++ b/opal/mca/shmem/sysv/configure.m4
@@ -13,6 +13,8 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +40,7 @@ AC_DEFUN([MCA_opal_shmem_sysv_CONFIG],[
           AC_CHECK_FUNC(shmget,
                   [shmem_sysv_sm_build_sysv=1],
                   [shmem_sysv_sm_build_sysv=0])])
-    AS_IF([test "$enable_sysv_shmem" = "yes" -a "$shmem_sysv_sm_build_sysv" = "0"],
+    AS_IF([test "$enable_sysv_shmem" = "yes" && test "$shmem_sysv_sm_build_sysv" = "0"],
           [AC_MSG_WARN([SYSV shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 

--- a/opal/mca/timer/aix/configure.m4
+++ b/opal/mca/timer/aix/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -66,8 +68,8 @@ AC_DEFUN([MCA_opal_timer_aix_CONFIG],[
            AC_CHECK_HEADERS([pmapi.h])])
    LIBS="$timer_aix_LIBS_SAVE"
 
-    AS_IF([test "$timer_aix_happy" = "no" -a \
-                "$timer_aix_should_use" = "1"],
+    AS_IF([test "$timer_aix_happy" = "no" && \
+           test "$timer_aix_should_use" = "1"],
           [AC_MSG_ERROR([AIX timer requested but not available.  Aborting.])])
 
     AC_SUBST(timer_aix_LIBS)

--- a/opal/mca/timer/altix/configure.m4
+++ b/opal/mca/timer/altix/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -71,8 +73,8 @@ AC_DEFUN([MCA_opal_timer_altix_CONFIG],[
 	         [timer_altix_happy="yes"],
                  [timer_altix_happy="no"])])
 
-    AS_IF([test "$timer_altix_happy" = "no" -a \
-                "$timer_altix_should_use" = "1"],
+    AS_IF([test "$timer_altix_happy" = "no" && \
+           test "$timer_altix_should_use" = "1"],
           [AC_MSG_ERROR([Altix timer requested but not available.  Aborting.])])
 
     AS_IF([test "$timer_altix_happy" = "yes"],

--- a/opal/mca/timer/darwin/configure.m4
+++ b/opal/mca/timer/darwin/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,8 +51,8 @@ AC_DEFUN([MCA_opal_timer_darwin_CONFIG],[
                          [timer_darwin_happy="yes"],
                          [timer_darwin_happy="no"])])
 
-   AS_IF([test "$timer_darwin_happy" = "no" -a \
-               "$timer_darwin_should_use" = "1"],
+   AS_IF([test "$timer_darwin_happy" = "no" && \
+          test "$timer_darwin_should_use" = "1"],
          [AC_MSG_ERROR([Darwin timer requested but not available.  Aborting.])])
 
     AS_IF([test "$timer_darwin_happy" = "yes"],

--- a/opal/mca/timer/linux/configure.m4
+++ b/opal/mca/timer/linux/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,8 +57,8 @@ AC_DEFUN([MCA_opal_timer_linux_CONFIG],[
         ;;
    esac
 
-   AS_IF([test "$timer_linux_happy" = "no" -a \
-               "$timer_linux_should_use" = "1"],
+   AS_IF([test "$timer_linux_happy" = "no" && \
+          test "$timer_linux_should_use" = "1"],
          [AC_MSG_ERROR([Linux timer requested but not available.  Aborting.])])
 
     AS_IF([test "$timer_linux_happy" = "yes"],

--- a/opal/mca/timer/solaris/configure.m4
+++ b/opal/mca/timer/solaris/configure.m4
@@ -11,6 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -48,8 +50,8 @@ AC_DEFUN([MCA_opal_timer_solaris_CONFIG],[
                          [timer_solaris_happy="yes"],
                          [timer_solaris_happy="no"])])
 
-   AS_IF([test "$timer_solaris_happy" = "no" -a \
-               "$timer_solaris_should_use" = "1"],
+   AS_IF([test "$timer_solaris_happy" = "no" && \
+          test "$timer_solaris_should_use" = "1"],
          [AC_MSG_ERROR([Solaris timer requested but not available.  Aborting.])])
 
     AS_IF([test "$timer_solaris_happy" = "yes"],

--- a/oshmem/mca/sshmem/mmap/configure.m4
+++ b/oshmem/mca/sshmem/mmap/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -28,7 +30,7 @@ AC_DEFUN([MCA_oshmem_sshmem_mmap_CONFIG],[
            AC_SEARCH_LIBS([mmap], [c],
                   [oshmem_mmap_sm_build_mmap=1],
                   [oshmem_mmap_sm_build_mmap=0])])
-    AS_IF([test "$enable_mmap_sshmem" = "yes" -a "$oshmem_mmap_sm_build_mmap" = "0"],
+    AS_IF([test "$enable_mmap_sshmem" = "yes" && test "$oshmem_mmap_sm_build_mmap" = "0"],
           [AC_MSG_WARN([MMAP shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 

--- a/oshmem/mca/sshmem/sysv/configure.m4
+++ b/oshmem/mca/sshmem/sysv/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -28,7 +30,7 @@ AC_DEFUN([MCA_oshmem_sshmem_sysv_CONFIG],[
           AC_CHECK_FUNC(shmget,
                   [oshmem_sysv_sm_build_sysv=1],
                   [oshmem_sysv_sm_build_sysv=0])])
-    AS_IF([test "$enable_sysv_sshmem" = "yes" -a "$oshmem_sysv_sm_build_sysv" = "0"],
+    AS_IF([test "$enable_sysv_sshmem" = "yes" && test "$oshmem_sysv_sm_build_sysv" = "0"],
           [AC_MSG_WARN([SYSV shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 

--- a/oshmem/mca/sshmem/verbs/configure.m4
+++ b/oshmem/mca/sshmem/verbs/configure.m4
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -87,7 +89,7 @@ AC_DEFUN([MCA_oshmem_sshmem_verbs_CONFIG],[
     AC_DEFINE_UNQUOTED(MPAGE_HAVE_SMR_EXP_ACCESS, $exp_access_happy, [exp_access field is part of ibv_exp_reg_shared_mr_in])
     AC_DEFINE_UNQUOTED(MPAGE_HAVE_IBV_EXP_REG_MR_CREATE_FLAGS, $exp_reg_mr_happy, [create_flags field is part of ibv_exp_reg_mr_in])
 
-    AS_IF([test "$enable_verbs_sshmem" = "yes" -a "$oshmem_verbs_sm_build_verbs" = "0"],
+    AS_IF([test "$enable_verbs_sshmem" = "yes" && test "$oshmem_verbs_sm_build_verbs" = "0"],
           [AC_MSG_WARN([VERBS shared memory support requested but not found])
            AC_MSG_ERROR([Cannot continue])])
 


### PR DESCRIPTION
replace test ... -o ... with test ... || test ...
and test ... -a ... with test ... && test ...

(back-ported from commit open-mpi/ompi@fec973efda4682645be812cf549dc927b87286aa)
