### PR TITLE
ras/lsf: Fix affinity for MPMD jobs running under LSF

### DIFF
--- a/orte/mca/ras/alps/ras_alps_module.c
+++ b/orte/mca/ras/alps/ras_alps_module.c
@@ -549,6 +549,7 @@ orte_ras_alps_read_appinfo_file(opal_list_t *nodes, char *filename,
                 node->slots_inuse = 0;
                 node->slots_max = 0;
                 node->slots = 1;
+                node->state = ORTE_NODE_STATE_UP;
                 /* need to order these node ids so the regex generator
                  * can properly function
                  */
@@ -585,6 +586,7 @@ orte_ras_alps_read_appinfo_file(opal_list_t *nodes, char *filename,
             node->slots_inuse = 0;
             node->slots_max = 0;
             node->slots = apNodes[ix].numPEs;
+            node->state = ORTE_NODE_STATE_UP;
             /* need to order these node ids so the regex generator
              * can properly function
              */

--- a/orte/mca/ras/lsf/ras_lsf_module.c
+++ b/orte/mca/ras/lsf/ras_lsf_module.c
@@ -107,6 +107,7 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
         node->slots_inuse = 0;
         node->slots_max = 0;
         node->slots = 1;
+        node->state = ORTE_NODE_STATE_UP;
         opal_list_append(nodes, &node->super);
     }
 

--- a/orte/mca/ras/tm/ras_tm_module.c
+++ b/orte/mca/ras/tm/ras_tm_module.c
@@ -212,6 +212,7 @@ static int discover(opal_list_t* nodelist, char *pbs_jobid)
             node->slots_inuse = 0;
             node->slots_max = 0;
             node->slots = ppn;
+            node->state = ORTE_NODE_STATE_UP;
             opal_list_append(nodelist, &node->super);
         } else {
 


### PR DESCRIPTION
Also brings over open-mpi/ompi@2c896c5 which was already applied to the 1.10 branch, but must have been missed for the v2.x branch.

This commit fixes open-mpi/ompi#1570 for the 2.x branch.
