### PR TITLE
Revert "mtl/ofi: Increase priority."

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -56,7 +56,7 @@ mca_mtl_ofi_component_t mca_mtl_ofi_component = {
 static int
 ompi_mtl_ofi_component_register(void)
 {
-    param_priority = 25;   /* for now give a lower priority than the psm mtl */
+    param_priority = 10;   /* for now give a lower priority than the psm mtl and ob1 */
     mca_base_component_var_register(&mca_mtl_ofi_component.super.mtl_version,
                                     "priority", "Priority of the OFI MTL component",
                                     MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,


### PR DESCRIPTION
This should never have gone into 2.0.0. The ofi provider's priority should
never be higher than ob1 if verbs or sockets is the provider.

This reverts commit 1b5637d5a3834a1761025f7b24690e3115e9a168.

Fixes open-mpi/ompi#1676
