### PR TITLE
linux: actually enable libudev based on the result of AC_CHECK_LIB

### DIFF
--- a/opal/mca/hwloc/hwloc1112/hwloc/NEWS
+++ b/opal/mca/hwloc/hwloc1112/hwloc/NEWS
@@ -17,6 +17,12 @@ bug fixes (and other actions) for each version of hwloc since version
 in v0.9.1).
 
 
+Version 1.11.4
+--------------
+* Fix Linux build with -m32 with respect to libudev.
+  Thanks to Paul Hargrove for reporting the issue.
+
+
 Version 1.11.3
 --------------
 * Fix /proc/mounts parsing on Linux by using mntent.h.

--- a/opal/mca/hwloc/hwloc1112/hwloc/README-ompi.txt
+++ b/opal/mca/hwloc/hwloc1112/hwloc/README-ompi.txt
@@ -1,3 +1,4 @@
 Cherry-picked commits after 1.11.2:
 
 open-mpi/hwloc@d2d07b9a2268699e13e1644b4f2ef7a53ef7396c
+open-mpi/hwloc@9549fd59af04dca2e2340e17f0e685f8c552d818

--- a/opal/mca/hwloc/hwloc1112/hwloc/config/hwloc.m4
+++ b/opal/mca/hwloc/hwloc1112/hwloc/config/hwloc.m4
@@ -714,7 +714,10 @@ EOF])
     # Linux libudev support
     if test "x$enable_libudev" != xno; then
       AC_CHECK_HEADERS([libudev.h], [
-	AC_CHECK_LIB([udev], [udev_device_new_from_subsystem_sysname], [HWLOC_LIBS="$HWLOC_LIBS -ludev"])
+	AC_CHECK_LIB([udev], [udev_device_new_from_subsystem_sysname], [
+	  HWLOC_LIBS="$HWLOC_LIBS -ludev"
+	  AC_DEFINE([HWLOC_HAVE_LIBUDEV], [1], [Define to 1 if you have libudev.])
+	])
       ])
     fi
 

--- a/opal/mca/hwloc/hwloc1112/hwloc/src/topology-linux.c
+++ b/opal/mca/hwloc/hwloc1112/hwloc/src/topology-linux.c
@@ -27,7 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_LIBUDEV_H
+#ifdef HWLOC_HAVE_LIBUDEV
 #include <libudev.h>
 #endif
 #include <sys/types.h>
@@ -46,7 +46,7 @@ struct hwloc_linux_backend_data_s {
   char *root_path; /* NULL if unused */
   int root_fd; /* The file descriptor for the file system root, used when browsing, e.g., Linux' sysfs and procfs. */
   int is_real_fsroot; /* Boolean saying whether root_fd points to the real filesystem root of the system */
-#ifdef HAVE_LIBUDEV_H
+#ifdef HWLOC_HAVE_LIBUDEV
   struct udev *udev; /* Global udev context */
 #endif
   char *dumped_hwdata_dirname;
@@ -4596,7 +4596,7 @@ hwloc_linux_block_class_fillinfos(struct hwloc_backend *backend,
     *tmp = '\0';
   hwloc_obj_add_info(obj, "LinuxDeviceID", line);
 
-#ifdef HAVE_LIBUDEV_H
+#ifdef HWLOC_HAVE_LIBUDEV
   if (data->udev) {
     struct udev_device *dev;
     const char *prop;
@@ -5106,7 +5106,7 @@ hwloc_linux_backend_disable(struct hwloc_backend *backend)
     free(data->root_path);
   close(data->root_fd);
 #endif
-#ifdef HAVE_LIBUDEV_H
+#ifdef HWLOC_HAVE_LIBUDEV
   if (data->udev)
     udev_unref(data->udev);
 #endif
@@ -5177,7 +5177,7 @@ hwloc_linux_component_instantiate(struct hwloc_disc_component *component,
 #endif
   data->root_fd = root;
 
-#ifdef HAVE_LIBUDEV_H
+#ifdef HWLOC_HAVE_LIBUDEV
   data->udev = NULL;
   if (data->is_real_fsroot) {
     data->udev = udev_new();


### PR DESCRIPTION
instead of doing AC_CHECK_HEADERS+AC_CHECK_LIB and only using the result of the former.

Thanks to Paul Hargrove for reporting the issue (OMPI build with -m32).

(cherry picked from open-mpi/hwloc@9549fd59af04dca2e2340e17f0e685f8c552d818)
(cherry picked from commit open-mpi/ompi@a2a721f961e50f9c62a877214f76c4ef81a05e70)

Reviewed by @jsquyres
