### PR TITLE
v1.10: verbs_usnic: do not build by default

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2007 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
@@ -957,6 +957,20 @@ NETWORKING SUPPORT / OPTIONS
   MPI will look in <openib directory>/lib and <openib
   directory>/lib64, which covers most cases.  This option is only
   needed for special configurations.
+
+--with-verbs-usnic
+  This option will activate support in Open MPI for disabling a
+  dire-sounding warning message from libibverbs that Cisco usNIC
+  devices are not supported (because Cisco usNIC devices are supported
+  through libfabric, not libibverbs).  This libibverbs warning can
+  also be suppressed by installing the "no op" libusnic_verbs plugin
+  for libibverbs (see https://github.com/cisco/libusnic_verbs, or
+  download binaries from cisco.com).  This option is disabled by
+  default because it causes libopen-pal.so to depend on libibverbs.so,
+  which is undesirable to many downstream packagers.
+
+--with-usnic
+  Abort configure if Cisco usNIC support cannot be built.
 
 RUN-TIME SYSTEM SUPPORT
 

--- a/ompi/mca/common/verbs/common_verbs_basics.c
+++ b/ompi/mca/common/verbs/common_verbs_basics.c
@@ -21,7 +21,9 @@
 #include <unistd.h>
 #endif
 
+#if OPAL_COMMON_VERSION_USNIC_HAPPY
 #include "ompi/mca/common/verbs_usnic/common_verbs_usnic.h"
+#endif
 
 /* This is crummy, but <infiniband/driver.h> doesn't work on all
    platforms with all compilers.  Specifically, trying to include it
@@ -93,12 +95,14 @@ int opal_common_verbs_fork_test(void)
     }
 #endif
 
+#if OPAL_COMMON_VERBS_USNIC_HAPPY
     /* Now register any necessary fake libibverbs drivers.  We
        piggyback loading these fake drivers on the fork test because
        they must be loaded before ibv_get_device_list() is invoked.
        Note that this routine is in a different common component (see
        comments over there for an explanation why).  */
     ompi_common_verbs_usnic_register_fake_drivers();
+#endif
 
     return ret;
 }

--- a/ompi/mca/common/verbs/common_verbs_basics.c
+++ b/ompi/mca/common/verbs/common_verbs_basics.c
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #endif
 
-#if OPAL_COMMON_VERSION_USNIC_HAPPY
+#if OPAL_COMMON_VERBS_USNIC_HAPPY
 #include "ompi/mca/common/verbs_usnic/common_verbs_usnic.h"
 #endif
 

--- a/ompi/mca/common/verbs_usnic/configure.m4
+++ b/ompi/mca/common/verbs_usnic/configure.m4
@@ -38,21 +38,26 @@ AC_DEFUN([MCA_ompi_common_verbs_usnic_COMPILE_MODE], [
 # ------------------------------------------------
 AC_DEFUN([MCA_ompi_common_verbs_usnic_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/common/verbs_usnic/Makefile])
-    common_verbs_usnic_happy="no"
+    common_verbs_usnic_happy=0
 
     AC_ARG_WITH(verbs-usnic,
                 AC_HELP_STRING([--with-verbs-usnic],
                                [Add support in Open MPI to defeat a seemingly dire warning message from libibverbs that Cisco usNIC devices are not supported.  This support is not compiled by default because you can also avoid this libibverbs bug by installing the libibverbs_usnic "no no" plugin, available from https://github.com/cisco/libusnic_verbs or in binary form from cisco.com]))
 
     AS_IF([test "$with_verbs_usnic" = "yes"],
-          [common_verbs_usnic_happy=yes])
+          [common_verbs_usnic_happy=1])
 
-    AS_IF([test "$common_verbs_usnic_happy" = "yes"],
+    AS_IF([test $common_verbs_usnic_happy -eq 1],
           [OMPI_CHECK_OPENFABRICS([common_verbs_usnic],
-                                  [common_verbs_usnic_happy="yes"])
+                                  [common_verbs_usnic_happy=1],
+                                  [common_verbs_usnic_happy=0])
           ])
 
-    AS_IF([test "$common_verbs_usnic_happy" = "yes"],
+    AC_DEFINE_UNQUOTED([OPAL_COMMON_VERBS_USNIC_HAPPY],
+                       [$common_verbs_usnic_happy],
+                       [Whether the common/usnic_verbs component is being built or not])
+
+    AS_IF([test $common_verbs_usnic_happy -eq 1],
           [$1],
           [$2])
 

--- a/ompi/mca/common/verbs_usnic/configure.m4
+++ b/ompi/mca/common/verbs_usnic/configure.m4
@@ -40,8 +40,17 @@ AC_DEFUN([MCA_ompi_common_verbs_usnic_CONFIG],[
     AC_CONFIG_FILES([ompi/mca/common/verbs_usnic/Makefile])
     common_verbs_usnic_happy="no"
 
-    OMPI_CHECK_OPENFABRICS([common_verbs_usnic],
-                           [common_verbs_usnic_happy="yes"])
+    AC_ARG_WITH(verbs-usnic,
+                AC_HELP_STRING([--with-verbs-usnic],
+                               [Add support in Open MPI to defeat a seemingly dire warning message from libibverbs that Cisco usNIC devices are not supported.  This support is not compiled by default because you can also avoid this libibverbs bug by installing the libibverbs_usnic "no no" plugin, available from https://github.com/cisco/libusnic_verbs or in binary form from cisco.com]))
+
+    AS_IF([test "$with_verbs_usnic" = "yes"],
+          [common_verbs_usnic_happy=yes])
+
+    AS_IF([test "$common_verbs_usnic_happy" = "yes"],
+          [OMPI_CHECK_OPENFABRICS([common_verbs_usnic],
+                                  [common_verbs_usnic_happy="yes"])
+          ])
 
     AS_IF([test "$common_verbs_usnic_happy" = "yes"],
           [$1],


### PR DESCRIPTION
This component is a workaround to a bug in libibverbs that prints a
dire warning that usNIC devices are not supported (of course not --
usNIC devices provide functionality through libfabric, not
libibverbs).  This component was written before a better workaround
was created: a "no op" libibverbs plugin for usNIC devices
(https://github.com/cisco/libusnic_verbs, and is also available in
binary form on cisco.com).

Hence, this component no longer builds by default.  It's still
available if a user specifically asks for it (e.g., if they do not
want to install the "no op" libibverbs plugin), but it's not the
default.  This component also has the side-effect of making
libopen-pal.so depend on libibverbs.so, which can be annoying for
packagers (which is another reason it isn't built by default any
more).

(cherry picked from commit open-mpi/ompi@0715802f52c24c236700ac085090d5441524644c)

@hppritcha Please review
