### PR TITLE
io/romio: fix filesystem type check on OpenBSD 5.7

### DIFF
--- a/ompi/mca/io/romio/romio/adio/common/ad_fstype.c
+++ b/ompi/mca/io/romio/romio/adio/common/ad_fstype.c
@@ -356,6 +356,8 @@ static void ADIO_FileSysType_fncall(const char *filename, int *fstype, int *erro
     }
 # endif
 
+# ifdef ROMIO_HAVE_STRUCT_STATFS_WITH_F_TYPE
+
 #  ifdef ROMIO_BGL 
     /* BlueGene is a special case: all file systems are AD_BGL, except for
      * certain exceptions */
@@ -428,6 +430,8 @@ static void ADIO_FileSysType_fncall(const char *filename, int *fstype, int *erro
 	    return;
     }
 # endif
+
+# endif /*ROMIO_HAVE_STRUCT_STATFS_WITH_F_TYPE */
 
 # ifdef ROMIO_UFS
     /* if UFS support is enabled, default to that */


### PR DESCRIPTION
check the existence of the f_type field in struct statfs

Thanks Paul Hargrove for the report

(back-ported from commit open-mpi/ompi@b159587325aaf3a06aaba0b3f205b8c4fa032f26)
