### PR TITLE
Revert "mellanox/optimized: set enable_openib_rdmacm_ibaddr=yes in the mellanox/optimized file."

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -6,7 +6,6 @@ with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes
 disable_wrapper_rpath=yes
-enable_openib_rdmacm_ibaddr=yes
 
 mellanox_autodetect=${mellanox_autodetect:="no"}
 mellanox_debug=${mellanox_debug:="no"}


### PR DESCRIPTION
need to revert since PR #1043 will not go in till v2.1

Reverts open-mpi/ompi-release#1075
