### PR TITLE
v2.x accumulate ordering

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -275,7 +275,7 @@ int ompi_info_set (ompi_info_t *info, const char *key, const char *value)
 int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
                               mca_base_var_enum_t *var_enum)
 {
-    const char *string_value;
+    char *string_value;
     int ret;
 
     ret = var_enum->string_from_value (var_enum, value, &string_value);
@@ -283,7 +283,9 @@ int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
         return ret;
     }
 
-    return ompi_info_set (info, key, string_value);
+    ret = ompi_info_set (info, key, string_value);
+    free (string_value);
+    return ret;
 }
 
 

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -139,7 +139,7 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
         return ret;
     }
 
-    win->w_acc_ops = acc_ops;
+    win->w_acc_ops = (ompi_win_accumulate_ops_t)acc_ops;
     win->w_flavor = flavor;
 
     /* setup data that is independent of osc component */

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -46,11 +46,22 @@ opal_pointer_array_t ompi_mpi_windows = {{0}};
 ompi_predefined_win_t ompi_mpi_win_null = {{{0}}};
 ompi_predefined_win_t *ompi_mpi_win_null_addr = &ompi_mpi_win_null;
 mca_base_var_enum_t *ompi_win_accumulate_ops = NULL;
+mca_base_var_enum_t *ompi_win_accumulate_order = NULL;
 
 static mca_base_var_enum_value_t accumulate_ops_values[] = {
     {.value = OMPI_WIN_ACCUMULATE_OPS_SAME_OP_NO_OP, .string = "same_op_no_op",},
     {.value = OMPI_WIN_ACCUMULATE_OPS_SAME_OP, .string = "same_op",},
     {.value = -1, .string = NULL},
+};
+
+static mca_base_var_enum_value_flag_t accumulate_order_flags[] = {
+    {.flag = OMPI_WIN_ACC_ORDER_NONE, .string = "none", .conflicting_flag = OMPI_WIN_ACC_ORDER_RAR |
+     OMPI_WIN_ACC_ORDER_WAR | OMPI_WIN_ACC_ORDER_RAW | OMPI_WIN_ACC_ORDER_WAW},
+    {.flag = OMPI_WIN_ACC_ORDER_RAR, .string = "rar", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_WAR, .string = "war", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_RAW, .string = "raw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_WAW, .string = "waw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {},
 };
 
 static void ompi_win_construct(ompi_win_t *win);
@@ -86,6 +97,11 @@ ompi_win_init(void)
         return ret;
     }
 
+    ret = mca_base_var_enum_create_flag ("accumulate_order", accumulate_order_flags, &ompi_win_accumulate_order);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
     return OMPI_SUCCESS;
 }
 
@@ -115,6 +131,7 @@ int ompi_win_finalize(void)
     OBJ_DESTRUCT(&ompi_mpi_win_null.win);
     OBJ_DESTRUCT(&ompi_mpi_windows);
     OBJ_RELEASE(ompi_win_accumulate_ops);
+    OBJ_RELEASE(ompi_win_accumulate_order);
 
     return OMPI_SUCCESS;
 }
@@ -123,7 +140,7 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
 {
     ompi_win_t *win;
     ompi_group_t *group;
-    int acc_ops, flag, ret;
+    int acc_ops, acc_order, flag, ret;
 
     /* create the object */
     win = OBJ_NEW(ompi_win_t);
@@ -140,6 +157,18 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
     }
 
     win->w_acc_ops = (ompi_win_accumulate_ops_t)acc_ops;
+
+    ret = ompi_info_get_value_enum (info, "accumulate_order", &acc_order,
+                                    OMPI_WIN_ACC_ORDER_RAR | OMPI_WIN_ACC_ORDER_WAR |
+                                    OMPI_WIN_ACC_ORDER_RAW | OMPI_WIN_ACC_ORDER_WAW,
+                                    ompi_win_accumulate_order, &flag);
+    if (OMPI_SUCCESS != ret) {
+        OBJ_RELEASE(win);
+        return ret;
+    }
+
+    win->w_acc_order = acc_order;
+
     win->w_flavor = flavor;
 
     /* setup data that is independent of osc component */

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -50,7 +50,25 @@ enum ompi_win_accumulate_ops_t {
 };
 typedef enum ompi_win_accumulate_ops_t ompi_win_accumulate_ops_t;
 
+/**
+ * Accumulate ordering flags. The default accumulate ordering in
+ * MPI-3.1 is rar,war,raw,waw.
+ */
+enum ompi_win_accumulate_order_flags_t {
+    /** no accumulate ordering (may valid with any other flag) */
+    OMPI_WIN_ACC_ORDER_NONE = 0x01,
+    /** read-after-read ordering */
+    OMPI_WIN_ACC_ORDER_RAR  = 0x02,
+    /** write-after-read ordering */
+    OMPI_WIN_ACC_ORDER_WAR  = 0x04,
+    /** read-after-write ordering */
+    OMPI_WIN_ACC_ORDER_RAW  = 0x08,
+    /** write-after-write ordering */
+    OMPI_WIN_ACC_ORDER_WAW  = 0x10,
+};
+
 OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_ops;
+OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_order;
 
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_windows;
 
@@ -87,6 +105,9 @@ struct ompi_win_t {
 
     /* one sided interface */
     ompi_osc_base_module_t *w_osc_module;
+
+    /** Accumulate ordering (see ompi_win_accumulate_order_flags_t above) */
+    int32_t w_acc_order;
 };
 typedef struct ompi_win_t ompi_win_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_win_t);

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -1526,7 +1526,7 @@ int mca_base_var_register (const char *project_name, const char *framework_name,
                            mca_base_var_scope_t scope, void *storage)
 {
     /* Only integer variables can have enumerator */
-    assert (NULL == enumerator || MCA_BASE_VAR_TYPE_INT == type);
+    assert (NULL == enumerator || (MCA_BASE_VAR_TYPE_INT == type || MCA_BASE_VAR_TYPE_UNSIGNED_INT == type));
 
     return register_variable (project_name, framework_name, component_name,
                               variable_name, description, type, enumerator,
@@ -1927,7 +1927,6 @@ static char *source_name(mca_base_var_t *var)
 static int var_value_string (mca_base_var_t *var, char **value_string)
 {
     const mca_base_var_storage_t *value;
-    const char *tmp;
     int ret;
 
     assert (MCA_BASE_VAR_TYPE_MAX > var->mbv_type);
@@ -1974,18 +1973,13 @@ static int var_value_string (mca_base_var_t *var, char **value_string)
     } else {
         /* we use an enumerator to handle string->bool and bool->string conversion */
         if (MCA_BASE_VAR_TYPE_BOOL == var->mbv_type) {
-            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->boolval, &tmp);
+            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->boolval, value_string);
         } else {
-            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->intval, &tmp);
+            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->intval, value_string);
         }
 
         if (OPAL_SUCCESS != ret) {
             return ret;
-        }
-
-        *value_string = strdup (tmp);
-        if (NULL == *value_string) {
-            ret = OPAL_ERR_OUT_OF_RESOURCE;
         }
     }
 

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -724,7 +724,7 @@ static int var_set_from_string (mca_base_var_t *var, char *src)
     case MCA_BASE_VAR_TYPE_BOOL:
     case MCA_BASE_VAR_TYPE_SIZE_T:
         ret = int_from_string(src, var->mbv_enumerator, &int_value);
-        if (OPAL_ERR_VALUE_OUT_OF_BOUNDS == ret ||
+        if (OPAL_SUCCESS != ret ||
             (MCA_BASE_VAR_TYPE_INT == var->mbv_type && ((int) int_value != (int64_t) int_value)) ||
             (MCA_BASE_VAR_TYPE_UNSIGNED_INT == var->mbv_type && ((unsigned int) int_value != int_value))) {
             if (var->mbv_enumerator) {

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -494,21 +494,28 @@ static int enum_value_from_string_flag (mca_base_var_enum_t *self, const char *s
 
         bool found = false, conflict = false;
         for (int j = 0 ; j < count ; ++j) {
-            if ((is_int && (value == flag_enum->enum_flags[i].flag)) ||
-                0 == strcasecmp (flags[i], flag_enum->enum_flags[i].string)) {
+            if ((is_int && (value & flag_enum->enum_flags[j].flag)) ||
+                0 == strcasecmp (flags[i], flag_enum->enum_flags[j].string)) {
                 found = true;
 
-                if (flag & flag_enum->enum_flags[i].conflicting_flag) {
+                if (flag & flag_enum->enum_flags[j].conflicting_flag) {
                     conflict = true;
                 } else {
-                    flag |= flag_enum->enum_flags[i].flag;
+                    flag |= flag_enum->enum_flags[j].flag;
                 }
 
-                break;
+                if (is_int) {
+                    value &= ~flag_enum->enum_flags[j].flag;
+                    if (0 == value) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
             }
         }
 
-        if (!found || conflict) {
+        if (!found || conflict || (is_int && value)) {
             opal_argv_free (flags);
             return !found ? OPAL_ERR_VALUE_OUT_OF_BOUNDS : OPAL_ERR_BAD_PARAM;
         }

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -514,6 +514,8 @@ static int enum_value_from_string_flag (mca_base_var_enum_t *self, const char *s
         }
     }
 
+    opal_argv_free (flags);
+
     *value_out = flag;
 
     return OPAL_SUCCESS;

--- a/opal/mca/btl/base/base.h
+++ b/opal/mca/btl/base/base.h
@@ -78,6 +78,9 @@ OPAL_DECLSPEC extern bool mca_btl_base_thread_multiple_override;
 
 OPAL_DECLSPEC extern mca_base_framework_t opal_btl_base_framework;
 
+extern mca_base_var_enum_flag_t *mca_btl_base_flag_enum;
+extern mca_base_var_enum_flag_t *mca_btl_base_atomic_enum;
+
 END_C_DECLS
 
 #endif /* MCA_BTL_BASE_H */

--- a/opal/mca/btl/base/base.h
+++ b/opal/mca/btl/base/base.h
@@ -30,6 +30,7 @@
 #include "opal/mca/mca.h"
 #include "opal/mca/base/mca_base_framework.h"
 #include "opal/mca/btl/btl.h"
+#include "opal/mca/base/mca_base_var_enum.h"
 
 BEGIN_C_DECLS
 

--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +32,39 @@
 #include "opal/mca/base/base.h"
 #include "opal/mca/btl/btl.h"
 #include "opal/mca/btl/base/base.h"
+
+mca_base_var_enum_flag_t *mca_btl_base_flag_enum = NULL;
+mca_base_var_enum_flag_t *mca_btl_base_atomic_enum = NULL;
+
+mca_base_var_enum_value_flag_t mca_btl_base_flag_enum_flags[] = {
+    {MCA_BTL_FLAGS_SEND, "send", 0},
+    {MCA_BTL_FLAGS_PUT, "put", 0},
+    {MCA_BTL_FLAGS_GET, "get", 0},
+    {MCA_BTL_FLAGS_SEND_INPLACE, "inplace", 0},
+    {MCA_BTL_FLAGS_SIGNALED, "signaled", 0},
+    {MCA_BTL_FLAGS_ATOMIC_OPS, "atomics", 0},
+    {MCA_BTL_FLAGS_ATOMIC_FOPS, "fetching-atomics", 0},
+    {MCA_BTL_FLAGS_SINGLE_ADD_PROCS, "static", 0},
+    {MCA_BTL_FLAGS_CUDA_PUT, "cuda-put", 0},
+    {MCA_BTL_FLAGS_CUDA_GET, "cuda-get", 0},
+    {MCA_BTL_FLAGS_CUDA_COPY_ASYNC_SEND, "cuda-async-send", 0},
+    {MCA_BTL_FLAGS_CUDA_COPY_ASYNC_RECV, "cuda-async-recv", 0},
+    {MCA_BTL_FLAGS_FAILOVER_SUPPORT, "failover", 0},
+    {MCA_BTL_FLAGS_NEED_ACK, "need-ack", 0},
+    {MCA_BTL_FLAGS_NEED_CSUM, "need-csum", 0},
+    {MCA_BTL_FLAGS_HETEROGENEOUS_RDMA, "hetero-rdma", 0},
+    {0, NULL, 0}
+};
+
+mca_base_var_enum_value_flag_t mca_btl_base_atomic_enum_flags[] = {
+  {MCA_BTL_ATOMIC_SUPPORTS_ADD, "add", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_AND, "and", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_OR, "or", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_XOR, "xor", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_CSWAP, "compare-and-swap", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_GLOB, "global"},
+  {0, NULL, 0}
+};
 
 mca_btl_active_message_callback_t mca_btl_base_active_message_trigger[MCA_BTL_TAG_MAX] = {{0}};
 
@@ -104,6 +140,9 @@ static int mca_btl_base_register(mca_base_register_flag_t flags)
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &mca_btl_base_warn_component_unused);
 
+    (void) mca_base_var_enum_create_flag ("btl_flags", mca_btl_base_flag_enum_flags, &mca_btl_base_flag_enum);
+    (void) mca_base_var_enum_create_flag ("btl_atomic_flags", mca_btl_base_atomic_enum_flags, &mca_btl_base_atomic_enum);
+
     return OPAL_SUCCESS;
 }
 
@@ -158,6 +197,14 @@ static int mca_btl_base_close(void)
     (void) mca_base_framework_components_close(&opal_btl_base_framework, NULL);
 
     OBJ_DESTRUCT(&mca_btl_base_modules_initialized);
+
+    if (mca_btl_base_flag_enum) {
+        OBJ_RELEASE(mca_btl_base_flag_enum);
+    }
+
+    if (mca_btl_base_atomic_enum) {
+        OBJ_RELEASE(mca_btl_base_atomic_enum);
+    }
 
 #if 0
     /* restore event processing */

--- a/opal/mca/btl/base/btl_base_mca.c
+++ b/opal/mca/btl/base/btl_base_mca.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -37,8 +37,6 @@
 int mca_btl_base_param_register(mca_base_component_t *version,
                                 mca_btl_base_module_t *module)
 {
-    char *msg;
-
     /* If this is ever triggered change the uint32_ts in mca_btl_base_module_t to unsigned ints */
     assert(sizeof(unsigned int) == sizeof(uint32_t));
 
@@ -49,33 +47,14 @@ int mca_btl_base_param_register(mca_base_component_t *version,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &module->btl_exclusivity);
 
-    asprintf(&msg, "BTL bit flags (general flags: SEND=%d, PUT=%d, GET=%d, SEND_INPLACE=%d, HETEROGENEOUS_RDMA=%d, "
-             "ATOMIC_OPS=%d; flags only used by the \"dr\" PML (ignored by others): ACK=%d, CHECKSUM=%d, "
-             "RDMA_COMPLETION=%d; flags only used by the \"bfo\" PML (ignored by others): FAILOVER_SUPPORT=%d)",
-             MCA_BTL_FLAGS_SEND,
-             MCA_BTL_FLAGS_PUT,
-             MCA_BTL_FLAGS_GET,
-             MCA_BTL_FLAGS_SEND_INPLACE,
-             MCA_BTL_FLAGS_HETEROGENEOUS_RDMA,
-             MCA_BTL_FLAGS_ATOMIC_OPS,
-             MCA_BTL_FLAGS_NEED_ACK,
-             MCA_BTL_FLAGS_NEED_CSUM,
-             MCA_BTL_FLAGS_RDMA_COMPLETION,
-             MCA_BTL_FLAGS_FAILOVER_SUPPORT);
-    (void) mca_base_component_var_register(version, "flags", msg,
-                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
-                                           OPAL_INFO_LVL_5,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
-                                           &module->btl_flags);
-    free(msg);
+    (void) mca_base_component_var_register(version, "flags", "BTL bit flags (general flags: send, put, get, in-place, hetero-rdma, "
+                                           "atomics, fetching-atomics)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           &mca_btl_base_flag_enum->super, 0, 0, OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY, &module->btl_flags);
 
-    asprintf (&msg, "BTL atomic bit flags (general flags: ADD=%d, AND=%d, OR=%d, XOR=%d",
-              MCA_BTL_ATOMIC_SUPPORTS_ADD, MCA_BTL_ATOMIC_SUPPORTS_AND, MCA_BTL_ATOMIC_SUPPORTS_OR,
-              MCA_BTL_ATOMIC_SUPPORTS_XOR);
-    (void) mca_base_component_var_register(version, "atomic_flags", msg, MCA_BASE_VAR_TYPE_UNSIGNED_INT,
-                                           NULL, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY, OPAL_INFO_LVL_5,
+    (void) mca_base_component_var_register(version, "atomic_flags", "BTL atomic support flags", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           &mca_btl_base_atomic_enum->super, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_CONSTANT, &module->btl_atomic_flags);
-    free(msg);
 
     (void) mca_base_component_var_register(version, "rndv_eager_limit", "Size (in bytes, including header) of \"phase 1\" fragment sent for all large messages (must be >= 0 and <= eager_limit)",
                                            MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,


### PR DESCRIPTION
This PR brings over support for the accumulate_ordering info key. To support parsing the info key I am also proposing bringing over MCA base support for flag variable enumerators. This info key is the only MPI-3.1 standard key missing.

:bot:assign: @jsquyres 
:bot:label:enhancement
:bot:milestone:v2.0.1
