### PR TITLE
pmix s2: adjust module structure initialisation to fit pmix.h

### DIFF
--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -88,6 +88,8 @@ const opal_pmix_base_module_t opal_pmix_s1_module = {
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
     /* utility APIs */
     NULL,
     opal_pmix_base_register_handler,

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -95,6 +95,8 @@ const opal_pmix_base_module_t opal_pmix_s2_module = {
     NULL,
     NULL,
     NULL,
+    NULL,
+    NULL,
     /* utility APIs */
     NULL,
     opal_pmix_base_register_handler,


### PR DESCRIPTION
In v2.x branch the pmix s2 module structure initialisation is out of sync with pmix.h.
This makes launch with "srun --mpi=pmi2" work again.
