### PR TITLE
pmix: do not include automatically generated include/private/autogen/…

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/include/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/include/Makefile.am
@@ -38,7 +38,9 @@ include_pmix_autogen_HEADERS = \
         include/pmix/autogen/pmix_config_top.h \
         include/pmix/autogen/pmix_config_bottom.h
 nodist_include_pmix_autogen_HEADERS = \
-        include/pmix/autogen/config.h \
+        include/pmix/autogen/config.h
+include_private_autogendir = $(includedir)/private/autogen
+nodist_include_private_autogen_HEADERS = \
         include/private/autogen/config.h
 
 endif ! PMIX_EMBEDDED_MODE

--- a/opal/mca/pmix/pmix112/pmix/include/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/include/Makefile.am
@@ -1,5 +1,7 @@
 #
 # Copyright 2015      Intel, Inc. All rights reserved
+# Copyright 2016      Research Organization for Information Science
+#                     and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -25,8 +27,7 @@ headers += \
         include/private/pmix_socket_errno.h \
         include/private/pmix_stdint.h \
         include/private/prefetch.h \
-        include/private/types.h \
-        include/private/autogen/config.h
+        include/private/types.h
 include_pmixdir = $(includedir)/pmix
 include_pmix_HEADERS = \
     include/pmix/rename.h \
@@ -37,6 +38,7 @@ include_pmix_autogen_HEADERS = \
         include/pmix/autogen/pmix_config_top.h \
         include/pmix/autogen/pmix_config_bottom.h
 nodist_include_pmix_autogen_HEADERS = \
-        include/pmix/autogen/config.h
+        include/pmix/autogen/config.h \
+        include/private/autogen/config.h
 
 endif ! PMIX_EMBEDDED_MODE


### PR DESCRIPTION
…config.h into dist tarball

Thanks Siegmar Gross for the initial report of this issue

(back-ported from commit open-mpi/ompi@73daf58ee5f230b58291beb0563a50dc21b0b69e)
