### PR TITLE
Fix performance regression caused by enabling opal thread support

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
@@ -133,7 +133,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
 
     OBJ_RETAIN(group);
 
-    if (!OPAL_ATOMIC_CMPSET(&module->start_group, NULL, group)) {
+    if (!OPAL_ATOMIC_CMPSET_PTR(&module->start_group, NULL, group)) {
         OBJ_RELEASE(group);
         return OMPI_ERR_RMA_SYNC;
     }
@@ -185,7 +185,7 @@ ompi_osc_sm_complete(struct ompi_win_t *win)
     opal_atomic_mb();
 
     group = module->start_group;
-    if (NULL == group || !OPAL_ATOMIC_CMPSET(&module->start_group, group, NULL)) {
+    if (NULL == group || !OPAL_ATOMIC_CMPSET_PTR(&module->start_group, group, NULL)) {
         return OMPI_ERR_RMA_SYNC;
     }
 

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,7 +67,7 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = comm->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET(&(comm->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_CMPSET_PTR(&(comm->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount decrease
      in errhandler_free.c. */

--- a/ompi/mpi/c/comm_set_errhandler.c
+++ b/ompi/mpi/c/comm_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,9 +70,7 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = comm->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(comm->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR(&comm->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */

--- a/ompi/mpi/c/file_get_errhandler.c
+++ b/ompi/mpi/c/file_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,7 +66,7 @@ int MPI_File_get_errhandler( MPI_File file, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = file->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET(&(file->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_CMPSET_PTR(&(file->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount
      decrease in errhandler_free.c. */

--- a/ompi/mpi/c/file_set_errhandler.c
+++ b/ompi/mpi/c/file_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,9 +69,7 @@ int MPI_File_set_errhandler( MPI_File file, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = file->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(file->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR (&file->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */

--- a/ompi/mpi/c/win_get_errhandler.c
+++ b/ompi/mpi/c/win_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,7 +59,7 @@ int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler)
        error_handler became atomic. */
     do {
         tmp = win->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(win->error_handler), tmp, tmp));
+    } while (!OPAL_ATOMIC_CMPSET_PTR(&(win->error_handler), tmp, tmp));
 
     /* Retain the errhandler, corresponding to object refcount
        decrease in errhandler_free.c. */

--- a/ompi/mpi/c/win_set_errhandler.c
+++ b/ompi/mpi/c/win_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,9 +64,7 @@ int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = win->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(win->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR(&win->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,10 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,7 +125,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "opal/sys/atomic.h"
+#include "opal/threads/thread_usage.h"
 
 BEGIN_C_DECLS
 
@@ -503,7 +508,7 @@ static inline opal_object_t *opal_obj_new(opal_class_t * cls)
 static inline int opal_obj_update(opal_object_t *object, int inc) __opal_attribute_always_inline__;
 static inline int opal_obj_update(opal_object_t *object, int inc)
 {
-    return opal_atomic_add_32(&(object->obj_reference_count), inc);
+    return OPAL_THREAD_ADD32(&object->obj_reference_count, inc);
 }
 
 END_C_DECLS

--- a/opal/threads/Makefile.am
+++ b/opal/threads/Makefile.am
@@ -29,7 +29,8 @@ headers += \
         threads/mutex_unix.h \
         threads/threads.h \
         threads/tsd.h \
-        threads/wait_sync.h
+        threads/wait_sync.h \
+	threads/thread_usage.h
 
 lib@OPAL_LIB_PREFIX@open_pal_la_SOURCES += \
         threads/condition.c \

--- a/opal/threads/mutex.h
+++ b/opal/threads/mutex.h
@@ -28,7 +28,7 @@
 
 #include "opal_config.h"
 
-#include "opal/sys/atomic.h"
+#include "opal/threads/thread_usage.h"
 
 BEGIN_C_DECLS
 
@@ -39,13 +39,6 @@ BEGIN_C_DECLS
  *
  * Functions for locking of critical sections.
  */
-
-#if OMPI_ENABLE_THREAD_MULTIPLE
-/*
- * declaring this here so that CL does not complain
- */
-OPAL_DECLSPEC extern bool opal_uses_threads;
-#endif
 
 /**
  * Opaque mutex object
@@ -107,73 +100,6 @@ END_C_DECLS
 #include "mutex_unix.h"
 
 BEGIN_C_DECLS
-
-/**
- * Check and see if the process is using multiple threads.
- *
- * @retval true If the process may have more than one thread.
- * @retval false If the process only has a single thread.
- *
- * The value that this function returns is influenced by:
- *
- * - how MPI_INIT or MPI_INIT_THREAD was invoked,
- * - what the final MPI thread level was determined to be,
- * - whether the OMPI or MPI libraries are multi-threaded (Jan 2003:
- *   they're not),
- * - whether configure determined if we have thread support or not
- *
- * MPI_INIT and MPI_INIT_THREAD (specifically, back-end OMPI startup
- * functions) invoke opal_set_using_threads() to influence the value of
- * this function, depending on their situation. Some examples:
- *
- * - if configure determined that we do not have threads, then this
- * value will always be false.
- *
- * - if MPI_INIT is invoked, and the ompi libraries are [still]
- * single-threaded, this value will be false.
- *
- * - if MPI_INIT_THREAD is invoked with MPI_THREAD_MULTIPLE, we have
- * thread support, and the final thread level is determined to be
- * MPI_THREAD_MULTIPLE, this value will be true.
- *
- * - if the process is a single-threaded OMPI executable (e.g., mpicc),
- * this value will be false.
- *
- * Hence, this function will return false if there is guaranteed to
- * only be one thread in the process.  If there is even the
- * possibility that we may have multiple threads, true will be
- * returned.
- */
-#if OMPI_ENABLE_THREAD_MULTIPLE
-#define opal_using_threads()  opal_uses_threads
-#else
-#define opal_using_threads()  0
-#endif
-
-/**
- * Set whether the process is using multiple threads or not.
- *
- * @param have Boolean indicating whether the process is using
- * multiple threads or not.
- *
- * @retval opal_using_threads The new return value from
- * opal_using_threads().
- *
- * This function is used to influence the return value of
- * opal_using_threads().  If configure detected that we have thread
- * support, the return value of future invocations of
- * opal_using_threads() will be the parameter's value.  If configure
- * detected that we have no thread support, then the retuen from
- * opal_using_threads() will always be false.
- */
-static inline bool opal_set_using_threads(bool have)
-{
-#if OMPI_ENABLE_THREAD_MULTIPLE
-    opal_uses_threads = have;
-#endif
-    return opal_using_threads();
-}
-
 
 /**
  * Lock a mutex if opal_using_threads() says that multiple threads may
@@ -260,90 +186,6 @@ static inline bool opal_set_using_threads(bool have)
             action;                             \
         }                                       \
     } while (0)
-
-/**
- * Use an atomic operation for increment/decrement if opal_using_threads()
- * indicates that threads are in use by the application or library.
- */
-
-static inline int32_t
-OPAL_THREAD_ADD32(volatile int32_t *addr, int delta)
-{
-    int32_t ret;
-
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_32(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
-
-    return ret;
-}
-
-#if OPAL_HAVE_ATOMIC_MATH_64
-static inline int64_t
-OPAL_THREAD_ADD64(volatile int64_t *addr, int delta)
-{
-    int64_t ret;
-
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_64(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
-
-    return ret;
-}
-#endif
-
-static inline size_t
-OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
-{
-    size_t ret;
-
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_size_t(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
-
-    return ret;
-}
-
-/* BWB: FIX ME: remove if possible */
-#define OPAL_CMPSET(x, y, z) ((*(x) == (y)) ? ((*(x) = (z)), 1) : 0)
-
-#if OPAL_HAVE_ATOMIC_CMPSET_32
-#define OPAL_ATOMIC_CMPSET_32(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_32(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET_64(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_64(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET_PTR(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_ptr(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-
-
-static inline void *opal_thread_swap_ptr (volatile void *ptr, void *newvalue)
-{
-    if (opal_using_threads ()) {
-        return opal_atomic_swap_ptr (ptr, newvalue);
-    }
-
-    void *old = ((void **) ptr)[0];
-    ((void **) ptr)[0] = newvalue;
-
-    return old;
-}
-
-#define OPAL_ATOMIC_SWAP_PTR(x, y) opal_thread_swap_ptr (x, y)
 
 END_C_DECLS
 

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -1,0 +1,213 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart, 
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ * 
+ * Additional copyrights may follow
+ * 
+ * $HEADER$
+ */
+
+#if !defined(OPAL_THREAD_USAGE_H)
+#define OPAL_THREAD_USAGE_H
+
+#include "opal/sys/atomic.h"
+#include "opal_config.h"
+
+/**
+ * Check and see if the process is using multiple threads.
+ *
+ * @retval true If the process may have more than one thread.
+ * @retval false If the process only has a single thread.
+ *
+ * The value that this function returns is influenced by:
+ *
+ * - how MPI_INIT or MPI_INIT_THREAD was invoked,
+ * - what the final MPI thread level was determined to be,
+ * - whether the OMPI or MPI libraries are multi-threaded
+ *
+ * MPI_INIT and MPI_INIT_THREAD (specifically, back-end OMPI startup
+ * functions) invoke opal_set_using_threads() to influence the value of
+ * this function, depending on their situation. Some examples:
+ *
+ * - if MPI_INIT is invoked, and the ompi components in use are
+ * single-threaded, this value will be false.
+ *
+ * - if MPI_INIT_THREAD is invoked with MPI_THREAD_MULTIPLE, we have
+ * thread support, and the final thread level is determined to be
+ * MPI_THREAD_MULTIPLE, this value will be true.
+ *
+ * - if the process is a single-threaded OMPI executable (e.g., mpicc),
+ * this value will be false.
+ *
+ * Hence, this function will return false if there is guaranteed to
+ * only be one thread in the process.  If there is even the
+ * possibility that we may have multiple threads, true will be
+ * returned.
+ */
+#if OMPI_ENABLE_THREAD_MULTIPLE
+
+OPAL_DECLSPEC extern bool opal_uses_threads;
+#define opal_using_threads()  opal_uses_threads
+
+#else
+
+#define opal_using_threads()  false
+
+#endif /* OMPI_ENABLE_THREAD_MULTIPLE */
+
+/**
+ * Set whether the process is using multiple threads or not.
+ *
+ * @param have Boolean indicating whether the process is using
+ * multiple threads or not.
+ *
+ * @retval opal_using_threads The new return value from
+ * opal_using_threads().
+ *
+ * This function is used to influence the return value of
+ * opal_using_threads().  If configure detected that we have thread
+ * support, the return value of future invocations of
+ * opal_using_threads() will be the parameter's value.  If configure
+ * detected that we have no thread support, then the retuen from
+ * opal_using_threads() will always be false.
+ */
+static inline bool opal_set_using_threads(bool have)
+{
+#if OMPI_ENABLE_THREAD_MULTIPLE
+    opal_uses_threads = have;
+#else
+    have = true;               /* just shut up the compiler */
+#endif
+    return opal_using_threads();
+}
+
+
+/**
+ * Use an atomic operation for increment/decrement if opal_using_threads()
+ * indicates that threads are in use by the application or library.
+ */
+
+#if OMPI_ENABLE_THREAD_MULTIPLE
+static inline int32_t
+OPAL_THREAD_ADD32(volatile int32_t *addr, int delta)
+{
+    int32_t ret;
+
+    if (opal_using_threads()) {
+        ret = opal_atomic_add_32(addr, delta);
+    } else {
+        ret = (*addr += delta);
+    }
+
+    return ret;
+}
+#else
+static inline int32_t
+OPAL_THREAD_ADD32(volatile int32_t *addr, int delta)
+{
+    int32_t ret;
+    ret = (*addr += delta);
+    return ret;
+}
+#endif
+
+#if OPAL_HAVE_ATOMIC_MATH_64
+#if OMPI_ENABLE_THREAD_MULTIPLE
+static inline int64_t
+OPAL_THREAD_ADD64(volatile int64_t *addr, int delta)
+{
+    int64_t ret;
+
+    if (opal_using_threads()) {
+        ret = opal_atomic_add_64(addr, delta);
+    } else {
+        ret = (*addr += delta);
+    }
+
+    return ret;
+}
+#else
+static inline int64_t
+OPAL_THREAD_ADD64(volatile int64_t *addr, int delta)
+{
+    int64_t ret;
+    ret = (*addr += delta);
+    return ret;
+}
+#endif
+#endif
+
+#if OMPI_ENABLE_THREAD_MULTIPLE
+static inline size_t
+OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
+{
+    size_t ret;
+
+    if (opal_using_threads()) {
+        ret = opal_atomic_add_size_t(addr, delta);
+    } else {
+        ret = (*addr += delta);
+    }
+
+    return ret;
+}
+#else
+static inline size_t
+OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
+{
+    size_t ret;
+    ret = (*addr += delta);
+    return ret;
+}
+#endif
+
+/* BWB: FIX ME: remove if possible */
+#define OPAL_CMPSET(x, y, z) ((*(x) == (y)) ? ((*(x) = (z)), 1) : 0)
+
+#if OPAL_HAVE_ATOMIC_CMPSET_32
+#define OPAL_ATOMIC_CMPSET_32(x, y, z) \
+    (opal_using_threads() ? opal_atomic_cmpset_32(x, y, z) : OPAL_CMPSET(x, y, z))
+#endif
+#if OPAL_HAVE_ATOMIC_CMPSET_64
+#define OPAL_ATOMIC_CMPSET_64(x, y, z) \
+    (opal_using_threads() ? opal_atomic_cmpset_64(x, y, z) : OPAL_CMPSET(x, y, z))
+#endif
+#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
+#define OPAL_ATOMIC_CMPSET(x, y, z) \
+    (opal_using_threads() ? opal_atomic_cmpset(x, y, z) : OPAL_CMPSET(x, y, z))
+#endif
+#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
+#define OPAL_ATOMIC_CMPSET_PTR(x, y, z) \
+    (opal_using_threads() ? opal_atomic_cmpset_ptr(x, y, z) : OPAL_CMPSET(x, y, z))
+#endif
+
+static inline void *opal_thread_swap_ptr (volatile void *ptr, void *newvalue)
+{
+    if (opal_using_threads ()) {
+        return opal_atomic_swap_ptr (ptr, newvalue);
+    }
+
+    void *old = ((void **) ptr)[0];
+    ((void **) ptr)[0] = newvalue;
+
+    return old;
+}
+
+#define OPAL_ATOMIC_SWAP_PTR(x, y) opal_thread_swap_ptr (x, y)
+
+#endif /* !defined(OPAL_THREAD_USAGE_H) */

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -26,6 +26,7 @@
 #define OPAL_THREAD_USAGE_H
 
 #include "opal/sys/atomic.h"
+#include "opal/prefetch.h"
 #include "opal_config.h"
 
 /**
@@ -101,113 +102,85 @@ static inline bool opal_set_using_threads(bool have)
  * Use an atomic operation for increment/decrement if opal_using_threads()
  * indicates that threads are in use by the application or library.
  */
-
-#if OMPI_ENABLE_THREAD_MULTIPLE
-static inline int32_t
-OPAL_THREAD_ADD32(volatile int32_t *addr, int delta)
-{
-    int32_t ret;
-
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_32(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
-
-    return ret;
+#define OPAL_THREAD_DEFINE_ATOMIC_ADD(type, suffix)     \
+static inline type opal_thread_add_ ## suffix (volatile type *addr, type delta) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_add_ ## suffix (addr, delta);                \
+    }                                                                   \
+                                                                        \
+    return (*addr += delta);                                            \
 }
-#else
-static inline int32_t
-OPAL_THREAD_ADD32(volatile int32_t *addr, int delta)
-{
-    int32_t ret;
-    ret = (*addr += delta);
-    return ret;
-}
-#endif
 
+#define OPAL_THREAD_DEFINE_ATOMIC_CMPSET(type, addr_type, suffix)       \
+static inline bool opal_thread_cmpset_bool_ ## suffix (volatile addr_type *addr, type compare, type value) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_cmpset_ ## suffix ((volatile type *) addr, compare, value); \
+    }                                                                   \
+                                                                        \
+    if ((type) *addr == compare) {                                      \
+        ((type *) addr)[0] = value;                                     \
+        return true;                                                    \
+    }                                                                   \
+                                                                        \
+    return false;                                                       \
+}
+
+#define OPAL_THREAD_DEFINE_ATOMIC_SWAP(type, addr_type, suffix)         \
+static inline type opal_thread_swap_ ## suffix (volatile addr_type *ptr, type newvalue) \
+{                                                                       \
+    if (opal_using_threads ()) {                                        \
+        return opal_atomic_swap_ ## suffix ((volatile type *) ptr, newvalue); \
+    }                                                                   \
+                                                                        \
+    type old = ((type *) ptr)[0];                                       \
+    ((type *) ptr)[0] = newvalue;                                       \
+                                                                        \
+    return old;                                                         \
+}
+
+OPAL_THREAD_DEFINE_ATOMIC_ADD(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_ADD(size_t, size_t)
+OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int32_t, int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_CMPSET(void *, intptr_t, ptr)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(int32_t, int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
+
+#define OPAL_THREAD_ADD32 opal_thread_add_32
+#define OPAL_ATOMIC_ADD32 opal_thread_add_32
+
+#define OPAL_THREAD_ADD_SIZE_T opal_thread_add_size_t
+#define OPAL_ATOMIC_ADD_SIZE_T opal_thread_add_size_t
+
+#define OPAL_THREAD_CMPSET_32 opal_thread_cmpset_bool_32
+#define OPAL_ATOMIC_CMPSET_32 opal_thread_cmpset_bool_32
+
+#define OPAL_THREAD_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
+#define OPAL_ATOMIC_CMPSET_PTR OPAL_THREAD_CMPSET_PTR
+
+#define OPAL_THREAD_SWAP_32 opal_thread_swap_32
+#define OPAL_ATOMIC_SWAP_32 opal_thread_swap_32
+
+#define OPAL_THREAD_SWAP_PTR(x, y) opal_thread_swap_ptr ((volatile intptr_t *) x, (void *) y)
+#define OPAL_ATOMIC_SWAP_PTR OPAL_THREAD_SWAP_PTR
+
+/* define 64-bit macros is 64-bit atomic math is available */
 #if OPAL_HAVE_ATOMIC_MATH_64
-#if OMPI_ENABLE_THREAD_MULTIPLE
-static inline int64_t
-OPAL_THREAD_ADD64(volatile int64_t *addr, int delta)
-{
-    int64_t ret;
 
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_64(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
+OPAL_THREAD_DEFINE_ATOMIC_ADD(int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int64_t, int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
-    return ret;
-}
-#else
-static inline int64_t
-OPAL_THREAD_ADD64(volatile int64_t *addr, int delta)
-{
-    int64_t ret;
-    ret = (*addr += delta);
-    return ret;
-}
+#define OPAL_THREAD_ADD64 opal_thread_add_64
+#define OPAL_ATOMIC_ADD64 opal_thread_add_64
+
+#define OPAL_THREAD_CMPSET_64 opal_thread_cmpset_bool_64
+#define OPAL_ATOMIC_CMPSET_64 opal_thread_cmpset_bool_64
+
+#define OPAL_THREAD_SWAP_64 opal_thread_swap_64
+#define OPAL_ATOMIC_SWAP_64 opal_thread_swap_64
+
 #endif
-#endif
-
-#if OMPI_ENABLE_THREAD_MULTIPLE
-static inline size_t
-OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
-{
-    size_t ret;
-
-    if (opal_using_threads()) {
-        ret = opal_atomic_add_size_t(addr, delta);
-    } else {
-        ret = (*addr += delta);
-    }
-
-    return ret;
-}
-#else
-static inline size_t
-OPAL_THREAD_ADD_SIZE_T(volatile size_t *addr, int delta)
-{
-    size_t ret;
-    ret = (*addr += delta);
-    return ret;
-}
-#endif
-
-/* BWB: FIX ME: remove if possible */
-#define OPAL_CMPSET(x, y, z) ((*(x) == (y)) ? ((*(x) = (z)), 1) : 0)
-
-#if OPAL_HAVE_ATOMIC_CMPSET_32
-#define OPAL_ATOMIC_CMPSET_32(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_32(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET_64(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_64(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-#if OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_ATOMIC_CMPSET_PTR(x, y, z) \
-    (opal_using_threads() ? opal_atomic_cmpset_ptr(x, y, z) : OPAL_CMPSET(x, y, z))
-#endif
-
-static inline void *opal_thread_swap_ptr (volatile void *ptr, void *newvalue)
-{
-    if (opal_using_threads ()) {
-        return opal_atomic_swap_ptr (ptr, newvalue);
-    }
-
-    void *old = ((void **) ptr)[0];
-    ((void **) ptr)[0] = newvalue;
-
-    return old;
-}
-
-#define OPAL_ATOMIC_SWAP_PTR(x, y) opal_thread_swap_ptr (x, y)
 
 #endif /* !defined(OPAL_THREAD_USAGE_H) */


### PR DESCRIPTION
This commit adds opal_using_threads() protection around the atomic
operation in OBJ_RETAIN/OBJ_RELEASE. This resolves the performance
issues seen when running psm with MPI_THREAD_SINGLE.

To avoid issues with header dependencies opal_using_threads() has been
moved to a new header (thread_usage.h). The OPAL_THREAD_ADD\* and
OPAL_THREAD_CMPSET\* macros have also been relocated to this header.

This was cherry-picked off a fix applied to v1.8 and not master. See
open-mpi/ompi#1902.

(cherry picked from commit ce91307918eadcdb6e4a3c8b6429b36d206cc0e3)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
