### PR TITLE
Improve the transport key print statement to ensure that we don't get zero fields as this can be a problem for PSM

### DIFF
--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -186,6 +186,9 @@ static int rte_init(void)
             ORTE_ERROR_LOG(ORTE_ERR_OUT_OF_RESOURCE);
             return ORTE_ERR_OUT_OF_RESOURCE;
         }
+        opal_output_verbose(2, orte_ess_base_framework.framework_output,
+                            "%s transport key %s",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), string_key);
         asprintf(&envar, OPAL_MCA_PREFIX"orte_precondition_transports=%s", string_key);
         putenv(envar);
         added_transport_keys = true;

--- a/orte/util/pre_condition_transports.c
+++ b/orte/util/pre_condition_transports.c
@@ -64,7 +64,7 @@ static inline void orte_pre_condition_transports_use_rand(uint64_t* unique_key) 
 char* orte_pre_condition_transports_print(uint64_t *unique_key)
 {
     unsigned int *int_ptr;
-    size_t i, string_key_len, written_len;
+    size_t i, j, string_key_len, written_len;
     char *string_key = NULL, *format = NULL;
 
     /* string is two 64 bit numbers printed in hex with a dash between
@@ -92,6 +92,12 @@ char* orte_pre_condition_transports_print(uint64_t *unique_key)
     /* print the first number */
     int_ptr = (unsigned int*) &unique_key[0];
     for (i = 0 ; i < sizeof(uint64_t) / sizeof(unsigned int) ; ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j=0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
         snprintf(string_key + written_len,
                  string_key_len - written_len,
                  format, int_ptr[i]);
@@ -105,6 +111,12 @@ char* orte_pre_condition_transports_print(uint64_t *unique_key)
     /* print the second number */
     int_ptr = (unsigned int*) &unique_key[1];
     for (i = 0 ; i < sizeof(uint64_t) / sizeof(unsigned int) ; ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j=0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
         snprintf(string_key + written_len,
                  string_key_len - written_len,
                  format, int_ptr[i]);


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@29bc24bdd503ced62ad40465085a1cb0249e26b0)
