### PR TITLE
v1.10: alloc_mem: fix multiply-defined symbol

### DIFF
--- a/ompi/mpi/fortran/mpif-h/profile/defines.h
+++ b/ompi/mpi/fortran/mpif-h/profile/defines.h
@@ -34,6 +34,7 @@
 #define ompi_allgather_f pompi_allgather_f
 #define ompi_allgatherv_f pompi_allgatherv_f
 #define ompi_alloc_mem_f pompi_alloc_mem_f
+#define ompi_alloc_mem_cptr_f pompi_alloc_mem_cptr_f
 #define ompi_allreduce_f pompi_allreduce_f
 #define ompi_alltoall_f pompi_alltoall_f
 #define ompi_alltoallv_f pompi_alltoallv_f


### PR DESCRIPTION
Without this define, the ompi_alloc_mem_cptr_f() function was not
getting transmorgified to its pompi_ equivalent, leading to a multiple
symbol definition linker error.

See https://mtt.open-mpi.org/index.php?do_redir=2296.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

@kawashima-fj Please review.
