### PR TITLE
ompi/group: fix sparse group proc reference counting

### DIFF
--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -275,7 +275,11 @@ static void ompi_group_destruct(ompi_group_t *group)
        the proc counts are not increased during the constructor,
        either). */
 
-    ompi_group_decrement_proc_count (group);
+#if OMPI_GROUP_SPARSE
+    if (OMPI_GROUP_IS_DENSE(group))
+	/* sparse groups do not increment proc reference counters */
+#endif
+	ompi_group_decrement_proc_count (group);
 
     /* release thegrp_proc_pointers memory */
     if (NULL != group->grp_proc_pointers) {


### PR DESCRIPTION
This commit fixes a bug when sparse groups are in use. Since sparse
group do not actually increment the reference counts of any procs
(they just retain the parent group) it is wrong to decrement the
reference counts of all procs in the group using
ompi_group_decrement_proc_count(). This commit makes the call to
ompi_group_decrement_proc_count() conditional on the group being
dense.

Fixes open-mpi/ompi#1593

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@1783d94f91fba330a7b1fc30fe9cfea9c6b2a85e)

Signed-off-by: Nathan Hjelm hjelmn@me.com

:bot:label:bug
:bot:milestone:v2.0.1
:bot:assign: @ggouaillardet 
