### PR TITLE
rcache: fix deadlock in multi-threaded environments

### DIFF
--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
@@ -528,6 +528,17 @@ static void mca_btl_vader_endpoint_constructor (mca_btl_vader_endpoint_t *ep)
     ep->fifo = NULL;
 }
 
+#if OPAL_BTL_VADER_HAVE_XPMEM
+static int mca_btl_vader_endpoint_rcache_cleanup (mca_mpool_base_registration_t *reg, void *ctx)
+{
+    struct mca_rcache_base_module_t *rcache = (struct mca_rcache_base_module_t *) ctx;
+    /* otherwise dereg will fail on assert */
+    reg->ref_count = 0;
+    (void) rcache->rcache_delete (rcache, reg);
+    return OPAL_SUCCESS;
+}
+#endif
+
 static void mca_btl_vader_endpoint_destructor (mca_btl_vader_endpoint_t *ep)
 {
     OBJ_DESTRUCT(&ep->pending_frags);
@@ -537,21 +548,10 @@ static void mca_btl_vader_endpoint_destructor (mca_btl_vader_endpoint_t *ep)
     if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
         if (ep->segment_data.xpmem.rcache) {
             /* clean out the registration cache */
-            const int nregs = 100;
-            mca_mpool_base_registration_t *regs[nregs];
-            int reg_cnt;
-
-            do {
-                reg_cnt = ep->segment_data.xpmem.rcache->rcache_find_all(ep->segment_data.xpmem.rcache, 0, (size_t)-1,
-                                                                          regs, nregs);
-
-                for (int i = 0 ; i < reg_cnt ; ++i) {
-                    /* otherwise dereg will fail on assert */
-                    regs[i]->ref_count = 0;
-                    OBJ_RELEASE(regs[i]);
-                }
-            } while (reg_cnt == nregs);
-
+            (void) ep->segment_data.xpmem.rcache->rcache_iterate (ep->segment_data.xpmem.rcache,
+                                                                  NULL, (size_t) -1,
+                                                                  mca_btl_vader_endpoint_rcache_cleanup,
+                                                                  (void *) ep->segment_data.xpmem.rcache);
             ep->segment_data.xpmem.rcache = NULL;
         }
 

--- a/opal/mca/mpool/grdma/mpool_grdma.h
+++ b/opal/mca/mpool/grdma/mpool_grdma.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Voltaire. All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -28,6 +28,7 @@
 
 #include "opal_config.h"
 #include "opal/class/opal_list.h"
+#include "opal/class/opal_lifo.h"
 #include "opal/mca/event/event.h"
 #include "opal/mca/mpool/mpool.h"
 #if HAVE_SYS_MMAN_H
@@ -42,7 +43,7 @@ struct mca_mpool_grdma_pool_t {
     opal_list_item_t super;
     char *pool_name;
     opal_list_t lru_list;
-    opal_list_t gc_list;
+    opal_lifo_t gc_lifo;
     struct mca_rcache_base_module_t *rcache;
 };
 typedef struct mca_mpool_grdma_pool_t mca_mpool_grdma_pool_t;

--- a/opal/mca/rcache/rcache.h
+++ b/opal/mca/rcache/rcache.h
@@ -59,6 +59,10 @@ typedef int (*mca_rcache_base_module_clean_fn_t)(
 typedef void (*mca_rcache_base_module_dump_range_fn_t)(
         struct mca_rcache_base_module_t* rcache, unsigned char* addr, size_t size, char *msg);
 
+typedef int (*mca_rcache_base_module_iterate_fn_t)(
+        struct mca_rcache_base_module_t* rcache, unsigned char *base, size_t size,
+        int (*callback_fn) (mca_mpool_base_registration_t *, void *), void *ctx);
+
 /**
   * finalize
   */
@@ -93,6 +97,7 @@ struct mca_rcache_base_module_t {
     mca_rcache_base_module_clean_fn_t rcache_clean;
     mca_rcache_base_module_finalize_fn_t rcache_finalize;
     mca_rcache_base_module_dump_range_fn_t rcache_dump_range;
+    mca_rcache_base_module_iterate_fn_t rcache_iterate;
     opal_mutex_t lock;
 };
 typedef struct mca_rcache_base_module_t mca_rcache_base_module_t;

--- a/opal/mca/rcache/vma/rcache_vma.c
+++ b/opal/mca/rcache/vma/rcache_vma.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -39,9 +42,9 @@ void mca_rcache_vma_module_init( mca_rcache_vma_module_t* rcache ) {
     rcache->base.rcache_find_all = mca_rcache_vma_find_all;
     rcache->base.rcache_insert = mca_rcache_vma_insert;
     rcache->base.rcache_delete = mca_rcache_vma_delete;
-    rcache->base.rcache_clean = mca_rcache_vma_clean;
     rcache->base.rcache_finalize = mca_rcache_vma_finalize;
     rcache->base.rcache_dump_range = mca_rcache_vma_dump_range;
+    rcache->base.rcache_iterate = mca_rcache_vma_iterate;
     OBJ_CONSTRUCT(&rcache->base.lock, opal_recursive_mutex_t);
     mca_rcache_vma_tree_init(rcache);
 }
@@ -139,29 +142,13 @@ int mca_rcache_vma_delete(struct mca_rcache_base_module_t* rcache,
     return mca_rcache_vma_tree_delete(vma_rcache, reg);
 }
 
-int mca_rcache_vma_clean(struct mca_rcache_base_module_t* rcache)
+int mca_rcache_vma_iterate (struct mca_rcache_base_module_t* rcache,
+                            unsigned char *base, size_t size,
+                            int (*callback_fn) (mca_mpool_base_registration_t *, void *),
+                            void *ctx)
 {
     mca_rcache_vma_module_t *vma_rcache = (mca_rcache_vma_module_t*)rcache;
-    mca_rcache_vma_t *vma;
-    opal_list_item_t *i;
-
-    do {
-	OPAL_THREAD_LOCK(&rcache->lock);
-	i = opal_list_get_first(&vma_rcache->vma_delete_list);
-	if(opal_list_get_end(&vma_rcache->vma_delete_list) == i) {
-	    vma = NULL;
-	    OPAL_THREAD_UNLOCK(&rcache->lock);
-	} else {
-	    vma = (mca_rcache_vma_t *)i;
-	    opal_list_remove_item(&vma_rcache->vma_delete_list, &vma->super);
-
-	    /* Need to drop the rcache lock before destroying the vma */
-	    OPAL_THREAD_UNLOCK(&rcache->lock);
-
-	    mca_rcache_vma_destroy(vma);
-	}
-    } while (NULL != vma);
-    return OPAL_SUCCESS;
+    return mca_rcache_vma_tree_iterate (vma_rcache, base, size, callback_fn, ctx);
 }
 
 /**

--- a/opal/mca/rcache/vma/rcache_vma_tree.h
+++ b/opal/mca/rcache/vma/rcache_vma_tree.h
@@ -1,26 +1,28 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
-/**
-  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
-  *                         University Research and Technology
-  *                         Corporation.  All rights reserved.
-  * Copyright (c) 2004-2007 The University of Tennessee and The University
-  *                         of Tennessee Research Foundation.  All rights
-  *                         reserved.
-  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
-  *                         University of Stuttgart.  All rights reserved.
-  * Copyright (c) 2004-2005 The Regents of the University of California.
-  *                         All rights reserved.
-  *
-  * Copyright (c) 2006      Voltaire. All rights reserved.
-  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
-  *
-  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
-  * $COPYRIGHT$
-  *
-  * Additional copyrights may follow
-  *
-  * $HEADER$
-  */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ *
+ * Copyright (c) 2006      Voltaire. All rights reserved.
+ * Copyright (c) 2009      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ *
+ * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
 /**
   * @file
   * Description of the Registration Cache framework
@@ -110,6 +112,15 @@ void mca_rcache_vma_destroy(mca_rcache_vma_t *vma);
  */
 void mca_rcache_vma_tree_dump_range(mca_rcache_vma_module_t *vma_rcache,
                                     unsigned char *base, size_t size, char *msg);
+
+
+/*
+ * Iterate over matching registration handles in the tree.
+ */
+int mca_rcache_vma_tree_iterate (mca_rcache_vma_module_t *vma_module,
+                                 unsigned char *base, size_t size,
+                                 int (*callback_fn) (mca_mpool_base_registration_t *, void *),
+                                 void *ctx);
 
 
 #endif /* MCA_RCACHE_VMA_TREE_H */


### PR DESCRIPTION
This commit fixes several bugs in the registration cache code:
- Fix a programming error in the grdma invalidation function that can
  cause an infinite loop if more than 100 registrations are
  associated with a munmapped region. This happens because the
  mca_rcache_base_vma_find_all function returns the same 100
  registrations on each call. This has been fixed by adding an
  iterate function to the vma tree interface.
- Always obtain the vma lock when needed. This is required because
  there may be other threads in the system even if
  opal_using_threads() is false. Additionally, since it is safe to do
  so (the vma lock is recursive) the vma interface has been made
  thread safe.
- Avoid calling free() while holding a lock. This avoids race
  conditions with locks held outside the Open MPI code.

Back-port of open-mpi/ompi@ab8ed177f503d3c550b51ad981266f40ff53b610

Fixes open-mpi/ompi#1654.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
