### PR TITLE
Fix parsing of envvars in MCA files

### DIFF
--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -227,16 +227,16 @@ static void trim_name(char *buffer, const char* prefix, const char* suffix)
     }
 
     /* trim spaces at the end */
-    echr = buffer + buffer_len - 1;
-    while (isspace (*echr)) {
+    echr = buffer + buffer_len;
+    while (isspace (*(echr - 1)) && echr > buffer) {
         echr--;
     }
-    echr[1] = '\0';
+    echr[0] = '\0';
 
-    if (NULL != suffix) {
+    if (NULL != suffix && (uintptr_t) (echr - buffer) > strlen (suffix)) {
         size_t suffix_len = strlen (suffix);
 
-        echr -= suffix_len - 1;
+        echr -= suffix_len;
 
         if (0 == strncmp (echr, suffix, strlen(suffix))) {
             do {

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -228,7 +228,7 @@ static void trim_name(char *buffer, const char* prefix, const char* suffix)
 
     /* trim spaces at the end */
     echr = buffer + buffer_len;
-    while (isspace (*(echr - 1)) && echr > buffer) {
+    while (echr > buffer && isspace (*(echr - 1))) {
         echr--;
     }
     echr[0] = '\0';


### PR DESCRIPTION
This commit fixes a memory corruption bug when parsing lines of the
form:

-x FOO=bar

The code was making changes to the size of the buffer allocated for
key_buffer without making the appropriate changes to
key_buffer_len. This was causing subsequent calls to save_param_name
to write to invalid memory.

This commit makes the following changes:
- Fix the above bug by modifying trim_name to move the string within
  the buffer instead of re-allocating space for the trimmed string.
- Cleaned up both trim_name and save_param_name. Both functions took
  a prefix and suffix to trim. Problem was the prefix was not
  treated like a prefix. Instead the "prefix" was located inside the
  string using strstr then the trimmed value started after the
  substring (even in the middle of the string). To allow trimming
  both -x and --x (as well as -mca and --mca) trim_name is now
  called with each prefix.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@32236736a4ece4056d849f65e715242d85b86c4e)

Fixes open-mpi/ompi#1375

Signed-off-by: Nathan Hjelm hjelmn@me.com
