### PR TITLE
v2.x: mpisync: Fix a compilation error.

### DIFF
--- a/ompi/tools/mpisync/sync.c
+++ b/ompi/tools/mpisync/sync.c
@@ -8,6 +8,8 @@
  * $HEADER$
  */
 
+#include "opal_config.h"
+
 #include <stdio.h>
 #include <mpi.h>
 #include <unistd.h>


### PR DESCRIPTION
This commit fixes the undefined `OPAL_MAXHOSTNAMELEN` error
which arises only when `--enable-timing` is specified for
`configure`.

(cherry picked from commit open-mpi/ompi@2a932f48adf0952b4f8c5d39558785e8c73ee177)

@jsquyres please review
