### PR TITLE
configury: fix opal_config_pthreads when -lrt is set

### DIFF
--- a/config/ompi_config_pthreads.m4
+++ b/config/ompi_config_pthreads.m4
@@ -57,6 +57,7 @@ int main(int argc, char* argv[])
     pthread_attr_t attr;
 
     me = pthread_self(); 
+    pthread_atfork(NULL, NULL, NULL);
     pthread_attr_init(&attr); 
     pthread_cleanup_push(cleanup_routine, 0);
     pthread_create(&newthread, &attr, thread_main, 0); 


### PR DESCRIPTION
the test program was successful without -pthread if -lrt is used.
-pthread _is_ required in order to correctly handle
the pthread_atfork function.

(cherry picked from commit open-mpi/ompi@9d9d05b22d4aa235e1861db0167245bad8288f7f)

@rhc54 and @jsquyres found this missing commit on the v1.10 branch.

Fixes open-mpi/ompi#1699.

Reviewed by @jsquyres / @rhc54 
