### PR TITLE
common/ugni: help out knl with aries

### DIFF
--- a/opal/mca/common/ugni/common_ugni.c
+++ b/opal/mca/common/ugni/common_ugni.c
@@ -258,7 +258,8 @@ int opal_common_ugni_init (void)
     /* Create a communication domain */
 
     modes = GNI_CDM_MODE_FORK_FULLCOPY | GNI_CDM_MODE_CACHED_AMO_ENABLED |
-            GNI_CDM_MODE_ERR_NO_KILL | GNI_CDM_MODE_FAST_DATAGRAM_POLL;
+            GNI_CDM_MODE_ERR_NO_KILL | GNI_CDM_MODE_FAST_DATAGRAM_POLL |
+            GNI_CDM_MODE_FMA_SHARED;
 
     /* collect uGNI information */
     rc = get_ptag(&opal_common_ugni_module.ptag);


### PR DESCRIPTION
The way the gni btl is currently coded,
it will run completely out of gas on KNL at
123 processes/node.  Since there are bound to be
those who try to run a MPI process/hyperthread
on KNL nodes, the fma sharing mode needs to be requested.

@hjelmn 

Signed-off-by: Howard Pritchard howardp@lanl.gov
(cherry picked from commit open-mpi/ompi@8b53487977da03ad50978379497ece8653bc94e9)
