### PR TITLE
fix ompio compilation problems on netbsd

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -78,9 +78,6 @@ int mca_fs_lustre_component_init_query(bool enable_progress_threads,
 struct mca_fs_base_module_1_0_0_t *
 mca_fs_lustre_component_file_query (mca_io_ompio_file_t *fh, int *priority)
 {
-    int err;
-    char *dir;
-    struct statfs fsbuf;
     char *tmp;
 
     /* The code in this function is based on the ADIO FS selection in ROMIO

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -81,9 +81,6 @@ mca_fs_pvfs2_component_file_query (mca_io_ompio_file_t *fh, int *priority)
      *   See COPYRIGHT notice in top-level directory.
      */
 
-    int err;
-    char *dir;
-    struct statfs fsbuf;
     char *tmp;
 
     /* The code in this function is based on the ADIO FS selection in ROMIO

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -270,9 +270,6 @@ file_query(struct ompi_file_t *file,
            int *priority)
 {
     mca_io_ompio_data_t *data;
-    int err;
-    char *dir;
-    struct statfs fsbuf;
     char *tmp;
     int rank;
     int is_lustre=0; //false


### PR DESCRIPTION
remove unused variables that lead to compilation problems on netbsd

Thanks to Paul Hargrove for reporting
This fixes the issue reported by @PHHargrove:  http://www.open-mpi.org/community/lists/devel/2016/05/18890.php

bot:milestone:v2.0.0
bot:label:bug
