### PR TITLE
ompi/request: fix performance regression

### DIFF
--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -416,8 +416,8 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
     if( OPAL_LIKELY(with_signal) ) {
         if(!OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, REQUEST_COMPLETED)) {
-            ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWP_PTR(&request->req_complete,
-                                                                                  REQUEST_COMPLETED);
+            ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
+                                                                                   REQUEST_COMPLETED);
             /* In the case where another thread concurrently changed the request to REQUEST_PENDING */
             if( REQUEST_PENDING != tmp_sync )
                 wait_sync_update(tmp_sync, 1, request->req_status.MPI_ERROR);

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -375,27 +375,25 @@ static inline int ompi_request_free(ompi_request_t** request)
  * Wait a particular request for completion
  */
 
-#if OPAL_ENABLE_MULTI_THREADS
 static inline void ompi_request_wait_completion(ompi_request_t *req)
 {
-    ompi_wait_sync_t sync;
-    WAIT_SYNC_INIT(&sync, 1);
+    if (opal_using_threads ()) {
+        ompi_wait_sync_t sync;
+        WAIT_SYNC_INIT(&sync, 1);
 
-    if(OPAL_ATOMIC_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
-        SYNC_WAIT(&sync);
-    }
+        if(OPAL_ATOMIC_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
+            SYNC_WAIT(&sync);
+        }
 
-    assert(REQUEST_COMPLETE(req));
-    WAIT_SYNC_RELEASE(&sync);
-}
-#else
-static inline void ompi_request_wait_completion(ompi_request_t *req)
-{
-    while(!REQUEST_COMPLETE(req)) {
-        opal_progress();
+        assert(REQUEST_COMPLETE(req));
+        WAIT_SYNC_RELEASE(&sync);
+    } else {
+        while(!REQUEST_COMPLETE(req)) {
+            opal_progress();
+        }
     }
 }
-#endif
+
 /**
  *  Signal or mark a request as complete. If with_signal is true this will
  *  wake any thread pending on the request. If with_signal is false, the

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -225,7 +225,7 @@ opal_progress(void)
         events += (callbacks[i])();
     }
 
-    if ((OPAL_THREAD_ADD32((volatile int32_t *) &num_calls, 1) & callbacks_lp_mask) == 0) {
+    if (callbacks_lp_len > 0 && (OPAL_THREAD_ADD32((volatile int32_t *) &num_calls, 1) & callbacks_lp_mask) == 0) {
         /* run low priority callbacks once every 8 calls to opal_progress() */
         for (i = 0 ; i < callbacks_lp_len ; ++i) {
             events += (callbacks_lp[i])();

--- a/opal/threads/mutex.h
+++ b/opal/threads/mutex.h
@@ -331,6 +331,20 @@ OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
 #endif
 
 
+static inline void *opal_thread_swap_ptr (volatile void *ptr, void *newvalue)
+{
+    if (opal_using_threads ()) {
+        return opal_atomic_swap_ptr (ptr, newvalue);
+    }
+
+    void *old = ((void **) ptr)[0];
+    ((void **) ptr)[0] = newvalue;
+
+    return old;
+}
+
+#define OPAL_ATOMIC_SWAP_PTR(x, y) opal_thread_swap_ptr (x, y)
+
 END_C_DECLS
 
 #endif                          /* OPAL_MUTEX_H */

--- a/opal/threads/wait_sync.c
+++ b/opal/threads/wait_sync.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2014-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,15 +22,6 @@ static ompi_wait_sync_t* wait_sync_list = NULL;
         pthread_cond_signal( &(who)->condition );      \
         pthread_mutex_unlock( &(who)->lock);           \
     } while(0)
-
-
-int sync_wait_st(ompi_wait_sync_t *sync)
-{
-    while(sync->count > 0) {
-        opal_progress();
-    }
-    return (0 == sync->status) ? OPAL_SUCCESS : OPAL_ERROR;
-}
 
 int sync_wait_mt(ompi_wait_sync_t *sync)
 {

--- a/opal/threads/wait_sync.h
+++ b/opal/threads/wait_sync.h
@@ -32,8 +32,6 @@ typedef struct ompi_wait_sync_t {
 #define REQUEST_COMPLETED      (void*)1L
 
 #define SYNC_WAIT(sync)                 (opal_using_threads() ? sync_wait_mt (sync) : sync_wait_st (sync))
-#define PTHREAD_COND_INIT(a,b)          (opal_using_threads() ? pthread_cond_init (a,b) : 0)
-#define PTHREAD_MUTEX_INIT(a,b)         (opal_using_threads() ? pthread_mutex_init (a,b) : 0)
 
 #define WAIT_SYNC_RELEASE(sync)                       \
     if (opal_using_threads()) {                       \
@@ -66,8 +64,8 @@ static inline int sync_wait_st (ompi_wait_sync_t *sync)
         (sync)->prev = NULL;                                    \
         (sync)->status = 0;                                     \
         if (opal_using_threads()) {                             \
-            PTHREAD_COND_INIT(&(sync)->condition, NULL);        \
-            PTHREAD_MUTEX_INIT(&(sync)->lock, NULL);            \
+            pthread_cond_init (&(sync)->condition, NULL);       \
+            pthread_mutex_init (&(sync)->lock, NULL);           \
         }                                                       \
     } while(0)
 

--- a/opal/threads/wait_sync.h
+++ b/opal/threads/wait_sync.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2014-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,50 +31,44 @@ typedef struct ompi_wait_sync_t {
 #define REQUEST_PENDING        (void*)0L
 #define REQUEST_COMPLETED      (void*)1L
 
-#if OPAL_ENABLE_MULTI_THREADS
-
-#define OPAL_ATOMIC_ADD_32(a,b)         opal_atomic_add_32(a,b)
-#define OPAL_ATOMIC_SWP_PTR(a,b)        opal_atomic_swap_ptr(a,b)
-#define SYNC_WAIT(sync)                 sync_wait_mt(sync)
-#define PTHREAD_COND_INIT(a,b)          pthread_cond_init(a,b)
-#define PTHREAD_MUTEX_INIT(a,b)         pthread_mutex_init(a,b)
+#define SYNC_WAIT(sync)                 (opal_using_threads() ? sync_wait_mt (sync) : sync_wait_st (sync))
+#define PTHREAD_COND_INIT(a,b)          (opal_using_threads() ? pthread_cond_init (a,b) : 0)
+#define PTHREAD_MUTEX_INIT(a,b)         (opal_using_threads() ? pthread_mutex_init (a,b) : 0)
 
 #define WAIT_SYNC_RELEASE(sync)                       \
-    do {                                              \
+    if (opal_using_threads()) {                       \
        pthread_cond_destroy(&(sync)->condition);      \
        pthread_mutex_destroy(&(sync)->lock);          \
-    } while(0)
+    }
 
 #define WAIT_SYNC_SIGNAL(sync)                        \
-    do {                                              \
+    if (opal_using_threads()) {                       \
         pthread_mutex_lock(&(sync->lock));            \
         pthread_cond_signal(&sync->condition);        \
         pthread_mutex_unlock(&(sync->lock));          \
-    } while(0)
-
-#else
-
-#define OPAL_ATOMIC_ADD_32(a,b)         (*(a) += (b))
-#define OPAL_ATOMIC_SWP_PTR(a,b)        *(a) = (b)
-#define PTHREAD_COND_INIT(a,b)
-#define PTHREAD_MUTEX_INIT(a,b)
-#define SYNC_WAIT(sync)                 sync_wait_st(sync)
-#define WAIT_SYNC_RELEASE(sync)
-#define WAIT_SYNC_SIGNAL(sync)
-
-#endif /* OPAL_ENABLE_MULTI_THREADS */
+    }
 
 OPAL_DECLSPEC int sync_wait_mt(ompi_wait_sync_t *sync);
-OPAL_DECLSPEC int sync_wait_st(ompi_wait_sync_t *sync);
+static inline int sync_wait_st (ompi_wait_sync_t *sync)
+{
+    while (sync->count > 0) {
+        opal_progress();
+    }
 
-#define WAIT_SYNC_INIT(sync,c)                        \
-    do {                                              \
-       (sync)->count = c;                             \
-       (sync)->next = NULL;                           \
-       (sync)->prev = NULL;                           \
-       (sync)->status = 0;                            \
-       PTHREAD_COND_INIT(&(sync)->condition, NULL);   \
-       PTHREAD_MUTEX_INIT(&(sync)->lock, NULL);       \
+    return sync->status;
+}
+
+
+#define WAIT_SYNC_INIT(sync,c)                                  \
+    do {                                                        \
+        (sync)->count = c;                                      \
+        (sync)->next = NULL;                                    \
+        (sync)->prev = NULL;                                    \
+        (sync)->status = 0;                                     \
+        if (opal_using_threads()) {                             \
+            PTHREAD_COND_INIT(&(sync)->condition, NULL);        \
+            PTHREAD_MUTEX_INIT(&(sync)->lock, NULL);            \
+        }                                                       \
     } while(0)
 
 /**
@@ -84,12 +80,13 @@ OPAL_DECLSPEC int sync_wait_st(ompi_wait_sync_t *sync);
 static inline void wait_sync_update(ompi_wait_sync_t *sync, int updates, int status)
 {
     if( OPAL_LIKELY(OPAL_SUCCESS == status) ) {
-        if( 0 != (OPAL_ATOMIC_ADD_32(&sync->count, -updates)) ) {
+        if( 0 != (OPAL_THREAD_ADD32(&sync->count, -updates)) ) {
             return;
         }
     } else {
-        OPAL_ATOMIC_CMPSET_32(&(sync->count), 0, 0);
-        sync->status = -1;
+        /* this is an error path so just use the atomic */
+        opal_atomic_swap_32 (&sync->count, 0);
+        sync->status = OPAL_ERROR;
     }
     WAIT_SYNC_SIGNAL(sync);
 }


### PR DESCRIPTION
This commit fixes a performance regression introduced by the request
rework. We were always using the multi-thread path because
OPAL_ENABLE_MULTI_THREADS is either not defined or always defined to 1
depending on the Open MPI version. To fix this I removed the
conditional and added a conditional on opal_using_threads(). This path
will be optimized out in 2.0.0 in a non-thread-multiple build as
opal_using_threads is #defined to false in that case.

Fixes open-mpi/ompi#1806

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@544adb9aed4e1469f3e15f56dd9218f53b4f1639)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
