### PR TITLE
Java error handling

### DIFF
--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -1157,9 +1157,8 @@ jboolean ompi_java_exceptionCheck(JNIEnv *env, int rc)
         (*env)->DeleteLocalRef(env, jmessage);
         return JNI_TRUE;
     }
-    else if (JNI_TRUE == jni_exception) {
-        return JNI_TRUE;
-    }
+    /* If we get here, a JNI error has occurred. */
+    return JNI_TRUE;
 }
 
 void* ompi_java_attrSet(JNIEnv *env, jbyteArray jval)


### PR DESCRIPTION
Fixed an error where if there were no MPI exceptions, a
JNI error could still exist and not get handled.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

:bot:milestone:v2.0.1

@hppritcha 
