### PR TITLE
io/ompio: fix the request in case of a zero size write/read operation

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_read.c
+++ b/ompi/mca/io/ompio/io_ompio_file_read.c
@@ -236,6 +236,8 @@ int ompio_io_ompio_file_iread (mca_io_ompio_file_t *fh,
 	ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
 	ompio_req->req_ompi.req_status._ucount = 0;
 	ompi_request_complete (&ompio_req->req_ompi, false);
+        *request = (ompi_request_t *) ompio_req;
+
 	return OMPI_SUCCESS;
     }
 

--- a/ompi/mca/io/ompio/io_ompio_file_write.c
+++ b/ompi/mca/io/ompio/io_ompio_file_write.c
@@ -228,6 +228,8 @@ int ompio_io_ompio_file_iwrite (mca_io_ompio_file_t *fh,
 	ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;
 	ompio_req->req_ompi.req_status._ucount = 0;
 	ompi_request_complete (&ompio_req->req_ompi, false);
+        *request = (ompi_request_t *) ompio_req;
+
 	return OMPI_SUCCESS;
     }
 


### PR DESCRIPTION
bot:milestone:v2.0.0
bot:label:bug

@hppritcha could you please review this patch? 
If the fix is postponed to 2.0.1, that's also fine  for me, its a trivial (2 line) fix.
