### PR TITLE
ompi/op: Provide a default value for type/flags

### DIFF
--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -443,6 +443,10 @@ static void ompi_op_construct(ompi_op_t *new_op)
 {
     int i;
 
+    /* Provide a default of a high value. Useful for non-predefined ops. */
+    new_op->op_type = OMPI_OP_NUM_OF_TYPES;
+    new_op->o_flags = 0;
+
     /* assign entry in fortran <-> c translation array */
 
     new_op->o_f_to_c_index =


### PR DESCRIPTION
- User defined ops leave the op_type unset which can confuse logic
  in a collective component that is trying to convert the op to the
  approprate local function.

(cherry picked from commit open-mpi/ompi@a776d78f2d77c17958a1e851a57f1c345fe0baa1)
