### PR TITLE
opal_check_libfabric: correctly check for user intent

### DIFF
--- a/config/opal_check_libfabric.m4
+++ b/config/opal_check_libfabric.m4
@@ -74,7 +74,7 @@ AC_DEFUN([OPAL_CHECK_LIBFABRIC],[
 
     AS_IF([test $opal_check_libfabric_happy -eq 1],
           [$2],
-          [AS_IF([test "$opal_want_libfabric" = "yes"],
+          [AS_IF([test -n "$with_libfabric" && test "$with_libfabric" != "no"],
                  [AC_MSG_WARN([libfabric support requested (via --with-libfabric), but not found.])
                   AC_MSG_ERROR([Cannot continue.])])
            $3])


### PR DESCRIPTION
If the user asked for libfabric and we can't build for it, abort.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@ccdc10dda3e5ed55974d91adf5a636ac288b7e45)

@rhc54 or @hppritcha please review
