### PR TITLE
bml/r2: be more restrictive on rdma endpoints

### DIFF
--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -266,7 +266,7 @@ static int mca_bml_r2_endpoint_add_btl (struct ompi_proc_t *proc, mca_bml_base_e
     }
 
     /* always add rdma endpoints if they support full rdma */
-    if ((btl_in_use && (btl_flags & MCA_BTL_FLAGS_RDMA) ||
+    if (((btl_in_use && (btl_flags & MCA_BTL_FLAGS_RDMA)) ||
          (btl_flags & (MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS)) == (MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS)) &&
         !((proc->super.proc_arch != ompi_proc_local_proc->super.proc_arch) &&
           (0 == (btl->btl_flags & MCA_BTL_FLAGS_HETEROGENEOUS_RDMA)))) {

--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -265,8 +265,9 @@ static int mca_bml_r2_endpoint_add_btl (struct ompi_proc_t *proc, mca_bml_base_e
         }
     }
 
-    /* always add rdma endpoints */
-    if ((btl_flags & MCA_BTL_FLAGS_RDMA) &&
+    /* always add rdma endpoints if they support full rdma */
+    if ((btl_in_use && (btl_flags & MCA_BTL_FLAGS_RDMA) ||
+         (btl_flags & (MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS)) == (MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_ATOMIC_FOPS)) &&
         !((proc->super.proc_arch != ompi_proc_local_proc->super.proc_arch) &&
           (0 == (btl->btl_flags & MCA_BTL_FLAGS_HETEROGENEOUS_RDMA)))) {
         mca_bml_base_btl_t *bml_btl_rdma = mca_bml_base_btl_array_insert(&bml_endpoint->btl_rdma);


### PR DESCRIPTION
This commit makes bml/r2 more restrictive on which endpoints end up in the rdma
endpoint list. Before this commit an endpoint was added if it supported either
put or get. This was done to ensure that endpoints are available for RMA.
Thought it is possible to support put or get endpoints we only currently
support endpoints that have put, get, and amos. bml/r2 now reflects this
support.

Signed-off-by: Nathan Hjelm hjelmn@me.com

(cherry picked from commit open-mpi/ompi@5f390b5f5af8a55cc18c8859552cfaaf5e58361d)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
