### PR TITLE
v1.10: fortran: Fix `ompi_alloc_mem_cptr_f` linkage error

### DIFF
--- a/ompi/mpi/fortran/mpif-h/profile/defines.h
+++ b/ompi/mpi/fortran/mpif-h/profile/defines.h
@@ -34,6 +34,7 @@
 #define ompi_allgather_f pompi_allgather_f
 #define ompi_allgatherv_f pompi_allgatherv_f
 #define ompi_alloc_mem_f pompi_alloc_mem_f
+#define ompi_alloc_mem_cptr_f pompi_alloc_mem_cptr_f
 #define ompi_allreduce_f pompi_allreduce_f
 #define ompi_alltoall_f pompi_alltoall_f
 #define ompi_alltoallv_f pompi_alltoallv_f


### PR DESCRIPTION
This fixes a linkage error when configured with `--disable-weak-symbols`, described in https://github.com/open-mpi/ompi/pull/1538#issuecomment-212994156

The `ompi_alloc_mem_cptr_f` function for `mpif-h` was introduced in 052b13d but I forgot to update `defines.h` file.

This bug exists only in v1.10 branch because the implementation of the profiling interface support was changed in master/v2.x.

This fix should be pulled before v1.10.3 release because it's a regression since v1.10.2.

@jsquyres please review

bot:label:bug
bot:milestone:v1.10.3
