### PR TITLE
v2.x: ompi/datatype: Fix args of HINDEXED_BLOCK

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -786,7 +786,7 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         ompi_datatype_create_hindexed_block( i[0], i[1], a, d[0], &datatype );
         {
             const int* a_i[2] = {&i[0], &i[1]};
-            ompi_datatype_set_args( datatype, 2 + i[0], a_i, i[0], a, 1, d, MPI_COMBINER_HINDEXED_BLOCK );
+            ompi_datatype_set_args( datatype, 2, a_i, i[0], a, 1, d, MPI_COMBINER_HINDEXED_BLOCK );
         }
         break;
         /******************************************************************/


### PR DESCRIPTION
PR for v2.0.1

@bosilca please review

This is a coding bug but probably no defect for users.

bot:label:bug
bot:milestone:v2.0.1

(cherry picked from commit open-mpi/ompi@84b110a1f2e1952459aed5dd788261fe2e68a87b)
