### PR TITLE
coll/libnbc: do not handle MPI_IN_PLACE in neighborhood collectives

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -57,13 +59,10 @@ int ompi_coll_libnbc_ineighbor_allgatherv(void *sbuf, int scount, MPI_Datatype s
   res = MPI_Type_extent(rtype, &rcvext);
   if (MPI_SUCCESS != res) { printf("MPI Error in MPI_Type_extent() (%i)\n", res); return res; }
 
-  char inplace;
   NBC_Schedule *schedule;
 #ifdef NBC_CACHE_SCHEDULE
   NBC_Ineighbor_allgatherv_args *args, *found, search;
 #endif
-
-  NBC_IN_PLACE(sbuf, rbuf, inplace);
 
   handle->tmpbuf=NULL;
 
@@ -94,50 +93,17 @@ int ompi_coll_libnbc_ineighbor_allgatherv(void *sbuf, int scount, MPI_Datatype s
       res = NBC_Comm_neighbors(comm, indegree, srcs, MPI_UNWEIGHTED, outdegree, dsts, MPI_UNWEIGHTED);
       if(res != NBC_OK) return res;
 
-      if(inplace) { /* we need an extra buffer to be deadlock-free */
-        int sumrcounts=0;
-        int offset=0;
-        for(i=0; i<indegree; ++i) sumrcounts += rcounts[i];
-        handle->tmpbuf = malloc(rcvext*sumrcounts);
-
-        for(i = 0; i < indegree; i++) {
-          if(srcs[i] != MPI_PROC_NULL) {
-            res = NBC_Sched_recv((char*)0+offset, true, rcounts[i], rtype, srcs[i], schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
-          }
-          offset += rcounts[i]*rcvext;
+      /* simply loop over neighbors and post send/recv operations */
+      for(i = 0; i < indegree; i++) {
+        if(srcs[i] != MPI_PROC_NULL) {
+          res = NBC_Sched_recv((char*)rbuf+displs[i]*rcvext, false, rcounts[i], rtype, srcs[i], schedule);
+          if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
         }
-        for(i = 0; i < outdegree; i++) {
-          if(dsts[i] != MPI_PROC_NULL) {
-            res = NBC_Sched_send((char*)sbuf, false, scount, stype, dsts[i], schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
-          }
-        }
-        /* unpack from buffer */
-        offset=0;
-        for(i = 0; i < indegree; i++) {
-          if(srcs[i] != MPI_PROC_NULL) {
-            res = NBC_Sched_barrier(schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_barrier() (%i)\n", res); return res; }
-            res = NBC_Sched_copy((char*)0+offset, true, rcounts[i], rtype, (char*)rbuf+displs[i]*rcvext, false, rcounts[i], rtype, schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_copy() (%i)\n", res); return res; }
-          }
-          offset += rcounts[i]*rcvext;
-        }
-      } else { /* non INPLACE case */
-
-        /* simply loop over neighbors and post send/recv operations */
-        for(i = 0; i < indegree; i++) {
-          if(srcs[i] != MPI_PROC_NULL) {
-            res = NBC_Sched_recv((char*)rbuf+displs[i]*rcvext, false, rcounts[i], rtype, srcs[i], schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
-          }
-        }
-        for(i = 0; i < outdegree; i++) {
-          if(dsts[i] != MPI_PROC_NULL) {
-            res = NBC_Sched_send((char*)sbuf, false, scount, stype, dsts[i], schedule);
-            if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
-          }
+      }
+      for(i = 0; i < outdegree; i++) {
+        if(dsts[i] != MPI_PROC_NULL) {
+          res = NBC_Sched_send((char*)sbuf, false, scount, stype, dsts[i], schedule);
+          if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
         }
       }
     }

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -55,13 +57,10 @@ int ompi_coll_libnbc_ineighbor_alltoall(void *sbuf, int scount, MPI_Datatype sty
   res = MPI_Type_extent(rtype, &rcvext);
   if (MPI_SUCCESS != res) { printf("MPI Error in MPI_Type_extent() (%i)\n", res); return res; }
 
-  char inplace;
   NBC_Schedule *schedule;
 #ifdef NBC_CACHE_SCHEDULE
   NBC_Ineighbor_alltoall_args *args, *found, search;
 #endif
-
-  NBC_IN_PLACE(sbuf, rbuf, inplace);
 
   handle->tmpbuf=NULL;
 
@@ -92,41 +91,17 @@ int ompi_coll_libnbc_ineighbor_alltoall(void *sbuf, int scount, MPI_Datatype sty
       res = NBC_Comm_neighbors(comm, indegree, srcs, MPI_UNWEIGHTED, outdegree, dsts, MPI_UNWEIGHTED);
       if(res != NBC_OK) return res;
 
-      if(inplace) { /* we need an extra buffer to be deadlock-free */
-        handle->tmpbuf = malloc(indegree*rcvext*rcount);
-
-        for(i = 0; i < indegree; i++) {
-          if (MPI_PROC_NULL != srcs[i]) {
-	    res = NBC_Sched_recv((char*)0+i*rcount*rcvext, true, rcount, rtype, srcs[i], schedule);
-	    if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
-	  }
+      /* simply loop over neighbors and post send/recv operations */
+      for(i = 0; i < indegree; i++) {
+        if (MPI_PROC_NULL != srcs[i]) {
+          res = NBC_Sched_recv((char*)rbuf+i*rcount*rcvext, false, rcount, rtype, srcs[i], schedule);
+          if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
         }
-        for(i = 0; i < outdegree; i++) {
-          if (MPI_PROC_NULL != dsts[i]) {
-	    res = NBC_Sched_send((char*)sbuf+i*scount*sndext, false, scount, stype, dsts[i], schedule);
-	    if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
-	  }
-        }
-        /* unpack from buffer */
-        for(i = 0; i < indegree; i++) {
-          res = NBC_Sched_barrier(schedule);
-          if (NBC_OK != res) { printf("Error in NBC_Sched_barrier() (%i)\n", res); return res; }
-          res = NBC_Sched_copy((char*)0+i*rcount*rcvext, true, rcount, rtype, (char*)rbuf+i*rcount*rcvext, false, rcount, rtype, schedule);
-          if (NBC_OK != res) { printf("Error in NBC_Sched_copy() (%i)\n", res); return res; }
-        }
-      } else { /* non INPLACE case */
-        /* simply loop over neighbors and post send/recv operations */
-        for(i = 0; i < indegree; i++) {
-          if (MPI_PROC_NULL != srcs[i]) {
-	    res = NBC_Sched_recv((char*)rbuf+i*rcount*rcvext, false, rcount, rtype, srcs[i], schedule);
-	    if (NBC_OK != res) { printf("Error in NBC_Sched_recv() (%i)\n", res); return res; }
-	  }
-        }
-        for(i = 0; i < outdegree; i++) {
-          if (MPI_PROC_NULL != dsts[i]) {
-	    res = NBC_Sched_send((char*)sbuf+i*scount*sndext, false, scount, stype, dsts[i], schedule);
-	    if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
-	  }
+      }
+      for(i = 0; i < outdegree; i++) {
+        if (MPI_PROC_NULL != dsts[i]) {
+          res = NBC_Sched_send((char*)sbuf+i*scount*sndext, false, scount, stype, dsts[i], schedule);
+          if (NBC_OK != res) { printf("Error in NBC_Sched_send() (%i)\n", res); return res; }
         }
       }
     }

--- a/ompi/mpi/c/ineighbor_allgather.c
+++ b/ompi/mpi/c/ineighbor_allgather.c
@@ -84,9 +84,9 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
           err = MPI_ERR_TYPE;
         } else if (recvcount < 0) {
           err = MPI_ERR_COUNT;
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
           return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
-        } else if (MPI_IN_PLACE != sendbuf) {
+        } else {
             OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);

--- a/ompi/mpi/c/ineighbor_allgatherv.c
+++ b/ompi/mpi/c/ineighbor_allgatherv.c
@@ -87,15 +87,13 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
                                          OMPI_COMM_IS_DIST_GRAPH(comm))) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         } else if (MPI_DATATYPE_NULL == recvtype) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TYPE, FUNC_NAME);
         }
 
-        if (MPI_IN_PLACE != sendbuf) {
-            OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
-        }
+        OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
 
       /* We always define the remote group to be the same as the local

--- a/ompi/mpi/c/ineighbor_alltoall.c
+++ b/ompi/mpi/c/ineighbor_alltoall.c
@@ -72,13 +72,8 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
                                          OMPI_COMM_IS_DIST_GRAPH(comm))) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
-                                          FUNC_NAME);
-        } else if (MPI_IN_PLACE == sendbuf) {
-            /* MPI_IN_PLACE is not fully implemented yet,
-               return MPI_ERR_INTERN for now */
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_INTERN,
                                           FUNC_NAME);
         } else {
             OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);

--- a/ompi/mpi/c/ineighbor_alltoallv.c
+++ b/ompi/mpi/c/ineighbor_alltoallv.c
@@ -99,13 +99,8 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
 
         if ((NULL == sendcounts) || (NULL == sdispls) ||
             (NULL == recvcounts) || (NULL == rdispls) ||
-            MPI_IN_PLACE == recvbuf) {
+            MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
-        } else if (MPI_IN_PLACE == sendbuf) {
-            /* MPI_IN_PLACE is not fully implemented yet,
-               return MPI_ERR_INTERN for now */
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_INTERN,
-                                          FUNC_NAME);
         }
 
         err = ompi_comm_neighbors_count(comm, &indegree, &outdegree, &weighted);

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -97,13 +97,8 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
 
         if ((NULL == sendcounts) || (NULL == sdispls) || (NULL == sendtypes) ||
             (NULL == recvcounts) || (NULL == rdispls) || (NULL == recvtypes) ||
-            MPI_IN_PLACE == recvbuf) {
+            MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
-        } else if (MPI_IN_PLACE == sendbuf) {
-            /* MPI_IN_PLACE is not fully implemented yet,
-               return MPI_ERR_INTERN for now */
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_INTERN,
-                                          FUNC_NAME);
         }
 
         err = ompi_comm_neighbors_count(comm, &indegree, &outdegree, &weighted);

--- a/ompi/mpi/c/neighbor_allgather.c
+++ b/ompi/mpi/c/neighbor_allgather.c
@@ -83,9 +83,9 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
           err = MPI_ERR_TYPE;
         } else if (recvcount < 0) {
           err = MPI_ERR_COUNT;
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
           return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
-        } else if (MPI_IN_PLACE != sendbuf) {
+        } else {
             OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
@@ -94,16 +94,13 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
     /* Do we need to do anything?  Everyone had to give the same send
        signature, which means that everyone must have given a
        sendcount > 0 if there's anything to send for the intra-communicator
-       case.  If we're doing IN_PLACE, however, check recvcount,
-       not sendcount. */
+       case. */
     if ( OMPI_COMM_IS_INTRA(comm) ) {
-       if ((MPI_IN_PLACE != sendbuf && 0 == sendcount) ||
-            (0 == recvcount)) {
+       if ((0 == sendcount) || (0 == recvcount)) {
             return MPI_SUCCESS;
         }
-    }
-    else if ( OMPI_COMM_IS_INTER(comm) ){
-        /* for inter comunicators, the communication pattern
+    } else if ( OMPI_COMM_IS_INTER(comm) ){
+        /* for inter communicators, the communication pattern
            need not be symmetric. Specifically, one group is
            allows to have sendcount=0, while the other has
            a valid sendcount. Thus, the only way not to do

--- a/ompi/mpi/c/neighbor_allgatherv.c
+++ b/ompi/mpi/c/neighbor_allgatherv.c
@@ -87,15 +87,13 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
                                          OMPI_COMM_IS_DIST_GRAPH(comm))) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         } else if (MPI_DATATYPE_NULL == recvtype) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TYPE, FUNC_NAME);
         }
 
-        if (MPI_IN_PLACE != sendbuf) {
-            OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
-        }
+        OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
 
       /* We always define the remote group to be the same as the local

--- a/ompi/mpi/c/neighbor_alltoall.c
+++ b/ompi/mpi/c/neighbor_alltoall.c
@@ -65,18 +65,13 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
         /* Unrooted operation -- same checks for all ranks on both
            intracommunicators and intercommunicators */
 
-        if (MPI_IN_PLACE == sendbuf) {
-            sendcount = recvcount;
-            sendtype = recvtype;
-        }
-
         err = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if (ompi_comm_invalid(comm) || !(OMPI_COMM_IS_CART(comm) || OMPI_COMM_IS_GRAPH(comm) ||
                                          OMPI_COMM_IS_DIST_GRAPH(comm))) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == recvbuf) {
+        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                           FUNC_NAME);
         } else {
@@ -86,7 +81,7 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }
 
-        if (MPI_IN_PLACE != sendbuf && !OMPI_COMM_IS_INTER(comm)) {
+        if (!OMPI_COMM_IS_INTER(comm)) {
             ompi_datatype_type_size(sendtype, &sendtype_size);
             ompi_datatype_type_size(recvtype, &recvtype_size);
             if ((sendtype_size*sendcount) != (recvtype_size*recvcount)) {
@@ -99,8 +94,7 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
 
     ompi_datatype_type_size(sendtype, &sendtype_size);
     ompi_datatype_type_size(recvtype, &recvtype_size);
-    if (((MPI_IN_PLACE == sendbuf) ||
-         (0 == sendcount) || (0 == sendtype_size)) &&
+    if (((0 == sendcount) || (0 == sendtype_size)) &&
         ((0 == recvcount) || 0 == (recvtype_size))) {
         return MPI_SUCCESS;
     }

--- a/ompi/mpi/c/neighbor_alltoallv.c
+++ b/ompi/mpi/c/neighbor_alltoallv.c
@@ -97,15 +97,9 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
                                           FUNC_NAME);
         }
 
-        if (MPI_IN_PLACE == sendbuf) {
-            sendcounts = recvcounts;
-            sdispls = rdispls;
-            sendtype = recvtype;
-        }
-
         if ((NULL == sendcounts) || (NULL == sdispls) ||
             (NULL == recvcounts) || (NULL == rdispls) ||
-            MPI_IN_PLACE == recvbuf) {
+            MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         }
 

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -93,15 +93,9 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
                                           FUNC_NAME);
         }
 
-        if (MPI_IN_PLACE == sendbuf) {
-            sendcounts = recvcounts;
-            sdispls    = rdispls;
-            sendtypes  = recvtypes;
-        }
-
         if ((NULL == sendcounts) || (NULL == sdispls) || (NULL == sendtypes) ||
             (NULL == recvcounts) || (NULL == rdispls) || (NULL == recvtypes) ||
-             MPI_IN_PLACE == recvbuf) {
+             MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         }
 


### PR DESCRIPTION
This is a one off and a quick fix, and it unlikely works with complex types
(e.g. negative lower bound).
libnbc considers MPI_Ineighbor_alltoallw is in place when send and recv buffers are identical,
and even if they do not overlap because of distinct displacements.

Thanks Jun Kudo for the bug report.
