### PR TITLE
btl/openib: fix segmentation fault

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -3743,7 +3743,9 @@ static int btl_openib_component_progress(void)
     for(i = 0; i < mca_btl_openib_component.devices_count; i++) {
         mca_btl_openib_device_t *device =
             (mca_btl_openib_device_t *) opal_pointer_array_get_item(&mca_btl_openib_component.devices, i);
-        count += progress_one_device(device);
+        if (NULL != device) {
+            count += progress_one_device(device);
+        }
     }
 
 #if OPAL_CUDA_SUPPORT /* CUDA_ASYNC_SEND */


### PR DESCRIPTION
This commit fixes a segmentation fault that occurs if a device can be
initialized but not used. In this case the devices_count is not equal
to the number of usable devices in the devices pointer array.

Thanks to @artpol84 for tracking this down.

Fixes open-mpi/ompi#1823

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from open-mpi/ompi@8128c8eb29d6adde288fca5db3f71fb98e1727f6)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
