### PR TITLE
v2.x: Sync usnic BTL to master

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +34,14 @@
 /* Inclue the progress thread stuff */
 #  include "opal/runtime/opal_progress_threads.h"
 
-/* Hhwloc is now guaranteed */
+/* Hwloc support is now guaranteed, and the rest of the code base does
+   not define OPAL_HAVE_HWLOC any more (because it would always be 1).
+
+   Note: The usnic BTL still uses OPAL_HAVE_HWLOC because Cisco
+   continues to sync it against a v1.10-based tree (where
+   OPAL_HAVE_HWLOC may still be 0 or 1).  Once Cisco stops syncing the
+   usnic BTL against v1.10.x, all the OPAL_HAVE_HWLOC code in the
+   usnic BTL can go away. */
 #  define OPAL_HAVE_HWLOC 1
 
 #  define USNIC_OUT opal_btl_base_framework.framework_output

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -48,9 +48,11 @@
 /* JMS Really want to be able to get the job size somehow...  But for
    now, so that we can compile, just set it to a constant :-( */
 #  define USNIC_MCW_SIZE 2
-
-#  define proc_bound() (NULL != opal_process_info.cpuset ? 1 : 0)
-
+#if OPAL_HAVE_HWLOC
+#    define proc_bound() (NULL != opal_process_info.cpuset ? 1 : 0)
+#else
+#    define proc_bound() 0
+#endif
 #  define USNIC_BTL_DEFAULT_VERSION(name) MCA_BTL_DEFAULT_VERSION(name)
 
 #  define USNIC_SEND_LOCAL        des_segments

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
@@ -87,7 +87,7 @@
 #define OPAL_BTL_USNIC_NUM_COMPLETIONS 500
 
 /* RNG buffer definition */
-opal_rng_buff_t opal_btl_usnic_rand_buff;
+opal_rng_buff_t opal_btl_usnic_rand_buff = {0};
 
 /* simulated clock */
 uint64_t opal_btl_usnic_ticks = 0;

--- a/opal/mca/btl/usnic/btl_usnic_hwloc.h
+++ b/opal/mca/btl/usnic/btl_usnic_hwloc.h
@@ -15,6 +15,8 @@
 #include "btl_usnic_module.h"
 
 
+#if OPAL_HAVE_HWLOC
 int opal_btl_usnic_hwloc_distance(opal_btl_usnic_module_t *module);
+#endif
 
 #endif /* BTL_USNIC_HWLOC_H */

--- a/opal/mca/btl/usnic/btl_usnic_mca.c
+++ b/opal/mca/btl/usnic/btl_usnic_mca.c
@@ -206,7 +206,7 @@ int opal_btl_usnic_component_register(void)
                      "grdma", &mca_btl_usnic_component.usnic_mpool_name, 0,
                      OPAL_INFO_LVL_5));
 
-    want_numa_device_assignment = 1;
+    want_numa_device_assignment = OPAL_HAVE_HWLOC ? 1 : -1;
     CHECK(reg_int("want_numa_device_assignment",
                   "If 1, use only Cisco VIC ports thare are a minimum NUMA distance from the MPI process for short messages.  If 0, use all available Cisco VIC ports for short messages.  This parameter is meaningless (and ignored) unless MPI proceses are bound to processor cores.  Defaults to 1 if NUMA support is included in Open MPI; -1 otherwise.",
                   want_numa_device_assignment,

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -13,9 +13,9 @@
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2014      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1940,6 +1940,7 @@ static void init_connectivity_checker(opal_btl_usnic_module_t *module)
 
 static void init_hwloc(opal_btl_usnic_module_t *module)
 {
+#if OPAL_HAVE_HWLOC
     /* If this process is bound to a single NUMA locality, calculate
        its NUMA distance from this usNIC device */
     if (mca_btl_usnic_component.want_numa_device_assignment) {
@@ -1948,6 +1949,10 @@ static void init_hwloc(opal_btl_usnic_module_t *module)
         opal_output_verbose(5, USNIC_OUT,
                             "btl:usnic: not sorting devices by NUMA distance (MCA btl_usnic_want_numa_device_assignment)");
     }
+#else
+    opal_output_verbose(5, USNIC_OUT,
+                        "btl:usnic: not sorting devices by NUMA distance (topology support not included)");
+#endif
 }
 
 static void init_procs(opal_btl_usnic_module_t *module)

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -2311,6 +2311,12 @@ int opal_btl_usnic_module_init(opal_btl_usnic_module_t *module)
 }
 
 
+static int usnic_ft_event(int state)
+{
+    return OPAL_SUCCESS;
+}
+
+
 opal_btl_usnic_module_t opal_btl_usnic_module_template = {
     .super = {
         .btl_component = &mca_btl_usnic_component.super,
@@ -2353,6 +2359,6 @@ opal_btl_usnic_module_t opal_btl_usnic_module_template = {
 
         .btl_mpool = NULL,
         .btl_register_error = usnic_register_pml_err_cb,
-        .btl_ft_event = NULL
+        .btl_ft_event = usnic_ft_event
     }
 };

--- a/opal/mca/btl/usnic/configure.m4
+++ b/opal/mca/btl/usnic/configure.m4
@@ -94,10 +94,13 @@ AC_DEFUN([_OPAL_BTL_USNIC_DO_CONFIG],[
           ])
 
     # The usnic BTL requires libfabric support.
-    AS_IF([test "$opal_btl_usnic_happy" = "yes" && \
-           test "$opal_common_libfabric_happy" = "yes"],
-          [opal_btl_usnic_happy=yes],
-          [opal_btl_usnic_happy=no])
+    AS_IF([test "$opal_btl_usnic_happy" = "yes"],
+          [AC_MSG_CHECKING([whether libfabric support is available])
+           AS_IF([test "$opal_common_libfabric_happy" = "yes"],
+                 [opal_btl_usnic_happy=yes],
+                 [opal_btl_usnic_happy=no])
+           AC_MSG_RESULT([$opal_btl_usnic_happy])
+          ])
 
     # The usnic BTL requires at least libfabric v1.1 (there was a
     # critical bug in libfabric v1.0).


### PR DESCRIPTION
Sync all the latest changes down from master to the v2.x branch for the usnic btl.

@hppritcha: although this is technically not a bug, I'm syncing the latest usnic BTL changes from master down to v2.x for sync-sanity reasons.  They're all pretty trivial changes.  One actually is a bug fix (remove a common symbol), and another is a update to configure output for clarity (describe why/why not the usnic BTL was built).  Can we allow this PR?
