### PR TITLE
memory: fix typo

### DIFF
--- a/contrib/platform/lanl/cray_xc_cle5.2/debug-common
+++ b/contrib/platform/lanl/cray_xc_cle5.2/debug-common
@@ -32,8 +32,5 @@ enable_mca_direct=pml-ob1
 # enable development headers
 with_devel_headers=yes
 
-# enable ptmalloc (enables lazy deregistration)
-with_memory_manager=linux
-
 # disable valgrind
 with_valgrind=no

--- a/contrib/platform/lanl/cray_xc_cle5.2/optimized-common
+++ b/contrib/platform/lanl/cray_xc_cle5.2/optimized-common
@@ -40,8 +40,5 @@ enable_mca_direct=pml-ob1
 # enable development headers
 with_devel_headers=yes
 
-# enable ptmalloc (enables lazy deregistration)
-with_memory_manager=linux
-
 # disable valgrind
 with_valgrind=no

--- a/contrib/platform/lanl/darwin/darwin-common
+++ b/contrib/platform/lanl/darwin/darwin-common
@@ -22,9 +22,6 @@ enable_cxx_exceptions=no
 # Disable components not needed on any TOSS platform
 enable_mca_no_build=carto,crs,filem,routed-linear,snapc,pml-dr,pml-crcp2,pml-crcpw,pml-v,pml-example,crcp,btl-tcp
 
-# Enable malloc hooks for mpi_leave_pinned
-with_memory_manager=linux
-
 # TOSS2 uses slurm
 with_slurm=yes
 with_tm=no

--- a/contrib/platform/lanl/toss/toss-common
+++ b/contrib/platform/lanl/toss/toss-common
@@ -22,9 +22,6 @@ enable_cxx_exceptions=no
 # Disable components not needed on any TOSS platform
 enable_mca_no_build=carto,crs,filem,routed-linear,snapc,pml-dr,pml-crcp2,pml-crcpw,pml-v,pml-example,crcp,btl-tcp
 
-# Enable malloc hooks for mpi_leave_pinned
-with_memory_manager=linux
-
 # TOSS2 uses slurm
 with_slurm=yes
 with_tm=no

--- a/opal/mca/memory/base/memory_base_open.c
+++ b/opal/mca/memory/base/memory_base_open.c
@@ -113,7 +113,7 @@ static int opal_memory_base_open(mca_base_open_flag_t flags)
 #if MEMORY_LINUX_PTMALLOC2
         /* See above comment about linux/ptmalloc2 about why this
            abstraction violation is here. */
-        if (0 == strcmp (tmp->mca_component_name, "linux")) {
+        if (0 == strcmp (tmp->memoryc_version.mca_component_name, "linux")) {
             /* if ptmalloc is enabled always use it */
             priority = 1000000;
         }

--- a/opal/mca/memory/linux/configure.m4
+++ b/opal/mca/memory/linux/configure.m4
@@ -19,7 +19,7 @@
 #
 # $HEADER$
 #
-AC_DEFUN([MCA_opal_memory_linux_PRIORITY], [40])
+AC_DEFUN([MCA_opal_memory_linux_PRIORITY], [41])
 
 AC_DEFUN([MCA_opal_memory_linux_COMPILE_MODE], [
     AC_MSG_CHECKING([for MCA component $2:$3 compile mode])


### PR DESCRIPTION
This is a 2.x specific change. No master equivalent.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

PEBKAC. Wasn't caught by MTT or CI.

:bot:label:bug
:bot:milestone:v2.0.0
:bot:assign: @jsquyres 
