### PR TITLE
Makefile.am: only check for common symbols on dev builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
@@ -30,10 +30,12 @@ dist-hook:
 # Check for common symbols.  Use a "-hook" to increase the odds that a
 # developer will see it at the end of their installation process.
 install-exec-hook:
-	-@$(top_srcdir)/config/find_common_syms \
-	    --brief \
-	    --top_builddir=$(top_builddir) \
-	    --top_srcdir=$(top_srcdir) \
-	    --objext=$(OBJEXT)
+	-@if test -d "$(top_srcdir)/.git"; then \
+	    $(top_srcdir)/config/find_common_syms \
+	        --brief \
+	        --top_builddir=$(top_builddir) \
+	        --top_srcdir=$(top_srcdir) \
+	        --objext=$(OBJEXT); \
+	fi
 
 ACLOCAL_AMFLAGS = -I config


### PR DESCRIPTION
Only run "find_common_syms" in the install-exec-hook when a .git
directory is present in the source dir.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@62c45e4a094a90ffc0024bb66926cd51d6a528b4)

Thanks to Tetsuya Mishima for raising the issue.

@hppritcha I think that this is worth it for v2.0.0 -- even at this late stage -- due to the very reason @ggouaillardet and Tetsuya raise in https://www.open-mpi.org/community/lists/devel/2016/07/19159.php: we don't want users to be alarmed by this false positive.  Additionally, the risk is very low in this small commit.  Thoughts?
