### PR TITLE
help-orterun: remove blank line at end of help message

### DIFF
--- a/orte/tools/orterun/help-orterun.txt
+++ b/orte/tools/orterun/help-orterun.txt
@@ -116,7 +116,6 @@ This may have caused other processes in the application to be
 terminated by signals sent by %s (as reported here).
 
 You can avoid this message by specifying -quiet on the %s command line.
-
 #
 [orterun:proc-exit-no-sync-unknown]
 %s has exited due to a process exiting without calling "finalize",


### PR DESCRIPTION
Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@cc651408dc4a12e6ff32700fb92a5f0deae87eed)

This commit simply removes the blank line at the end of a help message, to avoid an awkward blank line before the line of "-----" at the end of the show_help message.

@rhc54 Please review.
