### PR TITLE
v1.10: usnic: fix calculation for number of blocks

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -412,7 +412,7 @@ static int add_procs_create_endpoints(struct opal_btl_usnic_module_t* module,
     size_t block_len = eq_size;
     size_t num_av_inserts = nprocs * USNIC_NUM_CHANNELS;
     size_t num_blocks = num_av_inserts / block_len;
-    if (eq_size % num_av_inserts != 0) {
+    if (num_av_inserts % block_len != 0) {
         ++num_blocks;
     }
 


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@89eea51075659b4cc78793305a52b08d7d2e1e0d)

Reviewed by @bturrubiates
