### PR TITLE
Do not set a binding policy when we are overloading the default

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -119,7 +119,7 @@ static void unbind_procs(orte_job_t *jdata)
         }
     }
 }
-         
+
 static int bind_upwards(orte_job_t *jdata,
                         orte_node_t *node,
                         hwloc_obj_type_t target,
@@ -335,7 +335,6 @@ static int bind_downwards(orte_job_t *jdata,
                     return ORTE_ERR_SILENT;
                 } else {
                     /* if we have the default binding policy, then just don't bind */
-                    OPAL_SET_BINDING_POLICY(map->binding, OPAL_BIND_TO_NONE);
                     unbind_procs(jdata);
                     hwloc_bitmap_zero(totalcpuset);
                     return ORTE_SUCCESS;
@@ -373,7 +372,7 @@ static int bind_downwards(orte_job_t *jdata,
         }
     }
     hwloc_bitmap_free(totalcpuset);
-    
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -386,6 +386,24 @@ int orte_rmaps_rr_bynode(orte_job_t *jdata,
                  * properly set
                  */
                 node->oversubscribed = true;
+                /* check for permission */
+                if (node->slots_given) {
+                    /* if we weren't given a directive either way, then we will error out
+                     * as the #slots were specifically given, either by the host RM or
+                     * via hostfile/dash-host */
+                    if (!(ORTE_MAPPING_SUBSCRIBE_GIVEN & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping))) {
+                        orte_show_help("help-orte-rmaps-base.txt", "orte-rmaps-base:alloc-error",
+                                       true, app->num_procs, app->app);
+                        ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
+                        return ORTE_ERR_SILENT;
+                    } else if (ORTE_MAPPING_NO_OVERSUBSCRIBE & ORTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping)) {
+                        /* if we were explicitly told not to oversubscribe, then don't */
+                        orte_show_help("help-orte-rmaps-base.txt", "orte-rmaps-base:alloc-error",
+                                       true, app->num_procs, app->app);
+                        ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
+                        return ORTE_ERR_SILENT;
+                    }
+                }
             }
             if (nprocs_mapped == app->num_procs) {
                 /* we are done */


### PR DESCRIPTION
In 1.10, we allow oversubscription by default for non-managed allocations, and we silently do-not-bind if the user has not requested a binding policy and we are overloaded.

Fixes https://github.com/open-mpi/ompi/issues/1709

@abouteiller Please give this a whirl
