### PR TITLE
v1.10: memchecker.h: fix memchecker no-data case

### DIFF
--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  *
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,6 +96,10 @@ static inline int memchecker_call (int (*f)(void *, size_t), const void * addr,
                                    size_t count, struct ompi_datatype_t * datatype)
 {
     if (!opal_memchecker_base_runindebugger()) {
+        return OMPI_SUCCESS;
+    }
+
+    if ((0 == count) || (0 == datatype->super.size)) {
         return OMPI_SUCCESS;
     }
 


### PR DESCRIPTION
Thanks to @clintonstimpson for reporting the issue.

Fixes open-mpi/ompi#100

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@7b73c868d5672d3327ec35f840fc807a49ba083b)

Written by @bosilca, reviewed by @jsquyres.
