### PR TITLE
btl/openib: fix error path in init_one_device()

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -2184,19 +2184,6 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
     }
 
 error:
-#if OPAL_ENABLE_PROGRESS_THREADS
-    if (device->ib_channel) {
-        ibv_destroy_comp_channel(device->ib_channel);
-    }
-#endif
-    if (device->mpool) {
-        mca_mpool_base_module_destroy(device->mpool);
-    }
-
-    if (device->ib_pd) {
-        ibv_dealloc_pd(device->ib_pd);
-    }
-
     if (OPAL_SUCCESS != ret) {
         opal_show_help("help-mpi-btl-openib.txt",
                        "error in device init", true,
@@ -2204,9 +2191,6 @@ error:
                        ibv_get_device_name(device->ib_dev));
     }
 
-    if (device->ib_dev_context) {
-        ibv_close_device(device->ib_dev_context);
-    }
     if (NULL != allowed_ports) {
         free(allowed_ports);
     }


### PR DESCRIPTION
do not explicitly release ib verbs components since they will
be released in the object destructor

Thanks Durga for the report

(cherry picked from commit open-mpi/ompi@456b73da696ab69e88d36f6a72391b41b81c2792)
