### PR TITLE
plm/base: swat a orphaned CRS macro

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -55,9 +55,6 @@
 #include "orte/mca/routed/routed.h"
 #include "orte/mca/grpcomm/base/base.h"
 #include "orte/mca/odls/odls.h"
-#if OPAL_ENABLE_FT_CR == 1
-#include "orte/mca/snapc/base/base.h"
-#endif
 #include "orte/mca/filem/filem.h"
 #include "orte/mca/filem/base/base.h"
 #include "orte/mca/grpcomm/base/base.h"


### PR DESCRIPTION
@jsquyres 

swat I CRS related macro I missed.  Showed up with --enable-picky on current v2.x HEAD

Signed-off-by: Howard Pritchard howardp@lanl.gov
