### PR TITLE
v1.10: Add MPI_T man pages

### DIFF
--- a/ompi/mpi/man/man3/MPI_T_pvar_get_info.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_get_info.3in
@@ -87,7 +87,7 @@ behavior. The class returned in the \fIvar_class\fP parameter may be one of the 
 .TP 2
 MPI_T_PVAR_CLASS_STATE
 Variable represents a set of discrete states that may be described by an enumerator. Variables of this class
-must be represented by an MPI_INT. The starting value is the current state of the variable. 
+must be represented by an MPI_INT. The starting value is the current state of the variable.
 .TP 2
 MPI_T_PVAR_CLASS_LEVEL
 Variable represents the current utilization level of a resource. Variables of this class must be represented

--- a/ompi/mpi/man/man3/MPI_T_pvar_start.3in
+++ b/ompi/mpi/man/man3/MPI_T_pvar_start.3in
@@ -38,7 +38,7 @@ MPI_T_pvar_stop stops the performance variable with the handle specified in \fIh
 The special value MPI_T_PVAR_ALL_HANDLES can be passed in \fIhandle\fP to stop all
 non-continuous handles in the session specified in \fIsession\fP.
 
-Continuous performance variables can neither be started nor stopped. 
+Continuous performance variables can neither be started nor stopped.
 
 .SH ERRORS
 .ft R

--- a/ompi/mpi/man/man3/Makefile.extra
+++ b/ompi/mpi/man/man3/Makefile.extra
@@ -297,6 +297,34 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Status_set_cancelled.3 \
         mpi/man/man3/MPI_Status_set_elements.3 \
         mpi/man/man3/MPI_Status_set_elements_x.3 \
+        mpi/man/man3/MPI_T_category_changed.3 \
+        mpi/man/man3/MPI_T_category_get_categories.3 \
+        mpi/man/man3/MPI_T_category_get_cvars.3 \
+        mpi/man/man3/MPI_T_category_get_info.3 \
+        mpi/man/man3/MPI_T_category_get_num.3 \
+        mpi/man/man3/MPI_T_category_get_pvars.3 \
+        mpi/man/man3/MPI_T_cvar_get_info.3 \
+        mpi/man/man3/MPI_T_cvar_get_num.3 \
+        mpi/man/man3/MPI_T_cvar_handle_alloc.3 \
+        mpi/man/man3/MPI_T_cvar_handle_free.3 \
+        mpi/man/man3/MPI_T_cvar_read.3 \
+        mpi/man/man3/MPI_T_cvar_write.3 \
+        mpi/man/man3/MPI_T_enum_get_info.3 \
+        mpi/man/man3/MPI_T_enum_get_item.3 \
+        mpi/man/man3/MPI_T_finalize.3 \
+        mpi/man/man3/MPI_T_init_thread.3 \
+        mpi/man/man3/MPI_T_pvar_get_info.3 \
+        mpi/man/man3/MPI_T_pvar_get_num.3 \
+        mpi/man/man3/MPI_T_pvar_handle_alloc.3 \
+        mpi/man/man3/MPI_T_pvar_handle_free.3 \
+        mpi/man/man3/MPI_T_pvar_read.3 \
+        mpi/man/man3/MPI_T_pvar_readreset.3 \
+        mpi/man/man3/MPI_T_pvar_reset.3 \
+        mpi/man/man3/MPI_T_pvar_session_create.3 \
+        mpi/man/man3/MPI_T_pvar_session_free.3 \
+        mpi/man/man3/MPI_T_pvar_start.3 \
+        mpi/man/man3/MPI_T_pvar_stop.3 \
+        mpi/man/man3/MPI_T_pvar_write.3 \
         mpi/man/man3/MPI_Test.3 \
         mpi/man/man3/MPI_Testall.3 \
         mpi/man/man3/MPI_Testany.3 \


### PR DESCRIPTION
The man pages were already included in the v1.10 tree, but they were not listed in the Makefile.am -- so they weren't included in the tarball nor on the web site.

This is not a problem on master/v2.x.  I'm guessing we missed a commit somewhere along the way; I did not spelunk to find it.  The two commits on this PR are:
- Fix some whitespace in the MPI_T man pages (i.e., copied directly from master)
- Add the MPI_T man pages to the Makefile.am so that they get included in the tarball and installed

@hjelmn Please review
