### PR TITLE
v2.x: memchecker.h: fix memchecker no-data case

### DIFF
--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -10,6 +10,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  *
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,6 +98,10 @@ static inline int memchecker_call (int (*f)(void *, size_t), const void * addr,
                                    size_t count, struct ompi_datatype_t * datatype)
 {
     if (!opal_memchecker_base_runindebugger()) {
+        return OMPI_SUCCESS;
+    }
+
+    if ((0 == count) || (0 == datatype->super.size)) {
         return OMPI_SUCCESS;
     }
 


### PR DESCRIPTION
Thanks to @clintonstimpson for reporting the issue.

Fixes open-mpi/ompi#100

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@7b73c868d5672d3327ec35f840fc807a49ba083b)

Written by @bosilca, reviewed by @jsquyres

@hppritcha This can go in v2.0.0 or defer to v2.0.1 -- it's a minor issue.  I'll tentatively mark it as v2.0.1.
