### PR TITLE
Typo.

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
@@ -147,7 +147,7 @@ int ompi_osc_pt2pt_fence(int assert, ompi_win_t *win)
 
     /* short-circuit the noprecede case */
     if (0 != (assert & MPI_MODE_NOPRECEDE)) {
-        module->comm->c_coll.coll_barrier (module->comm,  module->comm->c_coll.coll_barrier);
+        module->comm->c_coll.coll_barrier (module->comm,  module->comm->c_coll.coll_barrier_module);
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "osc pt2pt: fence end (short circuit)"));
         return ret;


### PR DESCRIPTION
(cherry picked from open-mpi/ompi@7c574a35309a7b4ae6ce441c2d279f9fa465bd28)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
