### PR TITLE
v2.0.0: hwloc/external: set WRAPPER_EXTRA_* vars in proper location

### DIFF
--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 #
@@ -67,16 +67,6 @@ AC_DEFUN([MCA_opal_hwloc_external_POST_CONFIG],[
            AC_DEFINE_UNQUOTED(MCA_hwloc_external_openfabrics_header,
                   ["$opal_hwloc_dir/include/hwloc/openfabrics-verbs.h"],
                   [Location of external hwloc header])
-
-           # These flags need to get passed to the wrapper compilers
-           # (this is unnecessary for the internal/embedded hwloc)
-
-           # Finally, add some flags to the wrapper compiler if we're
-           # building with developer headers so that our headers can
-           # be found.
-           hwloc_external_WRAPPER_EXTRA_CPPFLAGS=$opal_hwloc_external_CPPFLAGS
-           hwloc_external_WRAPPER_EXTRA_LDFLAGS=$opal_hwloc_external_LDFLAGS
-           hwloc_external_WRAPPER_EXTRA_LIBS=$opal_hwloc_external_LIBS
           ])
     OPAL_VAR_SCOPE_POP
 ])dnl
@@ -183,6 +173,17 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                 AC_MSG_ERROR([Cannot continue])])
            AS_IF([test "$opal_hwloc_dir" != ""],
                  [CFLAGS=$opal_hwloc_external_CFLAGS_save])
+
+           # These flags need to get passed to the wrapper compilers
+           # (this is unnecessary for the internal/embedded hwloc)
+
+           # Finally, add some flags to the wrapper compiler if we're
+           # building with developer headers so that our headers can
+           # be found.
+           hwloc_external_WRAPPER_EXTRA_CPPFLAGS=$opal_hwloc_external_CPPFLAGS
+           hwloc_external_WRAPPER_EXTRA_LDFLAGS=$opal_hwloc_external_LDFLAGS
+           hwloc_external_WRAPPER_EXTRA_LIBS=$opal_hwloc_external_LIBS
+
            $1],
           [$2])
 


### PR DESCRIPTION
WRAPPER_EXTRA flags are checked _before_ the POST_CONFIG macro is
invoked.  So set them in the main CONFIG macro.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@eccf0ff4cd759aed8eb185d66c1cde5431e4e372)

@rhc54 please review
