### PR TITLE
travis: use gcc 6 and run brew upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,19 +44,20 @@ env:
         - LD_LIBRARY_PATH="$HOME/bogus/lib"
     matrix:
         - GCC_VERSION=default
-        - GCC_VERSION=5
+        - GCC_VERSION=6
 
 # Install dependencies for the verbs and usnic providers.  Open MPI is
 # not currently using the verbs provider in Libfabric, so we might as
 # well not build it.
 before_install:
-    - if [[ "GCC_VERSION" == "5" ]]; then COMPILERS="CC=gcc-5 CXX=g++-5 FC=gfortran-5"; fi
+    - if [[ "GCC_VERSION" == "6" ]]; then COMPILERS="CC=gcc-6 CXX=g++-6 FC=gfortran-6"; fi
     - export CONFIGURE_ARGS="--prefix=$HOME/bogus $COMPILERS" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://github.com/ofiwg/libfabric.git ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$GCC_VERSION" == "5" ]] ; then sudo apt-get --assume-yes install gcc-5 g++-5 gfortran-5; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 g++-6 gfortran-6; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd libfabric && ./autogen.sh && ./configure --prefix=$HOME/bogus --enable-usnic --disable-verbs $COMPILERS && make install && cd .. ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$GCC_VERSION" == "5" ]] ; then brew update; brew unlink gcc ; brew install gcc; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$GCC_VERSION" == "6" ]] ; then brew update; brew upgrade automake libtool gcc; fi
+    - mkdir -p $HOME/bogus/include $HOME/bogus/lib
 
 # Note that we use "make -k" to do the entire build, even if there was a
 # build error in there somewhere.  This prevents us from needing to submit
@@ -77,5 +78,5 @@ script:
 
 matrix:
   exclude:
-    - env: GCC_VERSION=5
+    - env: GCC_VERSION=6
       compiler: clang


### PR DESCRIPTION
brew update seems to remove /usr/local/Library/ENV, which breaks glibtool,
so manually upgrade a few formulas

(cherry picked from commit open-mpi/ompi@af23dcc1239188e06c1b71f0735a83edc45178f2)

Submitted by @ggouaillardet reviewed and tested by @jsquyres
