### PR TITLE
usnic: use version 1 of the API, not the current version

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_component.c
+++ b/ompi/mca/btl/usnic/btl_usnic_component.c
@@ -845,7 +845,7 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
         }
 
         ret =
-            module->usnic_fabric_ops->getinfo(FI_EXT_USNIC_INFO_VERSION,
+            module->usnic_fabric_ops->getinfo(1,
                                             fabric,
                                             &module->usnic_info);
         if (ret != 0) {


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@d44804f0c9d260472fffc9c9c5101ab4992b9752)

Same as #1027; reviewed by @bturrubiates 

With the pending release of libfabric v1.3, this is necessary in the next release of Open MPI.
