### PR TITLE
asm/powerpc: Fix empty colon list in asm for XL compiler on power

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -147,7 +147,7 @@ static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
    __asm__ __volatile__ ("lwarx   %0, 0, %1  \n\t"
                          : "=&r" (ret)
                          : "r" (addr)
-                         :);
+                         );
    return ret;
 }
 


### PR DESCRIPTION
Thanks to Paul Hargrove for reporting the problem, and submitting patch.
- https://www.open-mpi.org/community/lists/devel/2016/05/18886.php

(cherry picked from commit 788cf1a9feeeac5a535328e93a8d0e44df7b44e8)
