### PR TITLE
v1.10: f08: do not BIND(C) to subroutines with LOGICAL parameters

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/attr-fn-f08-callback-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-f08/attr-fn-f08-callback-interfaces.h
@@ -4,7 +4,7 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 !                         reserved.
-! Copyright (c) 2015      Research Organization for Information Science
+! Copyright (c) 2015-2016 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! $COPYRIGHT$
 !
@@ -45,7 +45,7 @@ interface
 
   subroutine MPI_COMM_NULL_COPY_FN( comm, comm_keyval, extra_state, &
                                     attribute_val_in, attribute_val_out, &
-                                    flag, ierr ) BIND(C,name="ompi_comm_null_copy_fn_f")
+                                    flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Comm) :: comm
@@ -57,7 +57,7 @@ interface
 
   subroutine MPI_COMM_DUP_FN( comm, comm_keyval, extra_state, &
                               attribute_val_in, attribute_val_out, &
-                              flag, ierr ) BIND(C,name="ompi_comm_dup_fn_f")
+                              flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Comm) :: comm
@@ -68,7 +68,7 @@ interface
   end subroutine MPI_COMM_DUP_FN
 
   subroutine MPI_COMM_NULL_DELETE_FN(comm, comm_keyval, attribute_val_out, &
-                                     extra_state, ierr ) BIND(C,name="ompi_comm_null_delete_fn_f")
+                                     extra_state, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Comm) :: comm
@@ -81,7 +81,7 @@ interface
 
   subroutine MPI_TYPE_NULL_COPY_FN( type, type_keyval, extra_state, &
                                     attribute_val_in, attribute_val_out, &
-                                    flag, ierr ) BIND(C,name="ompi_type_null_copy_fn_f")
+                                    flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Datatype) :: type
@@ -93,7 +93,7 @@ interface
 
   subroutine MPI_TYPE_DUP_FN( type, type_keyval, extra_state, &
                               attribute_val_in, attribute_val_out, &
-                              flag, ierr ) BIND(C,name="ompi_type_dup_fn_f")
+                              flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Datatype) :: type
@@ -104,7 +104,7 @@ interface
   end subroutine MPI_TYPE_DUP_FN
 
   subroutine MPI_TYPE_NULL_DELETE_FN( type, type_keyval, attribute_val_out, &
-                                      extra_state, ierr ) BIND(C,name="ompi_type_null_delete_fn_f")
+                                      extra_state, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Datatype) :: type
@@ -117,7 +117,7 @@ interface
 
   subroutine MPI_WIN_NULL_COPY_FN( window, win_keyval, extra_state, &
                                    attribute_val_in, attribute_val_out, &
-                                   flag, ierr ) BIND(C,name="ompi_win_null_copy_fn_f")
+                                   flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Win) :: window
@@ -129,7 +129,7 @@ interface
 
   subroutine MPI_WIN_DUP_FN( window, win_keyval, extra_state, &
                              attribute_val_in, attribute_val_out, &
-                             flag, ierr ) BIND(C,name="ompi_win_dup_fn_f")
+                             flag, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Win) :: window
@@ -140,7 +140,7 @@ interface
   end subroutine MPI_WIN_DUP_FN
 
   subroutine MPI_WIN_NULL_DELETE_FN( window, win_keyval, attribute_val_out, &
-                                     extra_state, ierr ) BIND(C,name="ompi_win_null_delete_fn_f")
+                                     extra_state, ierr )
      use mpi_f08_types
      implicit none
      type(MPI_Win) :: window

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f08-interfaces-callbacks.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f08-interfaces-callbacks.F90
@@ -2,7 +2,7 @@
 ! Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
-! Copyright (c) 2015      Research Organization for Information Science
+! Copyright (c) 2015-2016 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! $COPYRIGHT$
 
@@ -66,7 +66,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Comm_copy_attr_function(oldcomm,comm_keyval,extra_state, &
-                                       attribute_val_in,attribute_val_out,flag,ierror) BIND(C)
+                                       attribute_val_in,attribute_val_out,flag,ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Comm) :: oldcomm
@@ -78,7 +78,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Comm_delete_attr_function(comm,comm_keyval, &
-                                         attribute_val, extra_state, ierror) BIND(C)
+                                         attribute_val, extra_state, ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Comm) :: comm
@@ -89,7 +89,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Win_copy_attr_function(oldwin,win_keyval,extra_state, &
-                                      attribute_val_in,attribute_val_out,flag,ierror) BIND(C)
+                                      attribute_val_in,attribute_val_out,flag,ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Win) :: oldwin
@@ -101,7 +101,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Win_delete_attr_function(win,win_keyval,attribute_val, &
-                                        extra_state,ierror) BIND(C)
+                                        extra_state,ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Win) :: win
@@ -112,7 +112,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Type_copy_attr_function(oldtype,type_keyval,extra_state, &
-                                       attribute_val_in,attribute_val_out,flag,ierror) BIND(C)
+                                       attribute_val_in,attribute_val_out,flag,ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Datatype) :: oldtype
@@ -124,7 +124,7 @@ END INTERFACE
 
 OMPI_ABSTRACT INTERFACE
 SUBROUTINE MPI_Type_delete_attr_function(datatype,type_keyval, &
-                                         attribute_val,extra_state,ierror) BIND(C)
+                                         attribute_val,extra_state,ierror)
    USE mpi_f08_types
    IMPLICIT NONE
    TYPE(MPI_Datatype) :: datatype


### PR DESCRIPTION
Thanks Paul Romano (@paulromano) for reporting this issue (see open-mpi/ompi#1323).

(cherry picked from commit open-mpi/ompi@704f14f91e881e40e898a737e6049928a59ab994)

@jsquyres already reviewed; @ggouaillardet please sanity check
