### PR TITLE
mpi_init: move opal_set_using_threads() earlier in MPI_Init()

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -400,11 +400,24 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     /* Indicate that we have *started* MPI_INIT* */
     ompi_mpi_init_started = true;
 
-    /* Setup enough to check get/set MCA params */
+    /* Figure out the final MPI thread levels.  If we were not
+       compiled for support for MPI threads, then don't allow
+       MPI_THREAD_MULTIPLE.  Set this stuff up here early in the
+       process so that other components can make decisions based on
+       this value. */
 
+    ompi_mpi_thread_level(requested, provided);
+
+    /* Setup enough to check get/set MCA params */
     if (OPAL_SUCCESS != (ret = opal_init_util(&argc, &argv))) {
         error = "ompi_mpi_init: opal_init_util failed";
         goto error;
+    }
+
+    /* If thread support was enabled, then setup OPAL to allow for them. This must be done
+     * early to prevent a race condition that can occur with orte_init(). */
+    if (*provided != MPI_THREAD_SINGLE) {
+        opal_set_using_threads(true);
     }
 
     /* Convince OPAL to use our naming scheme */
@@ -503,13 +516,6 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     ompi_rte_register_errhandler(ompi_errhandler_runtime_callback,
                                  OMPI_RTE_ERRHANDLER_LAST);
 
-    /* Figure out the final MPI thread levels.  If we were not
-       compiled for support for MPI threads, then don't allow
-       MPI_THREAD_MULTIPLE.  Set this stuff up here early in the
-       process so that other components can make decisions based on
-       this value. */
-
-    ompi_mpi_thread_level(requested, provided);
 
     /* determine the bitflag belonging to the threadlevel_support provided */
     memset ( &threadlevel_bf, 0, sizeof(uint8_t));
@@ -524,13 +530,6 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
         goto error;
     }
 #endif
-
-    /* If thread support was enabled, then setup OPAL to allow for
-       them. */
-    if ((OPAL_ENABLE_PROGRESS_THREADS == 1) ||
-        (*provided != MPI_THREAD_SINGLE)) {
-        opal_set_using_threads(true);
-    }
 
     /* initialize datatypes. This step should be done early as it will
      * create the local convertor and local arch used in the proc


### PR DESCRIPTION
There is a potential race condition in MPI_Init() where an orte even
thread could be in a function that uses OPAL_THREAD_LOCK /
OPAL_THREAD_UNLOCK when ompi_mpi_init calls opal_set_using_threads().

Closes open-mpi/ompi#1586

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@1e4daa2a0eedd8e27ff6821236c2e0800b826145)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
