### PR TITLE
mpi/c: Add each check for count==0 in nonblocking reduce interface

### DIFF
--- a/ompi/mpi/c/iallreduce.c
+++ b/ompi/mpi/c/iallreduce.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,6 +92,15 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
             OMPI_CHECK_DATATYPE_FOR_SEND(err, datatype, count);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+    }
+
+    /* MPI standard says that reductions have to have a count of at least 1,
+     * but some benchmarks (e.g., IMB) calls this function with a count of 0.
+     * So handle that case.
+     */
+    if (0 == count) {
+        *request = &ompi_request_empty;
+        return MPI_SUCCESS;
     }
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/ireduce.c
+++ b/ompi/mpi/c/ireduce.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,6 +119,15 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
                 return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ROOT, FUNC_NAME);
             }
         }
+    }
+
+    /* MPI standard says that reductions have to have a count of at least 1,
+     * but some benchmarks (e.g., IMB) calls this function with a count of 0.
+     * So handle that case.
+     */
+    if (0 == count) {
+        *request = &ompi_request_empty;
+        return MPI_SUCCESS;
     }
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/ireduce_scatter.c
+++ b/ompi/mpi/c/ireduce_scatter.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@ static const char FUNC_NAME[] = "MPI_Ireduce_scatter";
 int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[],
                         MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request)
 {
-    int i, err, size;
+    int i, err, size, count;
 
     MEMCHECKER(
         int rank;
@@ -108,6 +109,21 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
           OMPI_CHECK_DATATYPE_FOR_SEND(err, datatype, recvcounts[i]);
           OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }
+    }
+
+    /* MPI standard says that reductions have to have a count of at least 1,
+     * but some benchmarks (e.g., IMB) calls this function with a count of 0.
+     * So handle that case.
+     */
+    size = ompi_comm_size(comm);
+    for (count = i = 0; i < size; ++i) {
+        if (0 == recvcounts[i]) {
+            ++count;
+        }
+    }
+    if (size == count) {
+        *request = &ompi_request_empty;
+        return MPI_SUCCESS;
     }
 
     /* Invoke the coll component to perform the back-end operation */


### PR DESCRIPTION
- Matches the blocking versions of these interfaces
  - `iallreduce.c` to match `allreduce.c`
  - `ireduce.c` to match `reduce.c`
  - `ireduce_scatter.c` to match `reduce_scatter.c`
- Workaround for IMB-NBC benchmark, similar to the workaround
  in place for the IMB-MPI1 benchmark for the blocking collectives.

(cherry picked from commit open-mpi/ompi@96779f68e84d90e3e127550845fc696d03853074)
https://github.com/open-mpi/ompi/pull/1836
