### PR TITLE
pmix/external: Remove non-existent header reference

### DIFF
--- a/opal/mca/pmix/external/pmix_ext_client.c
+++ b/opal/mca/pmix/external/pmix_ext_client.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +31,6 @@
 #include "opal/mca/pmix/base/base.h"
 #include "pmix_ext.h"
 #include "pmix.h"
-#include "pmix/src/buffer_ops/buffer_ops.h"
 
 static pmix_proc_t my_proc;
 static char *dbgvalue=NULL;


### PR DESCRIPTION
This header file is not installed when installing pmix. This causes the build to fail when building pmix 1.1.4rc2.
