### PR TITLE
v2.x: ompi_mpi_params.c: set mpi_add_procs_cutoff default to 0

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
@@ -64,7 +64,10 @@ int ompi_mpi_event_tick_rate = -1;
 char *ompi_mpi_show_mca_params_string = NULL;
 bool ompi_mpi_have_sparse_group_storage = !!(OMPI_GROUP_SPARSE);
 bool ompi_mpi_preconnect_mpi = false;
-uint32_t ompi_add_procs_cutoff = 1024;
+
+#define OMPI_ADD_PROCS_CUTOFF_DEFAULT 0
+uint32_t ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
+bool ompi_mpi_dynamics_enabled = true;
 
 static bool show_default_mca_params = false;
 static bool show_file_mca_params = false;
@@ -262,12 +265,12 @@ int ompi_mpi_register_params(void)
         ompi_rte_abort(1, NULL);
     }
 
-    ompi_add_procs_cutoff = 1024;
+    ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
     (void) mca_base_var_register ("ompi", "mpi", NULL, "add_procs_cutoff",
                                   "Maximum world size for pre-allocating resources for all "
                                   "remote processes. Increasing this limit may improve "
-                                  "communication performance at the cost of memory usage "
-                                  "(default: 1024)", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
+                                  "communication performance at the cost of memory usage",
+                                  MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
                                   0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
                                   &ompi_add_procs_cutoff);
 


### PR DESCRIPTION
Decrease the default value of the "mpi_add_procs_cutoff" MCA param from 1024 to 0.

(cherry picked from commit open-mpi/ompi@902b477aac2063976578f031aa079185104e07e0)

@hjelmn Please review.
