### PR TITLE
ompi/attributes: revamp attribute handling.

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -11,7 +11,9 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
- *                         reserved. 
+ *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -50,6 +52,8 @@
  *   means writing a pointer to an instance of something; changing the
  *   value of that instance will make it visible to anyone who reads
  *   that attribute value).
+ * - C also internally store some int attributes of a MPI_Win by value,
+ *   and these attributes appear to be read-only (e.g. set once for all)
  * - Fortran functions store values by value (i.e., writing an
  *   attribute value means that anyone who reads that attribute value
  *   will not be able to affect the value read by anyone else).
@@ -60,10 +64,10 @@
  * - MPI-2 4.12.7:Example 4.13 (p58) is wrong.  The C->Fortran example
  *   should have the Fortran "val" variable equal to &I.
  *
- * By the first two of these, there are 9 possible use cases -- 3
+ * By the first two of these, there are 12 possible use cases -- 4
  * possibilities for writing an attribute value, each of which has 3
  * possibilities for reading that value back.  The following lists
- * each of the 9 cases, and what happens in each.
+ * each of the 12 cases, and what happens in each.
  *
  * Cases where C writes an attribute value:
  * ----------------------------------------
@@ -109,22 +113,20 @@
  *            CALL MPI_COMM_GET_ATTR(..., ret, ierr) 
  *            --> ret will equal &bar
  *
- * Cases where Fortran MPI-1 writes an attribute value:
+ * Cases where C writes an int attribute:
  * ----------------------------------------------------
  *
- * In all of these cases, an INTEGER is written by Fortran.
+ * In all of these cases, an int is written by C.
+ * This is done internally when writing the attributes of a MPI_Win
  *
- * Example: INTEGER FOO = 7
- *          CALL MPI_ATTR_PUT(..., foo, ierr)
+ * Example: int foo = 7;
+ *          ompi_set_attr_int(..., foo, ...)
  *
  * 4. C reads the attribute value.  The value returned is a pointer
- *    that points to an INTEGER (i.e., an MPI_Fint) that has a value
+ *    that points to an int that has a value
  *    of 7.
- *    --> NOTE: The external MPI interface does not distinguish between
- *        this case and case 7.  It is the programer's responsibility
- *        to code accordingly.
  *
- * Example: MPI_Fint *ret; 
+ * Example: int *ret;
  *          MPI_Attr_get(..., &ret);
  *          -> *ret will equal 7.
  *
@@ -136,6 +138,40 @@
  *          --> ret will equal 7
  *
  * 6. Fortran MPI-2 reads the attribute value.  The same value is
+ *    returned, but potentially sign-extended if sizeof(INTEGER) <
+ *    sizeof(INTEGER(KIND=MPI_ADDRESS_KIND)).
+ *
+ * Example: INTEGER(KIND=MPI_ADDRESS_KIND) ret
+ *          CALL MPI_COMM_GET_ATTR(..., ret, ierr)
+ *          --> ret will equal 7
+ *
+ * Cases where Fortran MPI-1 writes an attribute value:
+ * ----------------------------------------------------
+ *
+ * In all of these cases, an INTEGER is written by Fortran.
+ *
+ * Example: INTEGER FOO = 7
+ *          CALL MPI_ATTR_PUT(..., foo, ierr)
+ *
+ * 7. C reads the attribute value.  The value returned is a pointer
+ *    that points to an INTEGER (i.e., an MPI_Fint) that has a value
+ *    of 7.
+ *    --> NOTE: The external MPI interface does not distinguish between
+ *        this case and case 7.  It is the programer's responsibility
+ *        to code accordingly.
+ *
+ * Example: MPI_Fint *ret; 
+ *          MPI_Attr_get(..., &ret);
+ *          -> *ret will equal 7.
+ *
+ * 8. Fortran MPI-1 reads the attribute value.  This is the unity
+ *    case; the same value is returned.
+ *
+ * Example: INTEGER ret
+ *          CALL MPI_ATTR_GET(..., ret, ierr)
+ *          --> ret will equal 7
+ *
+ * 9. Fortran MPI-2 reads the attribute value.  The same value is
  *    returned, but potentially sign-extended if sizeof(INTEGER) <
  *    sizeof(INTEGER(KIND=MPI_ADDRESS_KIND)).
  *
@@ -156,7 +192,7 @@
  *            INTEGER(KIND=MPI_ADDRESS_KIND) FOO = pow(2, 40)
  *            CALL MPI_COMM_PUT_ATTR(..., foo, ierr)
  *
- * 7. C reads the attribute value.  The value returned is a pointer
+ * 10. C reads the attribute value.  The value returned is a pointer
  *    that points to an INTEGER(KIND=MPI_ADDRESS_KIND) (i.e., a void*)
  *    that has a value of 12.
  *    --> NOTE: The external MPI interface does not distinguish between
@@ -170,7 +206,7 @@
  *            MPI_Attr_get(..., &ret);
  *            -> *ret will equal 2^40
  *
- * 8. Fortran MPI-1 reads the attribute value.  The same value is
+ * 11. Fortran MPI-1 reads the attribute value.  The same value is
  *    returned, but potentially truncated if sizeof(INTEGER) <
  *    sizeof(INTEGER(KIND=MPI_ADDRESS_KIND)).
  *
@@ -181,7 +217,7 @@
  *            CALL MPI_ATTR_GET(..., ret, ierr)
  *            --> ret will equal 0
  *
- * 9. Fortran MPI-2 reads the attribute value.  This is the unity
+ * 12. Fortran MPI-2 reads the attribute value.  This is the unity
  *    case; the same value is returned.
  *
  * Example A: INTEGER(KIND=MPI_ADDRESS_KIND) ret
@@ -235,10 +271,10 @@
 
    1. MPI-1 Fortran-style: attribute and extra state arguments are of
       type (INTEGER).  This is used if both the OMPI_KEYVAL_F77 and
-      OMPI_KEYVAL_F77_MPI1 flags are set.
+      OMPI_KEYVAL_F77_INT flags are set.
    2. MPI-2 Fortran-style: attribute and extra state arguments are of
       type (INTEGER(KIND=MPI_ADDRESS_KIND)).  This is used if the
-      OMPI_KEYVAL_F77 flag is set and the OMPI_KEYVAL_F77_MPI1 flag is
+      OMPI_KEYVAL_F77 flag is set and the OMPI_KEYVAL_F77_INT flag is
       *not* set.
    3. C-style: attribute arguments are of type (void*).  This is used
       if OMPI_KEYVAL_F77 is not set.
@@ -252,11 +288,13 @@ do { \
     if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77)) { \
         MPI_Fint f_key = OMPI_INT_2_FINT(key); \
         MPI_Fint f_err; \
+        MPI_Fint attr_##type##_f;                \
+        attr_##type##_f = OMPI_INT_2_FINT(((ompi_##type##_t *)keyval_obj)->attr_##type##_f); \
         /* MPI-1 Fortran-style */ \
-        if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77_MPI1)) { \
-            MPI_Fint attr_val = translate_to_fortran_mpi1(attribute); \
-            (*((keyval_obj->delete_attr_fn).attr_mpi1_fortran_delete_fn)) \
-                (&(((ompi_##type##_t *)object)->attr_##type##_f), \
+        if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77_INT)) { \
+            MPI_Fint attr_val = translate_to_fint(attribute); \
+            (*((keyval_obj->delete_attr_fn).attr_fint_delete_fn)) \
+                (&attr_##type##_f,                                        \
                  &f_key, &attr_val, &keyval_obj->extra_state.f_integer, &f_err); \
             if (MPI_SUCCESS != OMPI_FINT_2_INT(f_err)) { \
                 err = OMPI_FINT_2_INT(f_err);           \
@@ -264,9 +302,9 @@ do { \
         } \
         /* MPI-2 Fortran-style */ \
         else { \
-            MPI_Aint attr_val = translate_to_fortran_mpi2(attribute); \
-            (*((keyval_obj->delete_attr_fn).attr_mpi2_fortran_delete_fn)) \
-                (&(((ompi_##type##_t *)object)->attr_##type##_f), \
+            MPI_Aint attr_val = translate_to_aint(attribute); \
+            (*((keyval_obj->delete_attr_fn).attr_aint_delete_fn)) \
+                (&attr_##type##_f,                                        \
                  &f_key, (int*)&attr_val, &keyval_obj->extra_state.f_address, &f_err); \
             if (MPI_SUCCESS != OMPI_FINT_2_INT(f_err)) { \
                 err = OMPI_FINT_2_INT(f_err); \
@@ -295,11 +333,13 @@ do { \
         MPI_Fint f_err; \
         ompi_fortran_logical_t f_flag; \
         /* MPI-1 Fortran-style */ \
-        if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77_MPI1)) { \
-            MPI_Fint in, out;                                      \
-            in = translate_to_fortran_mpi1(in_attr); \
-            (*((keyval_obj->copy_attr_fn).attr_mpi1_fortran_copy_fn)) \
-                (&(((ompi_##type##_t *)old_object)->attr_##type##_f), \
+        if (0 != (keyval_obj->attr_flag & OMPI_KEYVAL_F77_INT)) { \
+            MPI_Fint in, out;                        \
+            MPI_Fint attr_##type##_f;                \
+            in = translate_to_fint(in_attr); \
+            attr_##type##_f = OMPI_INT_2_FINT(((ompi_##type##_t *)old_object)->attr_##type##_f); \
+            (*((keyval_obj->copy_attr_fn).attr_fint_copy_fn)) \
+                (&attr_##type##_f, \
                  &f_key, &keyval_obj->extra_state.f_integer, \
                  &in, &out, &f_flag, &f_err); \
             if (MPI_SUCCESS != OMPI_FINT_2_INT(f_err)) { \
@@ -313,9 +353,11 @@ do { \
         /* MPI-2 Fortran-style */ \
         else { \
             MPI_Aint in, out;                        \
-            in = translate_to_fortran_mpi2(in_attr); \
-            (*((keyval_obj->copy_attr_fn).attr_mpi2_fortran_copy_fn)) \
-                (&(((ompi_##type##_t *)old_object)->attr_##type##_f), \
+            MPI_Fint attr_##type##_f;                \
+            in = translate_to_aint(in_attr); \
+            attr_##type##_f = OMPI_INT_2_FINT(((ompi_##type##_t *)old_object)->attr_##type##_f); \
+            (*((keyval_obj->copy_attr_fn).attr_aint_copy_fn)) \
+                (&attr_##type##_f, \
                  &f_key, &keyval_obj->extra_state.f_address, &in, &out, \
                  &f_flag, &f_err); \
             if (MPI_SUCCESS != OMPI_FINT_2_INT(f_err)) { \
@@ -339,16 +381,15 @@ do { \
     OPAL_THREAD_LOCK(&attribute_lock); \
 } while (0)
 
-
-/* 
+/*
  * Cases for attribute values
  */
 typedef enum ompi_attribute_translate_t {
     OMPI_ATTRIBUTE_C,
-    OMPI_ATTRIBUTE_FORTRAN_MPI1,
-    OMPI_ATTRIBUTE_FORTRAN_MPI2
+    OMPI_ATTRIBUTE_INT,
+    OMPI_ATTRIBUTE_FINT,
+    OMPI_ATTRIBUTE_AINT
 } ompi_attribute_translate_t;
-
 
 /*
  * struct to hold attribute values on each MPI object
@@ -357,8 +398,9 @@ typedef struct attribute_value_t {
     opal_object_t super;
     int av_key;
     void *av_value;
-    MPI_Aint *av_address_kind_pointer;
+    int *av_int_pointer;
     MPI_Fint *av_integer_pointer;
+    MPI_Aint *av_address_kind_pointer;
     int av_set_from;
     int av_sequence;
 } attribute_value_t;
@@ -377,8 +419,9 @@ static int set_value(ompi_attribute_type_t type, void *object,
 static int get_value(opal_hash_table_t *attr_hash, int key, 
                      attribute_value_t **attribute, int *flag);
 static void *translate_to_c(attribute_value_t *val);
-static MPI_Fint translate_to_fortran_mpi1(attribute_value_t *val);
-static MPI_Aint translate_to_fortran_mpi2(attribute_value_t *val);
+static MPI_Fint translate_to_fint(attribute_value_t *val);
+static MPI_Aint translate_to_aint(attribute_value_t *val);
+
 static int compare_attr_sequence(const void *attr1, const void *attr2);
 
 
@@ -408,6 +451,7 @@ static opal_hash_table_t *keyval_hash;
 static opal_bitmap_t *key_bitmap;
 static int attr_sequence;
 static unsigned int int_pos = 12345;
+static unsigned int integer_pos = 12345;
 
 /*
  * MPI attributes are *not* high performance, so just use a One Big Lock
@@ -424,7 +468,8 @@ static void attribute_value_construct(attribute_value_t *item)
 {
     item->av_key = MPI_KEYVAL_INVALID;
     item->av_address_kind_pointer = (MPI_Aint*) &item->av_value;
-    item->av_integer_pointer = &(((MPI_Fint*) &item->av_value)[int_pos]);
+    item->av_int_pointer = (int *)&item->av_value + int_pos;
+    item->av_integer_pointer = (MPI_Fint *)&item->av_value + integer_pos;
     item->av_set_from = 0;
     item->av_sequence = -1;
 }
@@ -475,7 +520,7 @@ int ompi_attr_init(void)
 {
     int ret;
     void *bogus = (void*) 1;
-    MPI_Fint *p = (MPI_Fint*) &bogus;
+    int *p = (int *) &bogus;
 
     keyval_hash = OBJ_NEW(opal_hash_table_t);
     if (NULL == keyval_hash) {
@@ -490,9 +535,16 @@ int ompi_attr_init(void)
         return MPI_ERR_SYSRESOURCE;
     }
 
-    for (int_pos = 0; int_pos < (sizeof(void*) / sizeof(MPI_Fint)); 
+    for (int_pos = 0; int_pos < (sizeof(void*) / sizeof(int));
          ++int_pos) {
         if (p[int_pos] == 1) {
+            break;
+        }
+    }
+
+    for (integer_pos = 0; integer_pos < (sizeof(void*) / sizeof(MPI_Fint));
+         ++integer_pos) {
+        if (p[integer_pos] == 1) {
             break;
         }
     }
@@ -600,6 +652,9 @@ int ompi_attr_create_keyval_fint(ompi_attribute_type_t type,
     ompi_attribute_fortran_ptr_t es_tmp;
 
     es_tmp.f_integer = extra_state;
+#if SIZEOF_INT == OMPI_SIZEOF_FORTRAN_INTEGER
+    flags |= OMPI_KEYVAL_F77_INT;
+#endif
     return ompi_attr_create_keyval_impl(type, copy_attr_fn, delete_attr_fn,
                                         key, &es_tmp, flags,
                                         bindings_extra_state);
@@ -687,13 +742,44 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
 
 
 /*
+ * Front-end function internally called by the C API functions to set an
+ * int attribute.
+ */
+int ompi_attr_set_int(ompi_attribute_type_t type, void *object,
+                      opal_hash_table_t **attr_hash,
+                      int key, int attribute, bool predefined)
+{
+    int ret;
+    attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
+    if (NULL == new_attr) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    OPAL_THREAD_LOCK(&attribute_lock);
+
+    new_attr->av_value = (void *) 0;
+    *new_attr->av_int_pointer = attribute;
+    new_attr->av_set_from = OMPI_ATTRIBUTE_INT;
+    ret = set_value(type, object, attr_hash, key, new_attr, predefined);
+    if (OMPI_SUCCESS != ret) {
+        OBJ_RELEASE(new_attr);
+    }
+
+    opal_atomic_wmb();
+    OPAL_THREAD_UNLOCK(&attribute_lock);
+
+    return ret;
+}
+
+
+/*
  * Front-end function called by the Fortran MPI-1 API functions to set
  * an attribute.
  */
-int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *object, 
-                               opal_hash_table_t **attr_hash,
-                               int key, MPI_Fint attribute, 
-                               bool predefined)
+int ompi_attr_set_fint(ompi_attribute_type_t type, void *object,
+                       opal_hash_table_t **attr_hash,
+                       int key, MPI_Fint attribute,
+                       bool predefined)
 {
     int ret;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
@@ -705,7 +791,7 @@ int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *object,
 
     new_attr->av_value = (void *) 0;
     *new_attr->av_integer_pointer = attribute;
-    new_attr->av_set_from = OMPI_ATTRIBUTE_FORTRAN_MPI1;
+    new_attr->av_set_from = OMPI_ATTRIBUTE_FINT;
     ret = set_value(type, object, attr_hash, key, new_attr, predefined);
     if (OMPI_SUCCESS != ret) {
         OBJ_RELEASE(new_attr);
@@ -722,10 +808,10 @@ int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *object,
  * Front-end function called by the Fortran MPI-2 API functions to set
  * an attribute.
  */
-int ompi_attr_set_fortran_mpi2(ompi_attribute_type_t type, void *object, 
-                               opal_hash_table_t **attr_hash,
-                               int key, MPI_Aint attribute, 
-                               bool predefined)
+int ompi_attr_set_aint(ompi_attribute_type_t type, void *object,
+                       opal_hash_table_t **attr_hash,
+                       int key, MPI_Aint attribute,
+                       bool predefined)
 {
     int ret;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
@@ -736,7 +822,7 @@ int ompi_attr_set_fortran_mpi2(ompi_attribute_type_t type, void *object,
     OPAL_THREAD_LOCK(&attribute_lock);
 
     new_attr->av_value = (void *) attribute;
-    new_attr->av_set_from = OMPI_ATTRIBUTE_FORTRAN_MPI2;
+    new_attr->av_set_from = OMPI_ATTRIBUTE_AINT;
     ret = set_value(type, object, attr_hash, key, new_attr, predefined);
     if (OMPI_SUCCESS != ret) {
         OBJ_RELEASE(new_attr);
@@ -777,8 +863,8 @@ int ompi_attr_get_c(opal_hash_table_t *attr_hash, int key,
  * Front-end function called by the Fortran MPI-1 API functions to get
  * attributes.
  */
-int ompi_attr_get_fortran_mpi1(opal_hash_table_t *attr_hash, int key, 
-                               MPI_Fint *attribute, int *flag)
+int ompi_attr_get_fint(opal_hash_table_t *attr_hash, int key,
+                       MPI_Fint *attribute, int *flag)
 {
     attribute_value_t *val = NULL;
     int ret;
@@ -787,7 +873,7 @@ int ompi_attr_get_fortran_mpi1(opal_hash_table_t *attr_hash, int key,
 
     ret = get_value(attr_hash, key, &val, flag);
     if (MPI_SUCCESS == ret && 1 == *flag) {
-        *attribute = translate_to_fortran_mpi1(val);
+        *attribute = translate_to_fint(val);
     }
 
     opal_atomic_wmb();
@@ -800,8 +886,8 @@ int ompi_attr_get_fortran_mpi1(opal_hash_table_t *attr_hash, int key,
  * Front-end function called by the Fortran MPI-2 API functions to get
  * attributes.
  */
-int ompi_attr_get_fortran_mpi2(opal_hash_table_t *attr_hash, int key, 
-                               MPI_Aint *attribute, int *flag)
+int ompi_attr_get_aint(opal_hash_table_t *attr_hash, int key,
+                       MPI_Aint *attribute, int *flag)
 {
     attribute_value_t *val = NULL;
     int ret;
@@ -810,7 +896,7 @@ int ompi_attr_get_fortran_mpi2(opal_hash_table_t *attr_hash, int key,
 
     ret = get_value(attr_hash, key, &val, flag);
     if (MPI_SUCCESS == ret && 1 == *flag) {
-        *attribute = translate_to_fortran_mpi2(val);
+        *attribute = translate_to_aint(val);
     }
 
     opal_atomic_wmb();
@@ -903,10 +989,10 @@ int ompi_attr_copy_all(ompi_attribute_type_t type, void *old_object,
            -- not .TRUE. */
         if (1 == flag) {
             if (0 != (hash_value->attr_flag & OMPI_KEYVAL_F77)) {
-                if (0 != (hash_value->attr_flag & OMPI_KEYVAL_F77_MPI1)) {
-                    new_attr->av_set_from = OMPI_ATTRIBUTE_FORTRAN_MPI1;
+                if (0 != (hash_value->attr_flag & OMPI_KEYVAL_F77_INT)) {
+                    new_attr->av_set_from = OMPI_ATTRIBUTE_FINT;
                 } else {
-                    new_attr->av_set_from = OMPI_ATTRIBUTE_FORTRAN_MPI2;
+                    new_attr->av_set_from = OMPI_ATTRIBUTE_AINT;
                 }
             } else {
                 new_attr->av_set_from = OMPI_ATTRIBUTE_C;
@@ -1233,19 +1319,21 @@ static void *translate_to_c(attribute_value_t *val)
 {
     switch (val->av_set_from) {
     case OMPI_ATTRIBUTE_C:
-        /* Case 1: written in C, read in C (unity) */
+        /* Case 1: wrote a C pointer, read a C pointer
+           (unity) */
         return val->av_value;
-        break;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI1:
-        /* Case 4: written in Fortran MPI-1, read in C */
+    case OMPI_ATTRIBUTE_INT:
+        /* Case 4: wrote an int, read a C pointer */
+        return (void *) val->av_int_pointer;
+
+    case OMPI_ATTRIBUTE_FINT:
+        /* Case 7: wrote a MPI_Fint, read a C pointer */
         return (void *) val->av_integer_pointer;
-        break;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI2:
-        /* Case 7: written in Fortran MPI-2, read in C */
+    case OMPI_ATTRIBUTE_AINT:
+        /* Case 10: wrote a MPI_Aint, read a C pointer */
         return (void *) val->av_address_kind_pointer;
-        break;
 
     default:
         /* Should never reach here */
@@ -1261,24 +1349,25 @@ static void *translate_to_c(attribute_value_t *val)
  * This function does not fail -- it is only invoked in "safe"
  * situations.
  */
-static MPI_Fint translate_to_fortran_mpi1(attribute_value_t *val)
+static MPI_Fint translate_to_fint(attribute_value_t *val)
 {
     switch (val->av_set_from) {
     case OMPI_ATTRIBUTE_C:
-        /* Case 2: written in C, read in Fortran MPI-1 */
-        return *val->av_integer_pointer;
-        break;
+        /* Case 2: wrote a C pointer, read a MPI_Fint */
+        return (MPI_Fint)*val->av_int_pointer;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI1:
-        /* Case 5: written in Fortran MPI-1, read in Fortran MPI-1
+    case OMPI_ATTRIBUTE_INT:
+        /* Case 5: wrote an int, read a MPI_Fint */
+        return (MPI_Fint)*val->av_int_pointer;
+
+    case OMPI_ATTRIBUTE_FINT:
+        /* Case 8: wrote a MPI_Fint, read a MPI_Fint
            (unity) */
         return *val->av_integer_pointer;
-        break;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI2:
-        /* Case 8: written in Fortran MPI-2, read in Fortran MPI-1 */
-        return *val->av_integer_pointer;
-        break;
+    case OMPI_ATTRIBUTE_AINT:
+        /* Case 11: wrote a MPI_Aint, read a MPI_Fint */
+        return (MPI_Fint)*val->av_integer_pointer;
 
     default:
         /* Should never reach here */
@@ -1294,24 +1383,25 @@ static MPI_Fint translate_to_fortran_mpi1(attribute_value_t *val)
  * This function does not fail -- it is only invoked in "safe"
  * situations.
  */
-static MPI_Aint translate_to_fortran_mpi2(attribute_value_t *val)
+static MPI_Aint translate_to_aint(attribute_value_t *val)
 {
     switch (val->av_set_from) {
     case OMPI_ATTRIBUTE_C:
-        /* Case 3: written in C, read in Fortran MPI-2 */
+       /* Case 3: wrote a C pointer, read a MPI_Aint */
         return (MPI_Aint) val->av_value;
-        break;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI1:
-        /* Case 6: written in Fortran MPI-1, read in Fortran MPI-2 */
+    case OMPI_ATTRIBUTE_INT:
+        /* Case 6: wrote an int, read a MPI_Aint */
+        return (MPI_Aint) *val->av_int_pointer;
+
+    case OMPI_ATTRIBUTE_FINT:
+        /* Case 9: wrote a MPI_Fint, read a MPI_Aint */
         return (MPI_Aint) *val->av_integer_pointer;
-        break;
 
-    case OMPI_ATTRIBUTE_FORTRAN_MPI2:
-        /* Case 9: written in Fortran MPI-2, read in Fortran MPI-2
+    case OMPI_ATTRIBUTE_AINT:
+        /* Case 12: wrote a MPI_Aint, read a MPI_Aint
            (unity) */
         return (MPI_Aint) val->av_value;
-        break;
 
     default:
         /* Should never reach here */

--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -41,7 +43,7 @@
  */
 #define OMPI_KEYVAL_PREDEFINED     0x0001
 #define OMPI_KEYVAL_F77            0x0002
-#define OMPI_KEYVAL_F77_MPI1       0x0004
+#define OMPI_KEYVAL_F77_INT        0x0004
 
 
 BEGIN_C_DECLS
@@ -62,14 +64,14 @@ typedef enum ompi_attribute_type_t ompi_attribute_type_t;
    delete. These will only be used here and not in the front end
    functions. */
 
-typedef void (ompi_mpi1_fortran_copy_attr_function)(MPI_Fint *oldobj, 
+typedef void (ompi_fint_copy_attr_function)(MPI_Fint *oldobj,
                                                     MPI_Fint *keyval,
                                                     MPI_Fint *extra_state, 
                                                     MPI_Fint *attr_in,
                                                     MPI_Fint *attr_out,
                                                     ompi_fortran_logical_t *flag,
                                                     MPI_Fint *ierr);
-typedef void (ompi_mpi1_fortran_delete_attr_function)(MPI_Fint *obj, 
+typedef void (ompi_fint_delete_attr_function)(MPI_Fint *obj,
                                                       MPI_Fint *keyval,
                                                       MPI_Fint *attr_in,
                                                       MPI_Fint *extra_state, 
@@ -79,18 +81,18 @@ typedef void (ompi_mpi1_fortran_delete_attr_function)(MPI_Fint *obj,
    delete. These will only be used here and not in the front end
    functions. */
 
-typedef void (ompi_mpi2_fortran_copy_attr_function)(MPI_Fint *oldobj, 
-                                                    MPI_Fint *keyval,
-                                                    void *extra_state, 
-                                                    void *attr_in, 
-                                                    void *attr_out,
-                                                    ompi_fortran_logical_t *flag,
-                                                    MPI_Fint *ierr);
-typedef void (ompi_mpi2_fortran_delete_attr_function)(MPI_Fint *obj, 
-                                                      MPI_Fint *keyval,
-                                                      void *attr_in,
-                                                      void *extra_state, 
-                                                      MPI_Fint *ierr);
+typedef void (ompi_aint_copy_attr_function)(MPI_Fint *oldobj,
+                                            MPI_Fint *keyval,
+                                            void *extra_state,
+                                            void *attr_in,
+                                            void *attr_out,
+                                            ompi_fortran_logical_t *flag,
+                                            MPI_Fint *ierr);
+typedef void (ompi_aint_delete_attr_function)(MPI_Fint *obj,
+                                              MPI_Fint *keyval,
+                                              void *attr_in,
+                                              void *extra_state,
+                                              MPI_Fint *ierr);
 /*
  * Internally the copy function for all kinds of MPI objects has one more
  * argument, the pointer to the new object. Therefore, we can do on the
@@ -123,14 +125,14 @@ union ompi_attribute_fn_ptr_union_t {
     MPI_Win_internal_copy_attr_function    *attr_win_copy_fn;
 
     /* For Fortran old MPI-1 callback functions */
-    
-    ompi_mpi1_fortran_delete_attr_function *attr_mpi1_fortran_delete_fn;
-    ompi_mpi1_fortran_copy_attr_function   *attr_mpi1_fortran_copy_fn;
+
+    ompi_fint_delete_attr_function *attr_fint_delete_fn;
+    ompi_fint_copy_attr_function   *attr_fint_copy_fn;
 
     /* For Fortran new MPI-2 callback functions */
-    
-    ompi_mpi2_fortran_delete_attr_function *attr_mpi2_fortran_delete_fn;
-    ompi_mpi2_fortran_copy_attr_function   *attr_mpi2_fortran_copy_fn;
+
+    ompi_aint_delete_attr_function *attr_aint_delete_fn;
+    ompi_aint_copy_attr_function   *attr_aint_copy_fn;
 };
 
 typedef union ompi_attribute_fn_ptr_union_t ompi_attribute_fn_ptr_union_t;
@@ -297,8 +299,8 @@ int ompi_attr_free_keyval(ompi_attribute_type_t type, int *key,
  * If (*attr_hash) == NULL, a new hash will be created and
  * initialized.
  *
- * All three of these functions (ompi_attr_set_c(),
- * ompi_attr_set_fortran_mpi1(), and ompi_attr_set_fortran_mpi2())
+ * All four of these functions (ompi_attr_set_c(), ompi_attr_set_int(),
+ * ompi_attr_set_fint(), and ompi_attr_set_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -311,6 +313,35 @@ int ompi_attr_free_keyval(ompi_attribute_type_t type, int *key,
 int ompi_attr_set_c(ompi_attribute_type_t type, void *object, 
                     opal_hash_table_t **attr_hash,
                     int key, void *attribute, bool predefined);
+
+/**
+ * Set an int predefined attribute in a form valid for C.
+ *
+ * @param type           Type of attribute (COMM/WIN/DTYPE) (IN)
+ * @param object         The actual Comm/Win/Datatype object (IN)
+ * @param attr_hash      The attribute hash table hanging on the object(IN/OUT)
+ * @param key            Key val for the attribute (IN)
+ * @param attribute      The actual attribute value (IN)
+ * @param predefined     Whether the key is predefined or not 0/1 (IN)
+ * @return OMPI error code
+ *
+ * If (*attr_hash) == NULL, a new hash will be created and
+ * initialized.
+ *
+ * All four of these functions (ompi_attr_set_c(), ompi_attr_set_int(),
+ * ompi_attr_set_fint(), and ompi_attr_set_aint())
+ * could have been combined into one function that took some kind of
+ * (void*) and an enum to indicate which way to translate the final
+ * representation, but that just seemed to make an already complicated
+ * situation more complicated through yet another layer of
+ * indirection.
+ *
+ * So yes, this is more code, but it's clearer and less error-prone
+ * (read: better) this way.
+ */
+int ompi_attr_set_int(ompi_attribute_type_t type, void *object,
+                      opal_hash_table_t **attr_hash,
+                      int key, int attribute, bool predefined);
 
 /**
  * Set an attribute on the comm/win/datatype in a form valid for
@@ -327,8 +358,8 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
  * If (*attr_hash) == NULL, a new hash will be created and
  * initialized.
  *
- * All three of these functions (ompi_attr_set_c(),
- * ompi_attr_set_fortran_mpi1(), and ompi_attr_set_fortran_mpi2())
+ * All four of these functions (ompi_attr_set_c(), ompi_attr_set_int(),
+ * ompi_attr_set_fint(), and ompi_attr_set_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -338,10 +369,10 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
  * So yes, this is more code, but it's clearer and less error-prone
  * (read: better) this way.
  */
-OMPI_DECLSPEC int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *object, 
-                                             opal_hash_table_t **attr_hash,
-                                             int key, MPI_Fint attribute, 
-                                             bool predefined);
+OMPI_DECLSPEC int ompi_attr_set_fint(ompi_attribute_type_t type, void *object,
+                                     opal_hash_table_t **attr_hash,
+                                     int key, MPI_Fint attribute,
+                                     bool predefined);
 
 /**
  * Set an attribute on the comm/win/datatype in a form valid for
@@ -358,8 +389,8 @@ OMPI_DECLSPEC int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *o
  * If (*attr_hash) == NULL, a new hash will be created and
  * initialized.
  *
- * All three of these functions (ompi_attr_set_c(),
- * ompi_attr_set_fortran_mpi1(), and ompi_attr_set_fortran_mpi2())
+ * All four of these functions (ompi_attr_set_c(), ompi_attr_set_int(),
+ * ompi_attr_set_fint(), and ompi_attr_set_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -369,10 +400,10 @@ OMPI_DECLSPEC int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *o
  * So yes, this is more code, but it's clearer and less error-prone
  * (read: better) this way.
  */
-OMPI_DECLSPEC int ompi_attr_set_fortran_mpi2(ompi_attribute_type_t type, void *object, 
-                                             opal_hash_table_t **attr_hash,
-                                             int key, MPI_Aint attribute, 
-                                             bool predefined);
+OMPI_DECLSPEC int ompi_attr_set_aint(ompi_attribute_type_t type, void *object,
+                                     opal_hash_table_t **attr_hash,
+                                     int key, MPI_Aint attribute,
+                                     bool predefined);
 
 /**
  * Get an attribute on the comm/win/datatype in a form valid for C.
@@ -385,7 +416,7 @@ OMPI_DECLSPEC int ompi_attr_set_fortran_mpi2(ompi_attribute_type_t type, void *o
  * @return OMPI error code
  *
  * All three of these functions (ompi_attr_get_c(),
- * ompi_attr_get_fortran_mpi1(), and ompi_attr_get_fortran_mpi2())
+ * ompi_attr_get_fint(), and ompi_attr_get_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -412,7 +443,7 @@ int ompi_attr_get_c(opal_hash_table_t *attr_hash, int key,
  * @return OMPI error code
  *
  * All three of these functions (ompi_attr_get_c(),
- * ompi_attr_get_fortran_mpi1(), and ompi_attr_get_fortran_mpi2())
+ * ompi_attr_get_fint(), and ompi_attr_get_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -423,8 +454,8 @@ int ompi_attr_get_c(opal_hash_table_t *attr_hash, int key,
  * (read: better) this way.
  */
 
-    OMPI_DECLSPEC int ompi_attr_get_fortran_mpi1(opal_hash_table_t *attr_hash, int key, 
-                                                 MPI_Fint *attribute, int *flag);
+    OMPI_DECLSPEC int ompi_attr_get_fint(opal_hash_table_t *attr_hash, int key,
+                                         MPI_Fint *attribute, int *flag);
 
 
 /**
@@ -439,7 +470,7 @@ int ompi_attr_get_c(opal_hash_table_t *attr_hash, int key,
  * @return OMPI error code
  *
  * All three of these functions (ompi_attr_get_c(),
- * ompi_attr_get_fortran_mpi1(), and ompi_attr_get_fortran_mpi2())
+ * ompi_attr_get_fint(), and ompi_attr_get_aint())
  * could have been combined into one function that took some kind of
  * (void*) and an enum to indicate which way to translate the final
  * representation, but that just seemed to make an already complicated
@@ -450,8 +481,8 @@ int ompi_attr_get_c(opal_hash_table_t *attr_hash, int key,
  * (read: better) this way.
  */
 
-OMPI_DECLSPEC int ompi_attr_get_fortran_mpi2(opal_hash_table_t *attr_hash, int key, 
-                                             MPI_Aint *attribute, int *flag);
+OMPI_DECLSPEC int ompi_attr_get_aint(opal_hash_table_t *attr_hash, int key,
+                                     MPI_Aint *attribute, int *flag);
 
 
 /**

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -272,8 +274,8 @@ static int free_win(int keyval)
 
 static int set_f(int keyval, MPI_Fint value)
 {
-    return ompi_attr_set_fortran_mpi1(COMM_ATTR, MPI_COMM_WORLD,
-                                      &MPI_COMM_WORLD->c_keyhash,
-                                      keyval, value,
-                                      true);
+    return ompi_attr_set_fint(COMM_ATTR, MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              keyval, value,
+                              true);
 }

--- a/ompi/mpi/c/add_error_class.c
+++ b/ompi/mpi/c/add_error_class.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -65,12 +67,12 @@ int MPI_Add_error_class(int *errorclass)
     ** in attribute/attribute.c and attribute/attribute_predefined.c
     ** why we have to call the fortran attr_set function 
     */
-    rc  = ompi_attr_set_fortran_mpi1 (COMM_ATTR, 
-				      MPI_COMM_WORLD,
-				      &MPI_COMM_WORLD->c_keyhash,
-				      MPI_LASTUSEDCODE, 
-				      ompi_mpi_errcode_lastused,
-				      true);
+    rc  = ompi_attr_set_fint (COMM_ATTR,
+                              MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              MPI_LASTUSEDCODE,
+                              ompi_mpi_errcode_lastused,
+                              true);
     if ( MPI_SUCCESS != rc ) {
 	return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, rc, FUNC_NAME);
     }

--- a/ompi/mpi/c/add_error_code.c
+++ b/ompi/mpi/c/add_error_code.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -72,12 +74,12 @@ int MPI_Add_error_code(int errorclass, int *errorcode)
     ** in attribute/attribute.c and attribute/attribute_predefined.c
     ** why we have to call the fortran attr_set function 
     */
-    rc  = ompi_attr_set_fortran_mpi1 (COMM_ATTR, 
-				      MPI_COMM_WORLD,
-				      &MPI_COMM_WORLD->c_keyhash,
-				      MPI_LASTUSEDCODE, 
-				      ompi_mpi_errcode_lastused,
-				      true);
+    rc  = ompi_attr_set_fint (COMM_ATTR,
+                              MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              MPI_LASTUSEDCODE,
+                              ompi_mpi_errcode_lastused,
+                              true);
     if ( MPI_SUCCESS != rc ) {
 	return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, rc, FUNC_NAME);
     }

--- a/ompi/mpi/fortran/mpif-h/attr_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/attr_get_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -76,10 +78,10 @@ void ompi_attr_get_f(MPI_Fint *comm, MPI_Fint *keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi1(c_comm->c_keyhash, 
-                                        OMPI_FINT_2_INT(*keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_fint(c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/attr_put_f.c
+++ b/ompi/mpi/fortran/mpif-h/attr_put_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -75,11 +77,11 @@ void ompi_attr_put_f(MPI_Fint *comm, MPI_Fint *keyval, MPI_Fint *attribute_val,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_err = ompi_attr_set_fortran_mpi1(COMM_ATTR,
-                                       c_comm,
-                                       &c_comm->c_keyhash,
-                                       OMPI_FINT_2_INT(*keyval), 
-                                       *attribute_val,
-                                       false);
+    c_err = ompi_attr_set_fint(COMM_ATTR,
+                               c_comm,
+                               &c_comm->c_keyhash,
+                               OMPI_FINT_2_INT(*keyval),
+                               *attribute_val,
+                               false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_err);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
@@ -36,7 +36,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_COMM_CREATE_KEYVAL,
                            pmpi_comm_create_keyval_,
                            pmpi_comm_create_keyval__,
                            pompi_comm_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
 #endif
 
@@ -56,7 +56,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
                            mpi_comm_create_keyval_,
                            mpi_comm_create_keyval__,
                            ompi_comm_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
 #endif
 
@@ -67,8 +67,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
 
      static const char FUNC_NAME[] = "MPI_Comm_create_keyval_f";
 
-void ompi_comm_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn,
-                              ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn,
+void ompi_comm_create_keyval_f(ompi_aint_copy_attr_function* comm_copy_attr_fn,
+                              ompi_aint_delete_attr_function* comm_delete_attr_fn,
                               MPI_Fint *comm_keyval,
                               MPI_Aint *extra_state, MPI_Fint *ierr)
 {
@@ -76,8 +76,8 @@ void ompi_comm_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* comm_copy_a
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = comm_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = comm_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = comm_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = comm_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/comm_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -77,10 +79,10 @@ void ompi_comm_get_attr_f(MPI_Fint *comm, MPI_Fint *comm_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_comm->c_keyhash,
-                                        OMPI_FINT_2_INT(*comm_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*comm_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/comm_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_set_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -75,11 +77,11 @@ void ompi_comm_set_attr_f(MPI_Fint *comm, MPI_Fint *comm_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(COMM_ATTR,
-                                        c_comm,
-                                        &c_comm->c_keyhash,
-                                        OMPI_FINT_2_INT(*comm_keyval), 
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(COMM_ATTR,
+                                c_comm,
+                                &c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*comm_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/keyval_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/keyval_create_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -36,7 +38,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_KEYVAL_CREATE,
                            pmpi_keyval_create_,
                            pmpi_keyval_create__,
                            pompi_keyval_create_f,
-                           (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
                            (copy_fn, delete_fn, keyval, extra_state, ierr) )
 #endif
 
@@ -56,7 +58,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
                            mpi_keyval_create_,
                            mpi_keyval_create__,
                            ompi_keyval_create_f,
-                           (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
                            (copy_fn, delete_fn, keyval, extra_state, ierr) )
 #endif
 
@@ -67,17 +69,17 @@ OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
 
 static const char FUNC_NAME[] = "MPI_keyval_create_f";
 
-void ompi_keyval_create_f(ompi_mpi1_fortran_copy_attr_function* copy_attr_fn,
-                         ompi_mpi1_fortran_delete_attr_function* delete_attr_fn,
-                         MPI_Fint *keyval, MPI_Fint *extra_state, 
+void ompi_keyval_create_f(ompi_fint_copy_attr_function* copy_attr_fn,
+                         ompi_fint_delete_attr_function* delete_attr_fn,
+                         MPI_Fint *keyval, MPI_Fint *extra_state,
                          MPI_Fint *ierr)
 {
     int ret, c_ierr;
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi1_fortran_copy_fn = copy_attr_fn;
-    del_fn.attr_mpi1_fortran_delete_fn = delete_attr_fn;
+    copy_fn.attr_fint_copy_fn = copy_attr_fn;
+    del_fn.attr_fint_delete_fn = delete_attr_fn;
 
     /* Set the "F77_OLD" bit to denote that the callbacks should use
        the old MPI-1 INTEGER-parameter functions (as opposed to the
@@ -85,8 +87,8 @@ void ompi_keyval_create_f(ompi_mpi1_fortran_copy_attr_function* copy_attr_fn,
        functions). */
 
     ret = ompi_attr_create_keyval_fint(COMM_ATTR, copy_fn, del_fn,
-                                       keyval, *extra_state,
-                                       OMPI_KEYVAL_F77 | OMPI_KEYVAL_F77_MPI1,
+                                       OMPI_SINGLE_NAME_CONVERT(keyval), *extra_state,
+                                       OMPI_KEYVAL_F77,
                                        NULL);
 
     if (MPI_SUCCESS != ret) {

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2011-2013 Universite Bordeaux 1
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -120,7 +122,7 @@ PN2(void, MPI_Comm_call_errhandler, mpi_comm_call_errhandler, MPI_COMM_CALL_ERRH
 PN2(void, MPI_Comm_compare, mpi_comm_compare, MPI_COMM_COMPARE, (MPI_Fint *comm1, MPI_Fint *comm2, MPI_Fint *result, MPI_Fint *ierr));
 PN2(void, MPI_Comm_connect, mpi_comm_connect, MPI_COMM_CONNECT, (char *port_name, MPI_Fint *info, MPI_Fint *root, MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr, int port_name_len));
 PN2(void, MPI_Comm_create_errhandler, mpi_comm_create_errhandler, MPI_COMM_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create, mpi_comm_create, MPI_COMM_CREATE, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create_group, mpi_comm_create_group, MPI_COMM_CREATE_GROUP, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *tag, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_delete_attr, mpi_comm_delete_attr, MPI_COMM_DELETE_ATTR, (MPI_Fint *comm, MPI_Fint *comm_keyval, MPI_Fint *ierr));
@@ -299,7 +301,7 @@ PN2(void, MPI_Irsend, mpi_irsend, MPI_IRSEND, (char *buf, MPI_Fint *count, MPI_F
 PN2(void, MPI_Isend, mpi_isend, MPI_ISEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Issend, mpi_issend, MPI_ISSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Is_thread_main, mpi_is_thread_main, MPI_IS_THREAD_MAIN, (ompi_fortran_logical_t *flag, MPI_Fint *ierr));
-PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Keyval_free, mpi_keyval_free, MPI_KEYVAL_FREE, (MPI_Fint *keyval, MPI_Fint *ierr));
 PN2(void, MPI_Lookup_name, mpi_lookup_name, MPI_LOOKUP_NAME, (char *service_name, MPI_Fint *info, char *port_name, MPI_Fint *ierr, int service_name_len, int port_name_len));
 PN2(void, MPI_Mprobe, mpi_mprobe, MPI_MPROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *message, MPI_Fint *status, MPI_Fint *ierr));
@@ -365,7 +367,7 @@ PN2(void, MPI_Type_create_f90_integer, mpi_type_create_f90_integer, MPI_TYPE_CRE
 PN2(void, MPI_Type_create_f90_real, mpi_type_create_f90_real, MPI_TYPE_CREATE_F90_REAL, (MPI_Fint *p, MPI_Fint *r, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed, mpi_type_create_hindexed, MPI_TYPE_CREATE_HINDEXED, (MPI_Fint *count, MPI_Fint *array_of_blocklengths, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hvector, mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *stride, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
-PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_indexed_block, mpi_type_create_indexed_block, MPI_TYPE_CREATE_INDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Fint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed_block, mpi_type_create_hindexed_block, MPI_TYPE_CREATE_HINDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_struct, mpi_type_create_struct, MPI_TYPE_CREATE_STRUCT, (MPI_Fint *count, MPI_Fint *array_of_block_lengths, MPI_Aint *array_of_displacements, MPI_Fint *array_of_types, MPI_Fint *newtype, MPI_Fint *ierr));
@@ -413,7 +415,7 @@ PN2(void, MPI_Win_complete, mpi_win_complete, MPI_WIN_COMPLETE, (MPI_Fint *win, 
 PN2(void, MPI_Win_create, mpi_win_create, MPI_WIN_CREATE, (char *base, MPI_Aint *size, MPI_Fint *disp_unit, MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_dynamic, mpi_win_create_dynamic, MPI_WIN_CREATE_DYNAMIC, (MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_errhandler, mpi_win_create_errhandler, MPI_WIN_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL, (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Win_delete_attr, mpi_win_delete_attr, MPI_WIN_DELETE_ATTR, (MPI_Fint *win, MPI_Fint *win_keyval, MPI_Fint *ierr));
 PN2(void, MPI_Win_detach, mpi_win_detach, MPI_WIN_DETACH, (MPI_Fint *win, char *base, MPI_Fint *ierr));
 PN2(void, MPI_Win_fence, mpi_win_fence, MPI_WIN_FENCE, (MPI_Fint *assert, MPI_Fint *win, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
@@ -36,7 +36,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_TYPE_CREATE_KEYVAL,
                            pmpi_type_create_keyval_,
                            pmpi_type_create_keyval__,
                            pompi_type_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
 #endif
 
@@ -56,7 +56,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
                            mpi_type_create_keyval_,
                            mpi_type_create_keyval__,
                            ompi_type_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
 #endif
 
@@ -67,16 +67,16 @@ OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Type_create_keyval_f";
 
-void ompi_type_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn,
-                               ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn,
+void ompi_type_create_keyval_f(ompi_aint_copy_attr_function* type_copy_attr_fn,
+                               ompi_aint_delete_attr_function* type_delete_attr_fn,
                                MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = type_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = type_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = type_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = type_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/type_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -77,10 +79,10 @@ void ompi_type_get_attr_f(MPI_Fint *type, MPI_Fint *type_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_type->d_keyhash,
-                                        OMPI_FINT_2_INT(*type_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_type->d_keyhash,
+                                OMPI_FINT_2_INT(*type_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/type_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_set_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -74,11 +76,11 @@ void ompi_type_set_attr_f(MPI_Fint *type, MPI_Fint *type_keyval, MPI_Aint *attri
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(TYPE_ATTR,
-                                        c_type,
-                                        &c_type->d_keyhash,
-                                        OMPI_FINT_2_INT(*type_keyval), 
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(TYPE_ATTR,
+                                c_type,
+                                &c_type->d_keyhash,
+                                OMPI_FINT_2_INT(*type_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
@@ -36,7 +36,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_WIN_CREATE_KEYVAL,
                            pmpi_win_create_keyval_,
                            pmpi_win_create_keyval__,
                            pompi_win_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
 #endif
 
@@ -56,7 +56,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
                            mpi_win_create_keyval_,
                            mpi_win_create_keyval__,
                            ompi_win_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
 #endif
 
@@ -67,16 +67,16 @@ OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Win_create_keyval";
 
-void ompi_win_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn,
-                             ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn,
+void ompi_win_create_keyval_f(ompi_aint_copy_attr_function* win_copy_attr_fn,
+                             ompi_aint_delete_attr_function* win_delete_attr_fn,
                              MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = win_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = win_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = win_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = win_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/win_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -76,10 +78,10 @@ void ompi_win_get_attr_f(MPI_Fint *win, MPI_Fint *win_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_win->w_keyhash,
-                                        OMPI_FINT_2_INT(*win_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_win->w_keyhash,
+                                OMPI_FINT_2_INT(*win_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     OMPI_SINGLE_INT_2_LOGICAL(flag);
 }

--- a/ompi/mpi/fortran/mpif-h/win_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_set_attr_f.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -76,11 +78,11 @@ void ompi_win_set_attr_f(MPI_Fint *win, MPI_Fint *win_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(WIN_ATTR,
-                                        c_win,
-                                        &c_win->w_keyhash,
-                                        OMPI_FINT_2_INT(*win_keyval), 
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(WIN_ATTR,
+                                c_win,
+                                &c_win->w_keyhash,
+                                OMPI_FINT_2_INT(*win_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
@@ -113,8 +113,8 @@ void ompi_win_shared_query_f(MPI_Fint *win, MPI_Fint *rank, MPI_Aint *size,
 
     c_win = MPI_Win_f2c(*win);
 
-    c_ierr = MPI_Win_shared_query(c_win, OMPI_FINT_2_INT(*rank), size,
-                                  OMPI_FINT_2_INT(disp_unit), baseptr);
+    c_ierr = PMPI_Win_shared_query(c_win, OMPI_FINT_2_INT(*rank), size,
+                                   OMPI_SINGLE_NAME_CONVERT(disp_unit), baseptr);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }
 

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -136,25 +136,25 @@ config_window(void *base, size_t size, int disp_unit,
                           MPI_WIN_BASE, base, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi2(WIN_ATTR, win, 
-                                     &win->w_keyhash, 
-                                     MPI_WIN_SIZE, size, true);
+    ret = ompi_attr_set_aint(WIN_ATTR, win,
+                             &win->w_keyhash,
+                             MPI_WIN_SIZE, size, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_DISP_UNIT, disp_unit,
-                                     true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_DISP_UNIT, disp_unit,
+                            true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_CREATE_FLAVOR, flavor, true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_CREATE_FLAVOR, flavor, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_MODEL, model, true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_MODEL, model, true);
     if (OMPI_SUCCESS != ret) return ret;
 
     win->w_f_to_c_index = opal_pointer_array_add(&ompi_mpi_windows, win);


### PR DESCRIPTION
we now have 12 cases to deal (4 writers and 3 readers) :
1. C `void*` is written into the attribute value, and the value is read into a C `void*` (unity)
2. C `void*` is written, Fortran `INTEGER` is read
3. C `void*` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read
4. Fortran `INTEGER` is written, C `void*` is read
5. Fortran `INTEGER` is written, Fortran `INTEGER` is read (unity)
6. Fortran `INTEGER` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read
7. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, C `void*` is read
8. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, Fortran `INTEGER` is read
9. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read (unity)
10. Intrinsic is written, C `void*` is read
11. Intrinsic is written, Fortran `INTEGER` is read
12. Intrinsic is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read

(back-ported from commit open-mpi/ompi@5c50a5f7505b9492d256ca2326d23988761458e4)
