### PR TITLE
libompitrace: explicitly set the .so version

### DIFF
--- a/ompi/contrib/libompitrace/Makefile.am
+++ b/ompi/contrib/libompitrace/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,3 +41,5 @@ libompitrace_la_SOURCES = \
         request_free.c \
         send.c \
         sendrecv.c
+
+libompitrace_la_LDFLAGS = -version-info 20:0:0


### PR DESCRIPTION
On master, this value is explicitly set to 0:0:0.  On v2.x, set it to 20:0:0 (just so that it is different than master).

Fixes open-mpi/ompi#1906.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@2e0c3c7d77b69460dbdf387e8874aab917d545f3)

@rhc54 This library was originally created by you 😄  -- can you review?
