### PR TITLE
ompi/fortran: fix typos in request RMA bindings

### DIFF
--- a/ompi/mpi/fortran/mpif-h/raccumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/raccumulate_f.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -96,7 +96,7 @@ void ompi_raccumulate_f(char *origin_addr, MPI_Fint *origin_count,
 
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 
-    if (MPI_SUCCESS != ierr_c) {
+    if (MPI_SUCCESS == ierr_c) {
         *request = PMPI_Request_c2f(c_req);
     }
 }

--- a/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -100,7 +100,7 @@ void ompi_rget_accumulate_f(char *origin_addr, MPI_Fint *origin_count,
                                  c_target_datatype, c_op, c_win, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    if (MPI_SUCCESS != c_ierr) {
+    if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_req);
     }
 }

--- a/ompi/mpi/fortran/mpif-h/rget_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_f.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -92,7 +92,7 @@ void ompi_rget_f(char *origin_addr, MPI_Fint *origin_count,
                       c_target_datatype, c_win, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    if (MPI_SUCCESS != c_ierr) {
+    if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_req);
     }
 }

--- a/ompi/mpi/fortran/mpif-h/rput_f.c
+++ b/ompi/mpi/fortran/mpif-h/rput_f.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -92,7 +92,7 @@ void ompi_rput_f(char *origin_addr, MPI_Fint *origin_count,
                       c_target_datatype, c_win, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
-    if (MPI_SUCCESS != c_ierr) {
+    if (MPI_SUCCESS == c_ierr) {
         *request = PMPI_Request_c2f(c_req);
     }
 }


### PR DESCRIPTION
This commit fixes typos on the C side of the request-based RMA binding. We
were not returning the request on success but on failure. Thanks to
@alazzaro for reporting and @ggouaillardet, and @vondele for tracking
this down.

Fixes part of open-mpi/ompi#1869

Signed-off-by: Nathan Hjelm hjelmn@me.com

(cherry picked from commit open-mpi/ompi@8bdcb40dc4b6cba699c6203a07fe3b24fd4dec95)

Signed-off-by: Nathan Hjelm hjelmn@lanl.com
