### PR TITLE
OSHMEM/SPML/UCX: fixes typo in add_procs

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -192,7 +192,7 @@ int mca_spml_ucx_add_procs(oshmem_proc_t** procs, size_t nprocs)
     }
 
     err = ucp_worker_get_address(mca_spml_ucx.ucp_worker, &wk_local_addr, &wk_addr_len);
-    if (err == UCS_OK) {
+    if (err != UCS_OK) {
         goto error;
     }
     dump_address(my_rank, (char *)wk_local_addr, wk_addr_len);


### PR DESCRIPTION
(cherry picked from commit b269dd59e35bcd97c84762ccba3a2f7ce92ac744)
@miked-mellanox @yosefe somehow this commit did not get to v2.x
