### PR TITLE
MTL portals4 : remove the triggered rendez-vous protocol

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4.c
@@ -178,7 +178,6 @@ portals4_init_interface(void)
     me.ignore_bits = MTL_PORTALS4_CONTEXT_MASK |
         MTL_PORTALS4_SOURCE_MASK |
         MTL_PORTALS4_TAG_MASK;
-
     ret = PtlMEAppend(ompi_mtl_portals4.ni_h,
                       ompi_mtl_portals4.recv_idx,
                       &me,

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -158,8 +158,7 @@ extern mca_mtl_portals4_module_t ompi_mtl_portals4;
 /* send posting */
 #define MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, source, tag, type) \
     {                                                                   \
-        match_bits = 0;                                                 \
-        match_bits |= contextid;                                        \
+        match_bits = contextid;                                         \
         match_bits = (match_bits << 24);                                \
         match_bits |= source;                                           \
         match_bits = (match_bits << 24);                                \
@@ -172,7 +171,7 @@ extern mca_mtl_portals4_module_t ompi_mtl_portals4;
         match_bits = 0;                                                 \
         ignore_bits = MTL_PORTALS4_PROTOCOL_IGNR;                       \
                                                                         \
-        match_bits |= contextid;                                        \
+        match_bits = contextid;                                         \
         match_bits = (match_bits << 24);                                \
                                                                         \
         if (MPI_ANY_SOURCE == source) {                                 \
@@ -194,37 +193,29 @@ extern mca_mtl_portals4_module_t ompi_mtl_portals4;
     (0 != (MTL_PORTALS4_SHORT_MSG & match_bits))
 #define MTL_PORTALS4_IS_LONG_MSG(match_bits)            \
     (0 != (MTL_PORTALS4_LONG_MSG & match_bits))
+#define MTL_PORTALS4_IS_READY_MSG(match_bits)           \
+    (0 != (MTL_PORTALS4_READY_MSG & match_bits))
 
 #define MTL_PORTALS4_GET_TAG(match_bits)                \
     ((int)(match_bits & MTL_PORTALS4_TAG_MASK))
 #define MTL_PORTALS4_GET_SOURCE(match_bits)             \
     ((int)((match_bits & MTL_PORTALS4_SOURCE_MASK) >> 24))
-#define MTL_PORTALS4_GET_CONTEXT(match_bits)            \
-    ((int)((match_bits & MTL_PORTALS4_CONTEXT_MASK) >> 48))
 
 
 #define MTL_PORTALS4_SYNC_MSG       0x8000000000000000ULL
 
 #define MTL_PORTALS4_SET_HDR_DATA(hdr_data, opcount, length, sync)   \
     {                                                                \
-        hdr_data = 0;                                                \
+        hdr_data = (sync) ? 1 : 0;                                   \
+        hdr_data = (hdr_data << 15);                                 \
         hdr_data |= opcount & 0x7FFFULL;                             \
         hdr_data = (hdr_data << 48);                                 \
         hdr_data |= (length & 0xFFFFFFFFFFFFULL);                    \
-        hdr_data |= (sync ? MTL_PORTALS4_SYNC_MSG : 0);              \
     }
 
 #define MTL_PORTALS4_GET_LENGTH(hdr_data) ((size_t)(hdr_data & 0xFFFFFFFFFFFFULL))
 #define MTL_PORTALS4_IS_SYNC_MSG(hdr_data)            \
     (0 != (MTL_PORTALS4_SYNC_MSG & hdr_data))
-
-#define MTL_PORTALS4_SET_READ_BITS(match_bits, contextid, tag) \
-    {                                                                   \
-        match_bits = 0;                                                 \
-        match_bits |= (contextid & 0x0000000000FFFFFFULL);              \
-        match_bits = (match_bits << 24);                                \
-        match_bits |= (tag & 0x0000000000FFFFFFULL);                    \
-    }
 
 /* mtl-portals4 helpers */
 OMPI_DECLSPEC ompi_proc_t *

--- a/ompi/mca/mtl/portals4/mtl_portals4_probe.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_probe.c
@@ -41,7 +41,7 @@ completion_fn(ptl_event_t *ev, ompi_mtl_portals4_base_request_t *ptl_base_reques
         ptl_request->status.MPI_SOURCE = MTL_PORTALS4_GET_SOURCE(ev->match_bits);
         ptl_request->status.MPI_TAG = MTL_PORTALS4_GET_TAG(ev->match_bits);
         ptl_request->status.MPI_ERROR = MPI_SUCCESS;
-        ptl_request->status._ucount =MTL_PORTALS4_GET_LENGTH(ev->hdr_data);
+        ptl_request->status._ucount = MTL_PORTALS4_GET_LENGTH(ev->hdr_data);
         if (ev->type != PTL_EVENT_SEARCH) {
             ptl_request->message = ompi_mtl_portals4_message_alloc(ev);
         }

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -69,8 +69,6 @@ struct ompi_mtl_portals4_recv_request_t {
     ompi_mtl_portals4_base_request_t super;
     void *buffer_ptr;
     ptl_handle_me_t me_h;
-    ptl_handle_ct_t ct_h;
-    bool is_triggered;
     struct opal_convertor_t *convertor;
     void *delivery_ptr;
     size_t delivery_len;

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -182,7 +182,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                               ompi_mtl_portals4_isend_request_t *ptl_request)
 {
     int ret;
-    ptl_match_bits_t read_match_bits, match_bits;
+    ptl_match_bits_t match_bits;
     ptl_me_t me;
     ptl_hdr_data_t hdr_data;
 
@@ -190,12 +190,9 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                                MTL_PORTALS4_SHORT_MSG);
 
     MTL_PORTALS4_SET_HDR_DATA(hdr_data, ptl_request->opcount, length,
-                              MCA_PML_BASE_SEND_SYNCHRONOUS == mode);
+                              (MCA_PML_BASE_SEND_SYNCHRONOUS == mode) ? 1 : 0);
 
     if (MCA_PML_BASE_SEND_SYNCHRONOUS == mode) {
-
-        MTL_PORTALS4_SET_READ_BITS(read_match_bits, contextid, tag);
-
         me.start = NULL;
         me.length = 0;
         me.ct_handle = PTL_CT_NONE;
@@ -207,7 +204,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
             PTL_ME_EVENT_LINK_DISABLE |
             PTL_ME_EVENT_UNLINK_DISABLE;
         me.match_id = ptl_proc;
-        me.match_bits = read_match_bits;
+        me.match_bits = hdr_data;
         me.ignore_bits = 0;
 
         ret = PtlMEAppend(ompi_mtl_portals4.ni_h,
@@ -269,15 +266,13 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
                              ompi_mtl_portals4_isend_request_t *ptl_request)
 {
     int ret;
-    ptl_match_bits_t read_match_bits, match_bits;
+    ptl_match_bits_t match_bits;
     ptl_me_t me;
     ptl_hdr_data_t hdr_data;
     ptl_size_t put_length;
 
     MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, localrank, tag,
                                MTL_PORTALS4_LONG_MSG);
-
-    MTL_PORTALS4_SET_READ_BITS(read_match_bits, contextid, tag);
 
     MTL_PORTALS4_SET_HDR_DATA(hdr_data, ptl_request->opcount, length, 0);
 
@@ -292,7 +287,7 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
         PTL_ME_EVENT_LINK_DISABLE |
         PTL_ME_EVENT_UNLINK_DISABLE;
     me.match_id = ptl_proc;
-    me.match_bits = read_match_bits;
+    me.match_bits = hdr_data;
     me.ignore_bits = 0;
 
     ret = PtlMEAppend(ompi_mtl_portals4.ni_h,


### PR DESCRIPTION
Since we have found an unsolvable corner case that is in line with the MPI specification, it is preferrable to remove the patches I had introduced a few months ago concerning the automatic rendez-vous protocol triggering.
