### PR TITLE
memory/patcher: declare __curbrk as extern in order not to generate a…

### DIFF
--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -247,7 +247,7 @@ static int intercept_madvise (void *start, size_t length, int advice)
 #if defined SYS_brk
 
 #if OPAL_MEMORY_PATCHER_HAVE___CURBRK
-void *__curbrk; /* in libc */
+extern void *__curbrk; /* in libc */
 #endif
 
 static int (*original_brk) (void *);


### PR DESCRIPTION
…n (unitialized) common symbol

(cherry picked from commit open-mpi/ompi@4e21933a74fe8f2f0b05ac4b07139dabd6bba52c)
