### PR TITLE
Remove a stray print statement

### DIFF
--- a/opal/mca/patcher/base/patcher_base_patch.c
+++ b/opal/mca/patcher/base/patcher_base_patch.c
@@ -146,8 +146,6 @@ int mca_patcher_base_patch_hook (mca_patcher_base_module_t *module, uintptr_t ho
     const unsigned int nop = 0x60000000;
     unsigned int *nop_addr;
 
-    fprintf (stderr, "Patching hook @ 0x%lx\n", hook_addr);
-
     hook_patch = OBJ_NEW(mca_patcher_base_patch_t);
     if (OPAL_UNLIKELY(NULL == hook_patch)) {
         return OPAL_ERR_OUT_OF_RESOURCE;


### PR DESCRIPTION
PowerPC systems were being spammed with this stray print statement.
