### PR TITLE
Fix the basic barrier.

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_barrier.c
+++ b/ompi/mca/coll/basic/coll_basic_barrier.c
@@ -55,9 +55,6 @@ mca_coll_basic_barrier_intra_log(struct ompi_communicator_t *comm,
 
     dim = comm->c_cube_dim;
     hibit = opal_hibit(rank, dim);
-    if (hibit < 0) {
-        return MPI_ERR_OTHER;
-    }
     --dim;
 
     /* Receive from children. */


### PR DESCRIPTION
The log basic barrier was completely broken. The rank 0 gets the
hibit set to 0, so it always returned an error.

(cherry picked from commit open-mpi/ompi@9376b0340b59b702aaa381083063c74287e6f3fb)

Fixed by @bosilca, reviewed by @jsquyres

@hppritcha This made the coll basic barrier totally busted.  Needs to be in v2.0.0.  It's good to go.
