### PR TITLE
ompi/group: do not decrement parent group proc pointers in destruct

### DIFF
--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -295,7 +295,6 @@ static void ompi_group_destruct(ompi_group_t *group)
     }
 
     if (NULL != group->grp_parent_group_ptr){
-        ompi_group_decrement_proc_count(group->grp_parent_group_ptr);
         OBJ_RELEASE(group->grp_parent_group_ptr);
     }
 


### PR DESCRIPTION
:bot:assign: @jsquyres 
:bot:label:bug
:bot:milestone:v2.0.0

This line was missed with the group updates. Fixes an issue when using sparse groups.

(cherry picked from open-mpi/ompi@d26cc3fece511ce03aa1b709fffbcc4357c19694)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
