### PR TITLE
bml/r2: always add btl progress function

### DIFF
--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -165,22 +165,30 @@ static mca_bml_base_endpoint_t *mca_bml_r2_allocate_endpoint (ompi_proc_t *proc)
     return bml_endpoint;
 }
 
-static void mca_bml_r2_register_progress (mca_btl_base_module_t *btl)
+static void mca_bml_r2_register_progress (mca_btl_base_module_t *btl, bool hp)
 {
     if (NULL != btl->btl_component->btl_progress) {
         bool found = false;
+        size_t p;
 
-        for (size_t p = 0 ; p < mca_bml_r2.num_btl_progress ; ++p) {
+        for (p = 0 ; p < mca_bml_r2.num_btl_progress ; ++p) {
             if(mca_bml_r2.btl_progress[p] == btl->btl_component->btl_progress) {
                 found = true;
                 break;
             }
         }
 
-        if (found == false) {
-            mca_bml_r2.btl_progress[mca_bml_r2.num_btl_progress++] =
-                btl->btl_component->btl_progress;
-            opal_progress_register (btl->btl_component->btl_progress);
+        if (found == false || hp) {
+            if (found == false) {
+                mca_bml_r2.btl_progress[mca_bml_r2.num_btl_progress++] =
+                    btl->btl_component->btl_progress;
+            }
+
+            if (hp) {
+                opal_progress_register (btl->btl_component->btl_progress);
+            } else {
+                opal_progress_register_lp (btl->btl_component->btl_progress);
+            }
         }
     }
 }
@@ -403,7 +411,7 @@ static int mca_bml_r2_add_proc (struct ompi_proc_t *proc)
         if (OMPI_SUCCESS != rc) {
             btl->btl_del_procs (btl, 1, (opal_proc_t **) &proc, &btl_endpoint);
         } else {
-            mca_bml_r2_register_progress (btl);
+            mca_bml_r2_register_progress (btl, true);
             btl_in_use = true;
         }
     }
@@ -546,9 +554,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
             btl_inuse++;
         }
 
-        if (btl_inuse) {
-            mca_bml_r2_register_progress (btl);
-        }
+        mca_bml_r2_register_progress (btl, !!(btl_inuse));
     }
 
     free(btl_endpoints);

--- a/opal/runtime/opal_params.h
+++ b/opal/runtime/opal_params.h
@@ -73,6 +73,12 @@ OPAL_DECLSPEC extern bool opal_abort_print_stack;
  */
 OPAL_DECLSPEC extern int opal_abort_delay;
 
+/**
+ * Ratio of calls to high-priority to low-priority progress functions.
+ * Must be a power of two.
+ */
+OPAL_DECLSPEC extern unsigned int opal_progress_lp_call_ratio;
+
 #if OPAL_ENABLE_DEBUG
 extern bool opal_progress_debug;
 #endif

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -94,7 +94,7 @@ static int debug_output = -1;
  */
 static int fake_cb(void) { return 0; }
 
-static int _opal_progress_unregister (opal_progress_callback_t cb, opal_progress_callback_t *callback_array,
+static int _opal_progress_unregister (opal_progress_callback_t cb, volatile opal_progress_callback_t *callback_array,
                                       size_t *callback_array_len);
 
 /* init the progress engine - called from orte_init */
@@ -122,8 +122,8 @@ opal_progress_init(void)
     callbacks_lp = malloc (callbacks_lp_size * sizeof (callbacks_lp[0]));
 
     if (NULL == callbacks || NULL == callbacks_lp) {
-        free (callbacks);
-        free (callbacks_lp);
+        free ((void *) callbacks);
+        free ((void *) callbacks_lp);
         callbacks_size = callbacks_lp_size = 0;
         callbacks = callbacks_lp = NULL;
         return OPAL_ERR_OUT_OF_RESOURCE;
@@ -158,12 +158,12 @@ opal_progress_finalize(void)
 
     callbacks_len = 0;
     callbacks_size = 0;
-    free(callbacks);
+    free ((void *) callbacks);
     callbacks = NULL;
 
     callbacks_lp_len = 0;
     callbacks_lp_size = 0;
-    free(callbacks_lp);
+    free ((void *) callbacks_lp);
     callbacks_lp = NULL;
 
     opal_atomic_unlock(&progress_lock);
@@ -353,7 +353,7 @@ opal_progress_set_event_poll_rate(int polltime)
 #endif
 }
 
-static int opal_progress_find_cb (opal_progress_callback_t cb, opal_progress_callback_t *cbs,
+static int opal_progress_find_cb (opal_progress_callback_t cb, volatile opal_progress_callback_t *cbs,
                                      size_t cbs_len)
 {
     for (size_t i = 0 ; i < cbs_len ; ++i) {
@@ -365,7 +365,7 @@ static int opal_progress_find_cb (opal_progress_callback_t cb, opal_progress_cal
     return OPAL_ERR_NOT_FOUND;
 }
 
-static int _opal_progress_register (opal_progress_callback_t cb, opal_progress_callback_t **cbs,
+static int _opal_progress_register (opal_progress_callback_t cb, volatile opal_progress_callback_t **cbs,
                                     size_t *cbs_size, size_t *cbs_len)
 {
     int ret = OPAL_SUCCESS;
@@ -385,7 +385,7 @@ static int _opal_progress_register (opal_progress_callback_t cb, opal_progress_c
 
         if (*cbs) {
             /* copy old callbacks */
-            memcpy (tmp, *cbs, sizeof(tmp[0]) * *cbs_size);
+            memcpy (tmp, (void *) *cbs, sizeof(tmp[0]) * *cbs_size);
         }
 
         for (size_t i = *cbs_len ; i < 2 * *cbs_size ; ++i) {
@@ -441,7 +441,7 @@ int opal_progress_register_lp (opal_progress_callback_t cb)
     return ret;
 }
 
-static int _opal_progress_unregister (opal_progress_callback_t cb, opal_progress_callback_t *callback_array,
+static int _opal_progress_unregister (opal_progress_callback_t cb, volatile opal_progress_callback_t *callback_array,
                                       size_t *callback_array_len)
 {
     int ret = opal_progress_find_cb (cb, callback_array, *callback_array_len);

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -163,6 +163,8 @@ typedef int (*opal_progress_callback_t)(void);
  */
 OPAL_DECLSPEC int opal_progress_register(opal_progress_callback_t cb);
 
+OPAL_DECLSPEC int opal_progress_register_lp (opal_progress_callback_t cb);
+
 
 /**
  * Deregister previously registered event


### PR DESCRIPTION
This commit changes the behavior of bml/r2 from conditionally
registering btl progress functions to always registering progress
functions. Any progress function beloning to a btl that is not yet in
use is registered as low-priority. As soon as a proc is added that
will make use of the btl is is re-registered normally.

This works around an issue with some btls. In order to progress a
first message from an unknown peer both ugni and openib need to have
their progress functions called. If either btl is not in use after the
first call to add_procs the callback was never happening. This commit
ensures the btl progress function is called at some point but the
number of progress callbacks is reduced from normal to ensure lower
overhead when a btl is not used. The current ratio is 1 low priority
progress callback for every 8 calls to opal_progress().

Fixes open-mpi/ompi#1676

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@a679cc072b9458957671886062c643f6a40b0351)

:bot:label:bug
:bot:assign: @bosilca 
:bot:milestone:v2.0.0
