### PR TITLE
hwloc: correctly count cores with at least one allowed PU

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -492,8 +492,11 @@ static void df_search_cores(hwloc_obj_t obj, unsigned int *cnt)
             obj->userdata = (void*)data;
         }
         if (NULL == opal_hwloc_base_cpu_set) {
-            if (!hwloc_bitmap_isincluded(obj->cpuset, obj->allowed_cpuset)) {
-                /* do not count not allowed cores */
+            if (!hwloc_bitmap_intersects(obj->cpuset, obj->allowed_cpuset)) {
+                /*
+                 * do not count not allowed cores (e.g. cores with zero allowed PU)
+                 * if SMT is enabled, do count cores with at least one allowed hwthread
+                 */
                 return;
             }
             data->npus = 1;


### PR DESCRIPTION
when SMT is enabled, a core must be counted as long as one of its hwthread is allowed

Thanks Ben Menadue for the report.

This fixes a regression from open-mpi/ompi@6d149554a7cc4259fd6a4e885f4206f967a0ad4f

(cherry picked from commit d529951206ab2ea92954e841ba0f9274c724f3a2)
