### PR TITLE
v1.10: Fix MPI_TYPE_SET_ATTR with NULL value

### DIFF
--- a/ompi/mpi/c/type_set_attr.c
+++ b/ompi/mpi/c/type_set_attr.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart, 
@@ -46,17 +46,15 @@ int MPI_Type_set_attr (MPI_Datatype type,
     MEMCHECKER(
         memchecker_datatype(type);
     );
-    
-  if (MPI_PARAM_CHECK) {
-    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-    if (NULL == type || MPI_DATATYPE_NULL == type) {
-      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);
-    } else if (NULL == attribute_val) {
-      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
-    }
-  }
 
-  OPAL_CR_ENTER_LIBRARY();
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (NULL == type || MPI_DATATYPE_NULL == type) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);
+        }
+    }
+
+    OPAL_CR_ENTER_LIBRARY();
 
     ret = ompi_attr_set_c(TYPE_ATTR, type, &type->d_keyhash, 
                           type_keyval, attribute_val, false);


### PR DESCRIPTION
Fix issue identified by @dalcinl regarding the lack
of support for NULL value in MPI_Type_set_attr.
Provides a fix for issue open-mpi/ompi#1359.

(cherry picked from commit open-mpi/ompi@56425a5d487ce120d6953a00fdf1628d29069e5d)

Fix provided by @bosilca; reviewed by @jsquyres
