### PR TITLE
orte_rmaps_base_map_job: set OPAL_BIND_ALLOW_OVERLOAD when needed

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -293,6 +295,9 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     /* for performance, bind to socket */
                     OPAL_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_SOCKET);
                 }
+            }
+            if (OPAL_BIND_OVERLOAD_ALLOWED(opal_hwloc_binding_policy)) {
+                jdata->map->binding |= OPAL_BIND_ALLOW_OVERLOAD;
             }
         }
     }


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@4c43fb2a5016673d74152027324f162987012500)
