### PR TITLE
ompi/win: use type int* for MPI_WIN_DISP_UNIT, MPI_WIN_CREATE_FLAVOR …

### DIFF
--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -167,18 +167,18 @@ config_window(void *base, size_t size, int disp_unit,
                                      MPI_WIN_SIZE, size, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi2(WIN_ATTR, win,
+    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
                                      &win->w_keyhash,
                                      MPI_WIN_DISP_UNIT, disp_unit,
                                      true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi2(WIN_ATTR, win,
+    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
                                      &win->w_keyhash,
                                      MPI_WIN_CREATE_FLAVOR, flavor, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi2(WIN_ATTR, win,
+    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
                                      &win->w_keyhash,
                                      MPI_WIN_MODEL, model, true);
     if (OMPI_SUCCESS != ret) return ret;


### PR DESCRIPTION
…and MPI_WIN_MODEL

Thanks Alastair McKinstry for the report.

(cherry picked from commit open-mpi/ompi@d08fb46ec732ea36fe5ecb2e33d7fb7c60206b21)
