### PR TITLE
Repair the application suicide code for 2.0 - requires custom patch.

### DIFF
--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -31,6 +31,7 @@
 #include "opal/util/output.h"
 #include "opal/util/proc.h"
 #include "opal/util/show_help.h"
+#include "opal/errhandler/opal_errhandler.h"
 
 #include "opal/mca/pmix/base/base.h"
 #include "opal/mca/pmix/base/pmix_base_fns.h"
@@ -61,6 +62,8 @@ void opal_pmix_base_errhandler(int status,
 {
     if (NULL != errhandler) {
         errhandler(status, procs, info, cbfunc, cbdata);
+    } else {
+        opal_invoke_errhandler(OPAL_ERROR, NULL);
     }
 }
 

--- a/opal/mca/pmix/pmix112/pmix/src/client/pmix_client.c
+++ b/opal/mca/pmix/pmix112/pmix/src/client/pmix_client.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -68,13 +68,6 @@ static const char pmix_version_string[] = PMIX_VERSION;
 #define PMIX_MAX_RETRIES 10
 
 static int usock_connect(struct sockaddr *address);
-static void myerrhandler(pmix_status_t status,
-                         pmix_proc_t procs[], size_t nprocs,
-                         pmix_info_t info[], size_t ninfo)
-{
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:client default errhandler activated");
-}
 
 static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_usock_hdr_t *hdr,
                                     pmix_buffer_t *buf, void *cbdata)
@@ -262,7 +255,7 @@ int PMIx_Init(pmix_proc_t *proc)
     pmix_globals.uid = geteuid();
     pmix_globals.gid = getegid();
     /* default to our internal errhandler */
-    pmix_globals.errhandler = myerrhandler;
+    pmix_globals.errhandler = pmix_default_errhdlr;
 
     /* initialize the output system */
     if (!pmix_output_init()) {

--- a/opal/mca/pmix/pmix112/pmix/src/common/pmix_common.c
+++ b/opal/mca/pmix/pmix112/pmix/src/common/pmix_common.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,19 +18,73 @@
 #include <pmix_server.h>
 #include "src/include/pmix_globals.h"
 
+typedef struct {
+    pmix_event_t ev;
+    pmix_notification_fn_t errhandler;
+    pmix_errhandler_reg_cbfunc_t cbfunc;
+    int ref;
+    pmix_op_cbfunc_t opcbfunc;
+    void *cbdata;
+} shifter_t;
+
+ #define PMIX_THREADSHIFT(r, c)                       \
+ do {                                                 \
+    event_assign(&((r)->ev), pmix_globals.evbase,     \
+                 -1, EV_WRITE, (c), (r));             \
+    event_active(&((r)->ev), EV_WRITE, 1);            \
+} while(0);
+
+
+void pmix_default_errhdlr(pmix_status_t status,
+                          pmix_proc_t procs[], size_t nprocs,
+                          pmix_info_t info[], size_t ninfo)
+{
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:client default errhandler activated");
+}
+
+static void _register_err(int sd, short args, void *cbdata)
+{
+    shifter_t *st = (shifter_t*)cbdata;
+
+    pmix_globals.errhandler = st->errhandler;
+    if (NULL != st->cbfunc) {
+        st->cbfunc(PMIX_SUCCESS, 1, st->cbdata);
+    }
+    free(st);
+}
 void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
                               pmix_notification_fn_t errhandler,
                               pmix_errhandler_reg_cbfunc_t cbfunc,
                               void *cbdata)
 {
-    /* common err handler registration to be added */
+    shifter_t *st;
+    st = (shifter_t*)malloc(sizeof(shifter_t));
+    st->errhandler = errhandler;
+    st->cbfunc = cbfunc;
+    st->cbdata = cbdata;
+    PMIX_THREADSHIFT(st, _register_err);
 }
 
+static void _dereg_err(int sd, short args, void *cbdata)
+{
+    shifter_t *st = (shifter_t*)cbdata;
+
+    pmix_globals.errhandler = pmix_default_errhdlr;
+    if (NULL != st->opcbfunc) {
+        st->opcbfunc(PMIX_SUCCESS, st->cbdata);
+    }
+    free(st);
+}
 void PMIx_Deregister_errhandler(int errhandler_ref,
                                  pmix_op_cbfunc_t cbfunc,
                                  void *cbdata)
 {
-    /* common err handler deregistration goes here */
+    shifter_t *st;
+    st = (shifter_t*)malloc(sizeof(shifter_t));
+    st->opcbfunc = cbfunc;
+    st->cbdata = cbdata;
+    PMIX_THREADSHIFT(st, _dereg_err);
 }
 
 pmix_status_t PMIx_Notify_error(pmix_status_t status,

--- a/opal/mca/pmix/pmix112/pmix/src/include/pmix_globals.h
+++ b/opal/mca/pmix/pmix112/pmix/src/include/pmix_globals.h
@@ -108,6 +108,9 @@ void pmix_globals_init(void);
 void pmix_globals_finalize(void);
 
 extern pmix_globals_t pmix_globals;
+void pmix_default_errhdlr(pmix_status_t status,
+                          pmix_proc_t procs[], size_t nprocs,
+                          pmix_info_t info[], size_t ninfo);
 
 END_C_DECLS
 


### PR DESCRIPTION
The link from a PMIx comm failure back to the ORTE errmgr had been broken. Reconnect it so that the app's errmgr can abort upon loss of connection to the local daemon

@jsquyres The problem was that the call to PMIx_Register_errhandler wasn't implemented, and so we never connected to the PMIx errhandler to the ORTE errmgr even though we were registering it. This implements the registration code so the connection gets made.

Fixes open-mpi/ompi#1418
