### PR TITLE
oshmem: remove #if OMPI_ENABLE_MPI_PROFILING

### DIFF
--- a/oshmem/runtime/oshmem_shmem_exchange.c
+++ b/oshmem/runtime/oshmem_shmem_exchange.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -15,12 +15,6 @@
 #include "oshmem/constants.h"
 #include "oshmem/runtime/runtime.h"
 #include "oshmem/runtime/params.h"
-
-#if OMPI_ENABLE_MPI_PROFILING
-#define MPI_Allgather PMPI_Allgather
-#define MPI_Allgatherv PMPI_Allgatherv
-#define MPI_Barrier PMPI_Barrier
-#endif
 
 int oshmem_shmem_allgather(void *send_buf, void *rcv_buf, int elem_size)
 {

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -57,10 +57,6 @@
 #include "oshmem/request/request.h"
 #include "oshmem/shmem/shmem_lock.h"
 #include "oshmem/runtime/oshmem_shmem_preconnect.h"
-
-#if OMPI_ENABLE_MPI_PROFILING
-#define MPI_Comm_free PMPI_Comm_free
-#endif
 
 static int _shmem_finalize(void);
 

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -80,10 +80,6 @@
 #pragma ident OMPI_IDENT_STRING
 #elif OPAL_CC_USE_IDENT
 #ident OSHMEM_IDENT_STRING
-#endif
-
-#if OMPI_ENABLE_MPI_PROFILING
-#define MPI_Comm_dup PMPI_Comm_dup
 #endif
 
 /*


### PR DESCRIPTION
these bits were missing when open-mpi/ompi@291a464efb571806dab1386d43a90a170e014757
was cherry-picked into 881e2dd2b7494d273b378da5372473d6055d6486
