### PR TITLE
v1.10: Fix MPI_Get_address (MPI_BOTTOM, ...)

### DIFF
--- a/ompi/mpi/c/get_address.c
+++ b/ompi/mpi/c/get_address.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2013-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  * 
@@ -43,7 +43,7 @@ int MPI_Get_address(const void *location, MPI_Aint *address)
 
     if( MPI_PARAM_CHECK ) {
       OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-      if (NULL == location || NULL == address) {
+      if (NULL == address) {
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
       }
     }

--- a/ompi/mpi/fortran/mpif-h/get_address_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_address_f.c
@@ -20,6 +20,7 @@
 #include "ompi_config.h"
 
 #include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
 
 #if OPAL_HAVE_WEAK_SYMBOLS && OMPI_PROFILE_LAYER
 #pragma weak PMPI_GET_ADDRESS = ompi_get_address_f
@@ -69,7 +70,7 @@ void ompi_get_address_f(char *location, MPI_Aint *address, MPI_Fint *ierr)
     int c_ierr;
     MPI_Aint c_address;
 
-    c_ierr = MPI_Get_address(location, &c_address);
+    c_ierr = PMPI_Get_address(OMPI_F2C_BOTTOM(location), &c_address);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {


### PR DESCRIPTION
Nowhere in the standard does it say that it is invalid to pass
MPI_BOTTOM to MPI_Get_address yet we were returning an error. This
commit removes the error check on NULL == location.

Fixes open-mpi/ompi#1355.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@064a67f5b9f31c27afe8730c0ae81284bb7ab017)

Reviewed by @jsquyres

Thanks to @dalcinl for reporting.
