### PR TITLE
v1.10: opal.pc.in: fix typo; use the write AC_SUBST'ed variable

### DIFF
--- a/opal/tools/wrappers/opal.pc.in
+++ b/opal/tools/wrappers/opal.pc.in
@@ -14,7 +14,7 @@ libdir=@libdir@
 # (they're pulled in via libopen-pal.so's implicit dependencies), so
 # list them in Libs.private.
 #
-Libs: -L${libdir} @OPAL_WRAPPER_EXTRA_LDFLAGS@ -lopen-pal 
+Libs: -L${libdir} @OPAL_PKG_CONFIG_LDFLAGS@ -lopen-pal
 Libs.private: @OPAL_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because we


### PR DESCRIPTION
As reported by @marksantcroos, this substitution in opal.pc was incorrect -- it left @{libdir} in the string (vs. ${libdir}).  The fix is simple: use the proper substitution variable in opal.pc (it was never updated to reflect the new/correct name that was created just for the pkg-config files).

Fixes open-mpi/ompi#1343.

(cherry picked from commit open-mpi/ompi@8558def8580e5681868b8b49ede57a6870b80075)

@hppritcha or @ggouaillardet please review
