### PR TITLE
REMADE: updates to include feedback from rc4

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,7 +54,7 @@ included in the vX.Y.Z section and be denoted as:
                                  included in release version vA.B.C.
 
 
-2.0.0 -- 11 July 2016
+2.0.0 -- 12 July 2016
 ---------------------
 
  **********************************************************************

--- a/README
+++ b/README
@@ -173,6 +173,9 @@ Compiler Notes
             --enable-debug)
     pgi-13: 13.10 known GOOD
 
+  Users have reported hitting compiler internal errors using pgi-12/13
+  with the -m32 flag
+
 - Similarly, there is a known Fortran PGI compiler issue with long
   source directory path names that was resolved in 9.0-4 (9.0-3 is
   known to be broken in this regard).
@@ -246,6 +249,9 @@ Compiler Notes
   MPI applications.  As of 1 Feb 2012, if you upgrade to the latest
   version of the Intel 12.1 Linux compiler suite, the problem will go
   away.
+
+- It has been reported that Pathscale 5.0.5 and 6.0.527 compilers
+  give an internal compiler error when trying to Open MPI.
 
 - Early versions of the Portland Group 6.0 compiler have problems
   creating the C++ MPI bindings as a shared library (e.g., v6.0-1).


### PR DESCRIPTION
PHargrove reported compiler internal errors for
PGI and Pathscale when trying to build OMPI
2.0.0rc4.  Update README with info about these
observations.

Change date on NEWS to reflect 7/12/2016
release date.

@jsquyres 

Signed-off-by: Howard Pritchard howardp@lanl.gov
