### PR TITLE
opal/asm/base/MIPS.asm: fix uClibc regdef.h include path

### DIFF
--- a/opal/asm/base/MIPS.asm
+++ b/opal/asm/base/MIPS.asm
@@ -5,7 +5,12 @@ START_FILE
 #else
 #include <asm.h>
 #endif
+#include <features.h>
+#ifdef __UCLIBC__
+#include <sys/regdef.h>
+#else
 #include <regdef.h>
+#endif
 	
 	TEXT
 


### PR DESCRIPTION
Otherwise it will fail with an error like this one:

atomic-asm.S:7:20: fatal error: regdef.h: No such file or directory
 #include <regdef.h>

Signed-off-by: Vicente Olivert Riera Vincent.Riera@imgtec.com
