### PR TITLE
orte/mpirun: disable -debug option

### DIFF
--- a/orte/tools/orterun/help-orterun.txt
+++ b/orte/tools/orterun/help-orterun.txt
@@ -660,3 +660,10 @@ method and try launching your job again.
 
 Your job will now abort.
 #
+[no_debugger_launch_support]
+This version of Open MPI is known to have a problem using the "--debug"
+option to mpirun, and has therefore disabled it. This functionality will
+be restored in a future version of Open MPI.
+
+Please see https://github.com/open-mpi/ompi/issues/1225 for details.
+

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -1147,7 +1147,16 @@ static int parse_globals(int argc, char* argv[], opal_cmd_line_t *cmd_line)
     /* Do we want a user-level debugger? */
 
     if (orterun_globals.debugger) {
+#if 0
+        /* see https://github.com/open-mpi/ompi/issues/1225
+         * Once things are fixed, the orte_show_help/exit can be removed
+         * and this code re-enabled.
+         */
         run_debugger(orte_basename, cmd_line, argc, argv, orterun_globals.num_procs);
+#else
+        orte_show_help("help-orterun.txt", "no_debugger_launch_support", false);
+        exit(-1);
+#endif
     }
 
      /* if recovery was disabled on the cmd line, do so */


### PR DESCRIPTION
Since there's no support for launching a job under
a debugger using mpirun in the 2.0 release,
if the user tries to use -debug option with mpirun,
print out a help message and abort job launch.

I want this or an equivalent in by COB 1/21/16 for 2.0.0

@jsquyres 
@rhc54 

Signed-off-by: Howard Pritchard howardp@lanl.gov
