### PR TITLE
AUTHORS: Fix an errant reference to Subversion IDs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Open MPI Authors
 ================
 
-The following cumulative list contains the names and Subversion IDs of
+The following cumulative list contains the names and email addresses of
 all individuals who have committed code to the Open MPI repository.
 
 Email                           Name                        Affiliation(s)


### PR DESCRIPTION
Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@06eeeb3583b0bd54613e074dd899b32272c2c30d)

@rhc54 Trivial update to AUTHORS to fix the "Subversion" reference in there.
