### PR TITLE
PSM and PSM2 MTLs to detect drivers and link

### DIFF
--- a/config/ompi_check_psm.m4
+++ b/config/ompi_check_psm.m4
@@ -64,6 +64,13 @@ AC_DEFUN([OMPI_CHECK_PSM],[
            ompi_check_psm_happy="no"])
 
     AS_IF([test "$ompi_check_psm_happy" = "yes"],
+          [AC_CHECK_HEADERS(
+                glob.h,
+                    [],
+                    [AC_MSG_WARN([glob.h not found.  Can not build component.])
+                    ompi_check_psm_happy="no"])])
+
+    AS_IF([test "$ompi_check_psm_happy" = "yes"],
           [$2],
           [AS_IF([test ! -z "$with_psm" -a "$with_psm" != "no"],
                  [AC_MSG_ERROR([PSM support requested but not found.  Aborting])])

--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
 # Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2014      Intel Corporation. All rights reserved.
+# Copyright (c) 2016      Intel Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -64,6 +64,14 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
           [AC_MSG_WARN([PSM2 driver does not currently support progress threads.  Disabling MTL.])
            ompi_check_psm2_happy="no"])
 
+    AS_IF([test "$ompi_check_psm2_happy" = "yes"],
+          [AC_CHECK_HEADERS(
+                glob.h,
+                    [],
+                    [AC_MSG_WARN([glob.h not found.  Can not build component.])
+                    ompi_check_psm2_happy="no"])])
+	
+	
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],
           [$2],
           [AS_IF([test ! -z "$with_psm2" -a "$with_psm2" != "no"],

--- a/ompi/mca/mtl/psm/mtl_psm_component.c
+++ b/ompi/mca/mtl/psm/mtl_psm_component.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2010 QLogic Corporation. All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel Corporation. All rights reserved.
+ * Copyright (c) 2016      Intel Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <glob.h>
 
 static int param_priority;
 
@@ -185,12 +186,41 @@ ompi_mtl_psm_component_open(void)
     }
 
   /* Component available only if Truescale hardware is present */
-  if (0 == stat("/dev/ipath", &st)) {
-    return OMPI_SUCCESS;
-  }
-  else {
+  if (0 != stat("/dev/ipath", &st)) {
     return OPAL_ERR_NOT_AVAILABLE;
   }
+
+  /* Component available only if at least one qib port is ACTIVE */
+  bool foundOnlineQibPort = false;
+  size_t i;
+  char portState[128];
+  FILE *devFile;
+  glob_t globbuf;
+  globbuf.gl_offs = 0;
+  if (glob("/sys/class/infiniband/qib*/ports/*/state",
+        GLOB_DOOFFS, NULL, &globbuf) != 0) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  for (i=0;i < globbuf.gl_pathc; i++) {
+    devFile = fopen(globbuf.gl_pathv[i], "r");
+    fgets(portState, sizeof(portState), devFile);
+    fclose(devFile);
+
+    if (strstr(portState, "ACTIVE") != NULL) {
+      /* Found at least one ACTIVE port */
+      foundOnlineQibPort = true;
+      break;
+    }
+  }
+
+  globfree(&globbuf);
+
+  if (!foundOnlineQibPort) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  return OMPI_SUCCESS;
 }
 
 static int

--- a/ompi/mca/mtl/psm/mtl_psm_component.c
+++ b/ompi/mca/mtl/psm/mtl_psm_component.c
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <glob.h>
 
 static int param_priority;
 
@@ -185,12 +186,41 @@ ompi_mtl_psm_component_open(void)
     }
 
   /* Component available only if Truescale hardware is present */
-  if (0 == stat("/dev/ipath", &st)) {
-    return OMPI_SUCCESS;
-  }
-  else {
+  if (0 != stat("/dev/ipath", &st)) {
     return OPAL_ERR_NOT_AVAILABLE;
   }
+
+  /* Component available only if at least one qib port is ACTIVE */
+  bool foundOnlineQibPort = false;
+  size_t i;
+  char portState[128];
+  FILE *devFile;
+  glob_t globbuf;
+  globbuf.gl_offs = 0;
+  if (glob("/sys/class/infiniband/qib*/ports/*/state",
+        GLOB_DOOFFS, NULL, &globbuf) != 0) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  for (i=0;i < globbuf.gl_pathc; i++) {
+    devFile = fopen(globbuf.gl_pathv[i], "r");
+    fgets(portState, sizeof(portState), devFile);
+    fclose(devFile);
+
+    if (strstr(portState, "ACTIVE") != NULL) {
+      /* Found at least one ACTIVE port */
+      foundOnlineQibPort = true;
+      break;
+    }
+  }
+
+  globfree(&globbuf);
+
+  if (!foundOnlineQibPort) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  return OMPI_SUCCESS;
 }
 
 static int

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2006-2010 QLogic Corporation. All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <glob.h>
 
 static int param_priority;
 
@@ -102,15 +103,46 @@ ompi_mtl_psm2_component_register(void)
 static int
 ompi_mtl_psm2_component_open(void)
 {
-  struct stat st;
+  glob_t globbuf;
+  globbuf.gl_offs = 0;
 
   /* Component available only if Omni-Path hardware is present */
-  if (0 == stat("/dev/hfi1", &st)) {
-    return OMPI_SUCCESS;
-  }
-  else {
+  if ((glob("/dev/hfi1_[0-9]", GLOB_DOOFFS, NULL, &globbuf) != 0) &&
+      (glob("/dev/hfi1_[0-9][0-9]", GLOB_APPEND, NULL, &globbuf) != 0)) {
     return OPAL_ERR_NOT_AVAILABLE;
   }
+
+  globfree(&globbuf);
+
+  /* Component available only if at least one hfi1 port is ACTIVE */
+  bool foundOnlineHfi1Port = false;
+  size_t i;
+  char portState[128];
+  FILE *devFile;
+  if (glob("/sys/class/infiniband/hfi1_*/ports/*/state",
+        GLOB_DOOFFS, NULL, &globbuf) != 0) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  for (i=0;i < globbuf.gl_pathc; i++) {
+    devFile = fopen(globbuf.gl_pathv[i], "r");
+    fgets(portState, sizeof(portState), devFile);
+    fclose(devFile);
+
+    if (strstr(portState, "ACTIVE") != NULL) {
+      /* Found at least one ACTIVE port */
+      foundOnlineHfi1Port = true;
+      break;
+    }
+  }
+
+  globfree(&globbuf);
+
+  if (!foundOnlineHfi1Port) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  return OMPI_SUCCESS;
 }
 
 static int

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <glob.h>
 
 static int param_priority;
 
@@ -102,15 +103,46 @@ ompi_mtl_psm2_component_register(void)
 static int
 ompi_mtl_psm2_component_open(void)
 {
-  struct stat st;
+  glob_t globbuf;
+  globbuf.gl_offs = 0;
 
   /* Component available only if Omni-Path hardware is present */
-  if (0 == stat("/dev/hfi1", &st)) {
-    return OMPI_SUCCESS;
-  }
-  else {
+  if ((glob("/dev/hfi1_[0-9]", GLOB_DOOFFS, NULL, &globbuf) != 0) &&
+      (glob("/dev/hfi1_[0-9][0-9]", GLOB_APPEND, NULL, &globbuf) != 0)) {
     return OPAL_ERR_NOT_AVAILABLE;
   }
+
+  globfree(&globbuf);
+
+  /* Component available only if at least one hfi1 port is ACTIVE */
+  bool foundOnlineHfi1Port = false;
+  size_t i;
+  char portState[128];
+  FILE *devFile;
+  if (glob("/sys/class/infiniband/hfi1_*/ports/*/state",
+        GLOB_DOOFFS, NULL, &globbuf) != 0) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  for (i=0;i < globbuf.gl_pathc; i++) {
+    devFile = fopen(globbuf.gl_pathv[i], "r");
+    fgets(portState, sizeof(portState), devFile);
+    fclose(devFile);
+
+    if (strstr(portState, "ACTIVE") != NULL) {
+      /* Found at least one ACTIVE port */
+      foundOnlineHfi1Port = true;
+      break;
+    }
+  }
+
+  globfree(&globbuf);
+
+  if (!foundOnlineHfi1Port) {
+    return OPAL_ERR_NOT_AVAILABLE;
+  }
+
+  return OMPI_SUCCESS;
 }
 
 static int


### PR DESCRIPTION
Update in PSM and PSM2 MTLs to detect  entries created by drivers for
Intel TrueScale and Intel OmniPath, and detect a link in ACTIVE state.
This fix addresses the scenario reported in the below OMPI users email,
including formerly named Qlogic IB, now Intel True scale. Given the
nature of the PSM/PSM2 mtls this fix applies to OmniPath:
https://www.open-mpi.org/community/lists/users/2016/04/29018.php
