### PR TITLE
btl/scif: reduce default exclusivity

### DIFF
--- a/ompi/mca/btl/scif/btl_scif_component.c
+++ b/ompi/mca/btl/scif/btl_scif_component.c
@@ -160,7 +160,7 @@ static int btl_scif_component_register(void)
                                             NULL, NULL, NULL, &mca_btl_scif_component.put_count);
 #endif
 
-    mca_btl_scif_module.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH;
+    mca_btl_scif_module.super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH - 1;
     mca_btl_scif_module.super.btl_eager_limit               = 1 * 1024;
     mca_btl_scif_module.super.btl_rndv_eager_limit          = 1 * 1024;
     mca_btl_scif_module.super.btl_rdma_pipeline_frag_size   = 4 * 1024 * 1024;


### PR DESCRIPTION
This commit reduces the default exclusivity so that btl/scif is not
used for send/recv over other shared memory transports.

Fixes open-mpi/ompi#1712

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@5caf12cd9b4a636c7acf8ba6641464533df494f8)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
