### PR TITLE
osc/rdma: fix hang when performing large unaligned gets

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_frag.h
+++ b/ompi/mca/osc/rdma/osc_rdma_frag.h
@@ -60,7 +60,7 @@ static inline int ompi_osc_rdma_frag_alloc (ompi_osc_rdma_module_t *module, size
     request_len = OPAL_ALIGN(request_len, 8, size_t);
 
     if (request_len > (mca_osc_rdma_component.buffer_size >> 1)) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
+        return OMPI_ERR_VALUE_OUT_OF_BOUNDS;
     }
 
     OPAL_THREAD_LOCK(&module->lock);

--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -50,7 +50,7 @@ static inline int ompi_osc_rdma_lock_release_shared (ompi_osc_rdma_module_t *mod
 {
     uint64_t lock = (uint64_t) (intptr_t) peer->state + offset;
     volatile bool atomic_complete = false;
-    void *temp;
+    void *temp = NULL;
     int ret;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "releasing shared lock %" PRIx64 " on peer %d. value 0x%lx", lock,
@@ -117,7 +117,7 @@ static inline int ompi_osc_rdma_lock_acquire_shared (ompi_osc_rdma_module_t *mod
 {
     uint64_t lock = (uint64_t) peer->state + offset;
     volatile bool atomic_complete;
-    ompi_osc_rdma_lock_t *temp;
+    ompi_osc_rdma_lock_t *temp = NULL;
     int ret;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "acquiring shared lock %" PRIx64 " on peer %d. value 0x%lx", lock,
@@ -292,7 +292,7 @@ static inline int ompi_osc_rdma_lock_release_exclusive (ompi_osc_rdma_module_t *
 {
     uint64_t lock = (uint64_t) (intptr_t) peer->state + offset;
     volatile bool atomic_complete = false;
-    void *temp;
+    void *temp = NULL;
     int ret;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "releasing exclusive lock %" PRIx64 " on peer %d", lock, peer->rank);

--- a/ompi/mca/osc/rdma/osc_rdma_request.c
+++ b/ompi/mca/osc/rdma/osc_rdma_request.c
@@ -59,7 +59,10 @@ static void request_construct(ompi_osc_rdma_request_t *request)
     request->super.req_free = request_free;
     request->super.req_cancel = request_cancel;
     request->super.req_complete_cb = request_complete;
-    request->parent_request = 0;
+    request->parent_request = NULL;
+    request->buffer = NULL;
+    request->internal = false;
+    request->outstanding_requests = 0;
     OBJ_CONSTRUCT(&request->convertor, opal_convertor_t);
 }
 

--- a/ompi/mca/osc/rdma/osc_rdma_request.h
+++ b/ompi/mca/osc/rdma/osc_rdma_request.h
@@ -60,6 +60,7 @@ struct ompi_osc_rdma_request_t {
 
     /** synchronization object */
     struct ompi_osc_rdma_sync_t *sync;
+    void *buffer;
 };
 typedef struct ompi_osc_rdma_request_t ompi_osc_rdma_request_t;
 OBJ_CLASS_DECLARATION(ompi_osc_rdma_request_t);
@@ -78,18 +79,19 @@ OBJ_CLASS_DECLARATION(ompi_osc_rdma_request_t);
         req = (ompi_osc_rdma_request_t*) item;                          \
         OMPI_REQUEST_INIT(&req->super, false);                          \
         req->super.req_mpi_object.win = module->win;                    \
-        req->super.req_complete = false;                                \
         req->super.req_state = OMPI_REQUEST_ACTIVE;                     \
         req->module = rmodule;                                          \
-        req->internal = false;                                          \
-        req->outstanding_requests = 0;                                  \
-        req->parent_request = NULL;                                     \
         req->peer = (rpeer);                                            \
     } while (0)
 
 #define OMPI_OSC_RDMA_REQUEST_RETURN(req)                               \
     do {                                                                \
         OMPI_REQUEST_FINI(&(req)->super);                               \
+        free ((req)->buffer);                                           \
+        (req)->buffer = NULL;                                           \
+        (req)->parent_request = NULL;                                   \
+        (req)->internal = false;                                        \
+        (req)->outstanding_requests = 0;                                \
         opal_free_list_return (&mca_osc_rdma_component.requests,        \
                                (opal_free_list_item_t *) (req));        \
     } while (0)


### PR DESCRIPTION
This commit adds code to handle large unaligned gets. There are two
possible code paths for these transactions:

 1) The remote region and local region have the same alignment. In
 this case the get will be broken down into at most three get
 transactions: 1 transaction to get the unaligned start of the region
 (buffered), 1 transaction to get the aligned portion of the region,
 and 1 transaction to get the end of the region.

 2) The remote and local regions do not have the same alignment. This
 should be an uncommon case and is not optimized. In this case a
 buffer is allocated and registered locally to hold the aligned data
 from the remote region. There may be cases where this fails (low
 memory, can't register memory). Those conditions are unlikely and
 will be handled later.

(cherry picked from open-mpi/ompi@45da3114737d876d5c8bab25f61ad45f242d6eba)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
