### PR TITLE
osc/rdma: fix typo

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -517,10 +517,10 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
         if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
             for (int i = 0 ; i < local_size ; ++i) {
-                total_size += temp[i].size;
                 if (local_rank == i) {
                     my_base_offset = total_size;
                 }
+                total_size += temp[i].size;
             }
         }
 


### PR DESCRIPTION
Need to increment the total size after checking the local offset not
before. This typo causes large allocations with MPI_Win_allocate() to
fail.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@2409024c179f3261a52e8007487a52a50fc5799b)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

:bot:label:bug
:bot:milestone:v2.0.0
:bot:assign: @hppritcha 

This is an obvious bug that doesn't appear to occur with smaller memory windows. This needs to be in 2.0.0.
