### PR TITLE
pmi2 disqualified in singloton startup

### DIFF
--- a/opal/mca/common/pmi/common_pmi.c
+++ b/opal/mca/common/pmi/common_pmi.c
@@ -46,7 +46,6 @@ bool mca_common_pmi_init (void) {
         rank = -1;
         appnum = -1;
 
-
         /* if we can't startup PMI, we can't be used */
         if (PMI2_Initialized ()) {
             return true;
@@ -57,17 +56,13 @@ bool mca_common_pmi_init (void) {
             mca_common_pmi_init_count--;
             return false;
         }
-        if (size < 0 || rank < 0 ) {
+        /* depending on slurm versions, we may get bad rank/size or bad jobid */
+        if (size < 0 || rank < 0 || PMI2_SUCCESS != PMI2_Job_GetId(buf, PMI2_MAX_VALLEN)) {
             opal_show_help("help-common-pmi.txt", "pmi2-init-returned-bad-values", true);
             mca_common_pmi_init_count--;
             return false;
         }
 
-        if (PMI2_SUCCESS != PMI2_Job_GetId(buf, PMI2_MAX_VALLEN)) {
-            /* PMI2 can't be used if no job in singloton mode */
-            mca_common_pmi_init_count--;
-            return false;
-        }
         mca_common_pmi_init_size = size;
         mca_common_pmi_init_rank = rank;
         mca_common_pmi_init_count--;

--- a/opal/mca/common/pmi/common_pmi.c
+++ b/opal/mca/common/pmi/common_pmi.c
@@ -58,7 +58,10 @@ bool mca_common_pmi_init (void) {
         }
         /* depending on slurm versions, we may get bad rank/size or bad jobid */
         if (size < 0 || rank < 0 || PMI2_SUCCESS != PMI2_Job_GetId(buf, PMI2_MAX_VALLEN)) {
-            opal_show_help("help-common-pmi.txt", "pmi2-init-returned-bad-values", true);
+            /* When no srun (singloton) fail quietly */
+            if (NULL != getenv("SLURM_STEP_NUM_TASKS")) {
+                opal_show_help("help-common-pmi.txt", "pmi2-init-returned-bad-values", true);
+            }
             mca_common_pmi_init_count--;
             return false;
         }

--- a/opal/mca/common/pmi/common_pmi.c
+++ b/opal/mca/common/pmi/common_pmi.c
@@ -40,6 +40,7 @@ bool mca_common_pmi_init (void) {
     {
         int spawned, size, rank, appnum;
         int rc;
+        char buf[PMI2_MAX_VALLEN];
 
         size = -1;
         rank = -1;
@@ -58,6 +59,12 @@ bool mca_common_pmi_init (void) {
         }
         if (size < 0 || rank < 0 ) {
             opal_show_help("help-common-pmi.txt", "pmi2-init-returned-bad-values", true);
+            mca_common_pmi_init_count--;
+            return false;
+        }
+
+        if (PMI2_SUCCESS != PMI2_Job_GetId(buf, PMI2_MAX_VALLEN)) {
+            /* PMI2 can't be used if no job in singloton mode */
             mca_common_pmi_init_count--;
             return false;
         }

--- a/opal/mca/common/pmi/help-common-pmi.txt
+++ b/opal/mca/common/pmi/help-common-pmi.txt
@@ -13,7 +13,7 @@ We cannot use PMI2 at this time, and your job will
 likely abort.
 #
 [pmi2-init-returned-bad-values]
-PMI2 initialized but returned bad values for size and rank.
+PMI2 initialized but returned bad values for size/rank/jobid.
 This is symptomatic of either a failure to use the
 "--mpi=pmi2" flag in SLURM, or a borked PMI2 installation.
 If running under SLURM, try adding "-mpi=pmi2" to your


### PR DESCRIPTION
In openmpi <=1.10, there a bug when launching with PMI2 in singloton mode :

```
$ ./mpi_hello
[...]
 PMI2_Job_GetId failed failed
  --> Returned value (null) (14) instead of ORTE_SUCCESS
```

A possible correction is to check at pmi2 init if we get a job id.
