### PR TITLE
v2.x osc/rdma fixes

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -564,10 +564,11 @@ static void ompi_osc_rdma_cas_get_complete (struct mca_btl_base_module_t *btl, s
     if (OMPI_SUCCESS == status) {
         /* copy data to the user buffer (for gacc) */
         memcpy (request->result_addr, (void *) source, request->len);
-        memcpy ((void *) source, request->origin_addr, request->len);
 
         if (0 == memcmp ((void *) source, request->compare_addr, request->len)) {
             /* the target and compare buffers match so write the source to the target */
+            memcpy ((void *) source, request->origin_addr, request->len);
+
             ret = module->selected_btl->btl_put (module->selected_btl, peer->data_endpoint, local_address,
                                                  request->target_address, local_handle,
                                                  (mca_btl_base_registration_handle_t *) request->ctx,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -845,6 +845,8 @@ static int ompi_osc_rdma_share_data (ompi_osc_rdma_module_t *module)
                                                   module->region_size);
 
             my_data->base = (uint64_t) (intptr_t) module->rank_array;
+            /* store my rank in the length field */
+            my_data->len = (osc_rdma_size_t) my_rank;
 
             if (module->selected_btl->btl_register_mem) {
                 memcpy (my_data->btl_handle_data, module->state_handle, module->selected_btl->btl_registration_handle_size);
@@ -861,9 +863,11 @@ static int ompi_osc_rdma_share_data (ompi_osc_rdma_module_t *module)
                 }
             }
 
+            int base_rank = ompi_comm_rank (module->local_leaders) * ((comm_size + module->node_count - 1) / module->node_count);
+
             /* fill in the local part of the rank -> node map */
             for (int i = 0 ; i < RANK_ARRAY_COUNT(module) ; ++i) {
-                int save_rank = my_rank + i;
+                int save_rank = base_rank + i;
                 if (save_rank >= comm_size) {
                     break;
                 }

--- a/ompi/mca/osc/rdma/osc_rdma_passive_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_passive_target.c
@@ -8,7 +8,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
@@ -197,6 +197,8 @@ int ompi_osc_rdma_lock_atomic (int lock_type, int target, int assert, ompi_win_t
         return OMPI_ERR_RMA_SYNC;
     }
 
+    /* clear the global sync object (in case MPI_Win_fence was called) */
+    module->all_sync.type = OMPI_OSC_RDMA_SYNC_TYPE_NONE;
 
     /* create lock item */
     lock = ompi_osc_rdma_sync_allocate (module);

--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -19,7 +19,7 @@
 
 #include "ompi/mca/bml/base/base.h"
 
-#define NODE_ID_TO_RANK(module, node_id) ((node_id) * ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count))
+#define NODE_ID_TO_RANK(module, peer_data, node_id) ((int)(peer_data)->len)
 
 /**
  * @brief find the btl endpoint for a process
@@ -99,7 +99,7 @@ static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rd
     ompi_osc_rdma_rank_data_t rank_data;
     int registration_handle_size = 0;
     int node_id, node_rank, array_index;
-    int ret, disp_unit;
+    int ret, disp_unit, comm_size;
     char *peer_data;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "configuring peer for rank %d", peer->rank);
@@ -108,13 +108,18 @@ static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rd
         registration_handle_size = module->selected_btl->btl_registration_handle_size;
     }
 
+    comm_size = ompi_comm_size (module->comm);
+
     /* each node is responsible for holding a part of the rank -> node/local rank mapping array. this code
      * calculates the node and offset the mapping can be found. once the mapping has been read the state
      * part of the peer structure can be initialized. */
-    node_id = (peer->rank * module->node_count) / ompi_comm_size (module->comm);
-    node_rank = NODE_ID_TO_RANK(module, node_id);
-    array_index = peer->rank - node_rank;
+    node_id = (peer->rank * module->node_count) / comm_size;
     array_peer_data = (ompi_osc_rdma_region_t *) ((intptr_t) module->node_comm_info + node_id * module->region_size);
+
+    /* the node leader rank is stored in the length field */
+    node_rank = NODE_ID_TO_RANK(module, array_peer_data, node_id);
+    array_index = peer->rank % ((comm_size + module->node_count - 1) / module->node_count);
+
     array_pointer = array_peer_data->base + array_index * sizeof (rank_data);
 
     /* lookup the btl endpoint needed to retrieve the mapping */
@@ -123,8 +128,8 @@ static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rd
         return OMPI_ERR_UNREACH;
     }
 
-    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "reading region data from rank: %d pointer: 0x%" PRIx64
-                     ", size: %lu", node_rank, array_pointer, sizeof (rank_data));
+    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "reading region data for %d from rank: %d, index: %d, pointer: 0x%" PRIx64
+                     ", size: %lu", peer->rank, node_rank, array_index, array_pointer, sizeof (rank_data));
 
     ret = ompi_osc_get_data_blocking (module, array_endpoint, array_pointer, (mca_btl_base_registration_handle_t *) array_peer_data->btl_handle_data,
                                       &rank_data, sizeof (rank_data));
@@ -143,7 +148,7 @@ static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rd
         peer->state_handle = (mca_btl_base_registration_handle_t *) node_peer_data->btl_handle_data;
     }
 
-    peer->state_endpoint = ompi_osc_rdma_peer_btl_endpoint (module, NODE_ID_TO_RANK(module, rank_data.node_id));
+    peer->state_endpoint = ompi_osc_rdma_peer_btl_endpoint (module, NODE_ID_TO_RANK(module, node_peer_data, rank_data.node_id));
     if (OPAL_UNLIKELY(NULL == peer->state_endpoint)) {
         return OPAL_ERR_UNREACH;
     }


### PR DESCRIPTION
This PR fixes a couple of outstanding bugs in osc/rdma:
- Fix global array index calculation when not mapping by core.
- Fix bad synchronization detection when MPI_Win_fence() is used in the same window as MPI_Win_lock(). It is legal to call MPI_Win_lock() in a fence epoch if no communication has occurred. Without this patch the user gets MPI_ERR_RMA_SYNC.

@hppritcha Both fixes are straightforward and would be ok for the next 2.0.0 rc but I am marking this for 2.0.1.

:bot:label:bug
:bot:milestone:v2.0.1
:bot:assign: @artpol84 
