### PR TITLE
osc_rdma_peer: properly include ompi_config.h

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -4,12 +4,15 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
  *
  * $HEADER$
  */
+
+#include "ompi_config.h"
 
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>


### PR DESCRIPTION
Thanks to Paul Hargrove for reporting.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@33dd8ca81e83c500b5c0aa583eaa4bdc46bf954a)

This fixes the issue reported by @PHHargrove: http://www.open-mpi.org/community/lists/devel/2016/05/18873.php

@hjelmn Please review; trivial addition of `ompi_config.h`.
