### PR TITLE
Bring missing osc/rdma fixes to v2.x

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -668,7 +668,7 @@ static inline int cas_rdma (ompi_osc_rdma_sync_t *sync, const void *source_buffe
             break;
         }
 
-        if (OPAL_UNLIKELY(OPAL_ERR_OUT_OF_RESOURCE != ret || OPAL_ERR_TEMP_OUT_OF_RESOURCE != ret)) {
+        if (OPAL_UNLIKELY(OPAL_ERR_OUT_OF_RESOURCE != ret && OPAL_ERR_TEMP_OUT_OF_RESOURCE != ret)) {
             ompi_osc_rdma_frag_complete (frag);
             return ret;
         }

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -456,7 +456,8 @@ int ompi_osc_rdma_complete_atomic (ompi_win_t *win)
 
     ompi_osc_rdma_sync_rdma_complete (sync);
 
-    if (MCA_BTL_FLAGS_ATOMIC_OPS & module->selected_btl->btl_flags) {
+    if (!(MCA_BTL_FLAGS_ATOMIC_OPS & module->selected_btl->btl_flags)) {
+        /* need a temporary buffer for performing fetching atomics */
         ret = ompi_osc_rdma_frag_alloc (module, 8, &frag, (char **) &scratch_lock);
         if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
             return ret;


### PR DESCRIPTION
These commits fixed bugs found by MTT on master. They were intended for the v2.x branch but were never brought over. Fixes a failure on nvidia MTT.

See open-mpi/ompi#1427 for a typical backtrack. Ignore the title of the bug though as this has nothing to do with MPI_Aint.

:bot:assign: @sjeaugey 
:bot:label:bug
:bot:milestone:v2.0.0
