### PR TITLE
coll/basic: fix mca_coll_basic_bcast_log_intra()

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_bcast.c
+++ b/ompi/mca/coll/basic/coll_basic_bcast.c
@@ -9,7 +9,9 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,14 +63,12 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
 
     dim = comm->c_cube_dim;
     hibit = opal_hibit(vrank, dim);
-    if (hibit < 0) {
-        return MPI_ERR_OTHER;
-    }
     --dim;
 
     /* Receive data from parent in the tree. */
 
     if (vrank > 0) {
+        assert(hibit >= 0);
         peer = ((vrank & ~(1 << hibit)) + root) % size;
 
         err = MCA_PML_CALL(recv(buff, count, datatype, peer,


### PR DESCRIPTION
The log basic bcast was completely broken. The rank 0 gets the
hibit set to -1, so it always returned an error.

(cherry picked from commit open-mpi/ompi@c976559877d8b5bf23e52c234d011771ae44a1d2)
