### PR TITLE
openib: fix compiler warnings

### DIFF
--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -424,7 +424,6 @@ static int openib_btl_size_queues(struct mca_btl_openib_module_t* openib_btl)
     int rc = OPAL_SUCCESS;
     mca_btl_openib_device_t *device = openib_btl->device;
     uint32_t requested[BTL_OPENIB_MAX_CQ];
-    bool need_resize = false;
 
     opal_mutex_lock(&openib_btl->ib_lock);
 
@@ -451,7 +450,7 @@ static int openib_btl_size_queues(struct mca_btl_openib_module_t* openib_btl)
     for (int cq = 0 ; cq < BTL_OPENIB_MAX_CQ ; ++cq) {
         if (requested[cq] < mca_btl_openib_component.ib_cq_size[cq]) {
             requested[cq] = mca_btl_openib_component.ib_cq_size[cq];
-        } else if (requested[cq] > openib_btl->device->ib_dev_attr.max_cqe) {
+        } else if (requested[cq] > (uint32_t) openib_btl->device->ib_dev_attr.max_cqe) {
             requested[cq] = openib_btl->device->ib_dev_attr.max_cqe;
         }
 


### PR DESCRIPTION
Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@7a8d7fb9489f6575d022e5e2f83f6b01dde62f0c)

@hppritcha I marked this as v2.0.0; it's a pair of compiler warning fixes.  Keep in v2.0.0, or move to v2.0.1?
