### PR TITLE
btl/openib: correctly issue a warning when two btls or more are in th…

### DIFF
--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013-2014 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014      Bull SAS.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  *
@@ -312,6 +312,7 @@ struct mca_btl_openib_component_t {
 #if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
     bool rroce_enable;
 #endif
+    unsigned int num_default_gid_btls; /* numbers of btl in the default subnet */
 }; typedef struct mca_btl_openib_component_t mca_btl_openib_component_t;
 
 OPAL_MODULE_DECLSPEC extern mca_btl_openib_component_t mca_btl_openib_component;

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -181,6 +181,7 @@ static int btl_openib_component_open(void)
 
     /* initialize state */
     mca_btl_openib_component.ib_num_btls = 0;
+    mca_btl_openib_component.num_default_gid_btls = 0;
     mca_btl_openib_component.openib_btls = NULL;
     OBJ_CONSTRUCT(&mca_btl_openib_component.devices, opal_pointer_array_t);
     mca_btl_openib_component.devices_count = 0;
@@ -687,11 +688,15 @@ static int init_one_port(opal_list_t *btl_list, mca_btl_openib_device_t *device,
                  ibv_get_device_name(device->ib_dev), port_num, subnet_id));
 #endif
 
-    if(mca_btl_openib_component.ib_num_btls > 0 &&
+    if(mca_btl_openib_component.num_default_gid_btls > 0 &&
             IB_DEFAULT_GID_PREFIX == subnet_id &&
             mca_btl_openib_component.warn_default_gid_prefix) {
         opal_show_help("help-mpi-btl-openib.txt", "default subnet prefix",
                 true, opal_process_info.nodename);
+    }
+
+    if (IB_DEFAULT_GID_PREFIX == subnet_id) {
+        mca_btl_openib_component.num_default_gid_btls++;
     }
 
     lmc = (1 << ib_port_attr->lmc);


### PR DESCRIPTION
…e default subnet gid

Thanks Matias Cabral for reporting this issue.

Fixes open-mpi/ompi#1352

(cherry picked from commit open-mpi/ompi@861564df94777034d8764e0c0c19f4fb8d3f7930)
