### PR TITLE
mellanox/optimized: set enable_openib_rdmacm_ibaddr=yes in the mellanox/optimized file.

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -6,6 +6,7 @@ with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes
 disable_wrapper_rpath=yes
+enable_openib_rdmacm_ibaddr=yes
 
 mellanox_autodetect=${mellanox_autodetect:="no"}
 mellanox_debug=${mellanox_debug:="no"}


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@6cd7282631bf999336c975a1a418aeda83a244c6)

depends on https://github.com/open-mpi/ompi-release/pull/1043

bot:milestone:v2.0.0
bot:assign: @jladd-mlnx 
