### PR TITLE
autogen: patch configure in order to correctly detect Solaris Studio …

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -5,7 +5,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      IBM Corporation.  All rights reserved.
 #
@@ -976,6 +976,12 @@ sub patch_autotools_output {
         push(@verbose_out, $indent_str . "Patching configure for Sun Studio Fortran version strings ($tag)\n");
         $c =~ s/$search_string/$replace_string/;
     }
+
+    # Oracle has apparently begun (as of 12.5-beta) removing the "Sun" branding.
+    # So this patch (cumulative over the previous one) is required.
+    push(@verbose_out, $indent_str . "Patching configure for Oracle Studio Fortran version strings\n");
+    $c =~ s/\*Sun\*Fortran\*\)/*Sun*Fortran* | *Studio*Fortran*)/g;
+    $c =~ s/\*Sun\\ F\*\)(.*\n\s+tmp_sharedflag=)/*Sun\\ F* | *Studio*Fortran*)$1/g;
 
     # See http://git.savannah.gnu.org/cgit/libtool.git/commit/?id=v2.2.6-201-g519bf91 for details
     # Note that this issue was fixed in LT 2.2.8, however most distros are still using 2.2.6b


### PR DESCRIPTION
…12.5 beta compilers

previously: f90: Sun Fortran 95 8.7 Linux_i386 2014/10/20
now : Studio 12.5 Fortran 95 8.8 Linux_i386 Beta 2015/11/17
note the "Sun" branding has gone

Thanks Paul Hargrove for the report and the patch

(cherry picked from commit open-mpi/ompi@ef3ee027b07fa8cd447e4fffec56ecfe3332548e)
