### PR TITLE
BufFix for coll/hcoll: coll_request must be set to ACTIVE when alloced

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -398,6 +398,7 @@ static void* get_coll_handle(void)
     OMPI_REQUEST_INIT(ompi_req,false);
     ompi_req->req_complete_cb = NULL;
     ompi_req->req_status.MPI_ERROR = MPI_SUCCESS;
+    ompi_req->req_state = OMPI_REQUEST_ACTIVE;
     ompi_req->req_free = request_free;
     return (void *)ompi_req;
 }


### PR DESCRIPTION
```
   If the state of the request is not set to OMPI_REQUEST_ACTIVE
   then MPI_Test would immediately signal such request completed
   while hcoll may still be working on it.
```

Signed-off-by: Joshua Ladd jladd.mlnx@gmail.com

:cherries: -picked from open-mpi/ompi@5e2a2c0
