### PR TITLE
Fix CUDA in v2.x

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -81,9 +81,9 @@ mca_pml_ob1_t mca_pml_ob1 = {
 };
 
 #if OPAL_CUDA_SUPPORT
-void mca_pml_ob1_cuda_add_ipc_support(struct mca_btl_base_module_t* btl,
-                                      int32_t flags, ompi_proc_t* errproc,
-                                      char* btlinfo);
+extern void mca_pml_ob1_cuda_add_ipc_support(struct mca_btl_base_module_t* btl,
+                                             int32_t flags, ompi_proc_t* errproc,
+                                             char* btlinfo);
 #endif /* OPAL_CUDA_SUPPORT */
 
 void mca_pml_ob1_error_handler( struct mca_btl_base_module_t* btl,
@@ -560,7 +560,7 @@ int mca_pml_ob1_dump(struct ompi_communicator_t* comm, int verbose)
             continue;
         }
 
-        mca_bml_base_endpoint_t* ep = (mca_bml_base_endpoint_t*)proc->ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+        mca_bml_base_endpoint_t* ep = mca_bml_base_get_endpoint(proc->ompi_proc);
         size_t n;
 
         opal_output(0, "[Rank %d] expected_seq %d ompi_proc %p send_seq %d\n",

--- a/ompi/mca/pml/ob1/pml_ob1_cuda.c
+++ b/ompi/mca/pml/ob1/pml_ob1_cuda.c
@@ -156,8 +156,7 @@ int mca_pml_ob1_cuda_need_buffers(void * rreq,
                                   mca_btl_base_module_t* btl)
 {
     mca_pml_ob1_recv_request_t* recvreq = (mca_pml_ob1_recv_request_t*)rreq;
-    mca_bml_base_endpoint_t* bml_endpoint =
-        (mca_bml_base_endpoint_t*)recvreq->req_recv.req_base.req_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+    mca_bml_base_endpoint_t* bml_endpoint = mca_bml_base_get_endpoint (recvreq->req_recv.req_base.req_proc);
     mca_bml_base_btl_t *bml_btl = mca_bml_base_btl_array_find(&bml_endpoint->btl_send, btl);
 
     /* A btl could be in the rdma list but not in the send list so check there also */


### PR DESCRIPTION
Get bml_endpoint with mca_mbl_get_endpoint instead of direct access.

Fixes open-mpi/ompi#1402
