### PR TITLE
Allow NULL arrays for empty datatypes.

### DIFF
--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -51,7 +51,7 @@ int32_t ompi_datatype_create_subarray(int ndims,
     /* If the ndims is zero then return the NULL datatype */
     if( ndims < 2 ) {
         if( 0 == ndims ) {
-            *newtype = &ompi_mpi_datatype_null.dt;
+            ompi_datatype_duplicate(&ompi_mpi_datatype_null.dt, newtype);
             return MPI_SUCCESS;
         }
         ompi_datatype_create_contiguous( subsize_array[0], oldtype, &last_type );

--- a/ompi/mpi/c/type_create_darray.c
+++ b/ompi/mpi/c/type_create_darray.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -65,7 +65,8 @@ int MPI_Type_create_darray(int size,
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
         } else if( ndims < 0 ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT, FUNC_NAME);
-        } else if( (NULL == gsize_array) || (NULL == distrib_array) || (NULL == darg_array) || (NULL == psize_array)) {
+        } else if( (ndims > 0) && ((NULL == gsize_array) || (NULL == distrib_array) ||
+                                   (NULL == darg_array) || (NULL == psize_array))) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
         } else if (NULL == newtype) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);

--- a/ompi/mpi/c/type_create_hindexed.c
+++ b/ompi/mpi/c/type_create_hindexed.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -57,8 +57,8 @@ int MPI_Type_create_hindexed(int count,
         if( count < 0 ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT,
                                           FUNC_NAME);
-        } else if (NULL == array_of_blocklengths ||
-                   NULL == array_of_displacements) {
+        } else if ((count > 0) && (NULL == array_of_blocklengths ||
+                                   NULL == array_of_displacements)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                           FUNC_NAME);
         } else if (MPI_DATATYPE_NULL == oldtype || NULL == oldtype ||

--- a/ompi/mpi/c/type_create_subarray.c
+++ b/ompi/mpi/c/type_create_subarray.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -59,7 +59,7 @@ int MPI_Type_create_subarray(int ndims,
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
         if( ndims < 0 ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT, FUNC_NAME);
-        } else if( (NULL == size_array) || (NULL == subsize_array) || (NULL == start_array) ) {
+        } else if( (ndims > 0) && ((NULL == size_array) || (NULL == subsize_array) || (NULL == start_array)) ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
         } else if( (NULL == oldtype) || (MPI_DATATYPE_NULL == oldtype) || (NULL == newtype) ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);

--- a/ompi/mpi/c/type_hindexed.c
+++ b/ompi/mpi/c/type_hindexed.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -57,8 +57,8 @@ int MPI_Type_hindexed(int count,
       } else if (count < 0) {
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT,
                                       FUNC_NAME );
-      } else if (NULL == array_of_blocklengths ||
-                 NULL == array_of_displacements) {
+      } else if ((count > 0) && (NULL == array_of_blocklengths ||
+                                 NULL == array_of_displacements) ) {
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                       FUNC_NAME );
       }

--- a/ompi/mpi/c/type_indexed.c
+++ b/ompi/mpi/c/type_indexed.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -60,8 +60,8 @@ int MPI_Type_indexed(int count,
         } else if( count < 0 ) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT,
                                           FUNC_NAME);
-        } else if (NULL == array_of_blocklengths ||
-                   NULL == array_of_displacements) {
+        } else if ((count > 0) && (NULL == array_of_blocklengths ||
+                                   NULL == array_of_displacements)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                           FUNC_NAME);
         }


### PR DESCRIPTION
When building an empty datatype (aka. size = 0) because the count of
included datatypes is 0, be less strict on what the arguments are
(allow NULL pointers).

(cherry picked from commit open-mpi/ompi@6e6ed62a3c3a58b9352b7ac28418a1504c1baa68)

@bosilca Please review.  Straightforward cherry-pick from master.

@hppritcha I just PR'ed this to v1.10.3, and it apparently solves a user issue (reported by @wkliao in open-mpi/ompi#1611).  I don't have strong feelings as to whether this is in v2.0.0 or v2.0.1, other than the fact that it fixes a user-reported error.  Opinions?
