### PR TITLE
Unlock the mutex prior to destructing it.

### DIFF
--- a/ompi/mca/rte/orte/rte_orte_component.c
+++ b/ompi/mca/rte/orte/rte_orte_component.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
@@ -83,6 +83,7 @@ static int rte_orte_close(void)
 {
     opal_mutex_lock(&mca_rte_orte_component.lock);
     OPAL_LIST_DESTRUCT(&mca_rte_orte_component.modx_reqs);
+    opal_mutex_unlock(&mca_rte_orte_component.lock);
     OBJ_DESTRUCT(&mca_rte_orte_component.lock);
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
Thanks to Nicolas Joly for the report

(cherry picked from commit open-mpi/ompi@a35bb8453a40333bd45c1e22d6022d6e79f6a15d)

@jsquyres Same as for 1.10
