### PR TITLE
patcher/overwrite: remove warning message

### DIFF
--- a/opal/mca/patcher/overwrite/patcher_overwrite_module.c
+++ b/opal/mca/patcher/overwrite/patcher_overwrite_module.c
@@ -278,7 +278,7 @@ static int mca_patcher_overwrite_patch_symbol (const char *func_symbol_name, uin
     if (NULL == sym_addr) {
         sym_addr = dlsym(RTLD_DEFAULT, func_symbol_name);
         if ( (sym_addr == NULL) && ((error = dlerror()) != NULL) )  {
-            opal_output(0, "error locating symbol %s to patch. %s", func_symbol_name,
+            opal_output(-1, "error locating symbol %s to patch. %s", func_symbol_name,
                         error);
             return OPAL_ERR_NOT_FOUND;
         }


### PR DESCRIPTION
This is a 2.x specific commit that removes a warning message when the
munmap symbol can not be found to be patched. This can happen when
building an application with -static.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

:bot:label:bug
:bot:milestone:v2.0.0
:bot:assign: @hppritcha 
