### PR TITLE
v1.10 examples: fix check for Fortran "use mpi" bindings

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2007 Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # $COPYRIGHT$
@@ -90,7 +90,7 @@ mpi:
 	@ if ompi_info --parsable | grep bindings:mpif.h:yes >/dev/null; then \
 	    $(MAKE) hello_mpifh ring_mpifh; \
 	fi
-	@ if ompi_info --parsable | grep bindings:use_mpi:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep bindings:use_mpi:\"yes >/dev/null; then \
 	    $(MAKE) hello_usempi ring_usempi; \
 	fi
 	@ if ompi_info --parsable | grep bindings:use_mpi_f08:yes >/dev/null; then \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -84,19 +84,19 @@ all: hello_c ring_c connectivity_c
 # MPI examples
 
 mpi:
-	@ if ompi_info --parsable | grep bindings:cxx:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:cxx:yes >/dev/null; then \
 	    $(MAKE) hello_cxx ring_cxx; \
 	fi
-	@ if ompi_info --parsable | grep bindings:mpif.h:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then \
 	    $(MAKE) hello_mpifh ring_mpifh; \
 	fi
-	@ if ompi_info --parsable | grep bindings:use_mpi:\"yes >/dev/null; then \
+	@ if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then \
 	    $(MAKE) hello_usempi ring_usempi; \
 	fi
-	@ if ompi_info --parsable | grep bindings:use_mpi_f08:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then \
 	    $(MAKE) hello_usempif08 ring_usempif08; \
 	fi
-	@ if ompi_info --parsable | grep bindings:java:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:java:yes >/dev/null; then \
 	    $(MAKE) Hello.class Ring.class; \
 	fi
 


### PR DESCRIPTION
The output from "ompi_info --parsable" for the Fortran "use mpi"
bindings apparently has changed over time.  It is now:

```
   "yes (full: ignore TKR)"
or "yes (limited: overloading)"
```

(including the quotes)

So update the test in examples/Makefile to also look for the quote.

(cherry picked from commit open-mpi/ompi@20fade1345620ba62ee875e277d82446938a3b38)

@ggouaillardet please review
