### PR TITLE
libevent, romio: use opal_random() instead of rand(3)

### DIFF
--- a/ompi/mca/io/romio314/romio/adio/common/shfp_fname.c
+++ b/ompi/mca/io/romio314/romio/adio/common/shfp_fname.c
@@ -17,6 +17,13 @@
 #ifdef HAVE_TIME_H
 #include <time.h>
 #endif
+
+/*
+ * Open MPI: we have to use internal opal_random() instead of rand(3)
+ * to prevent pertubing user's randon seed
+ */
+#include <opal/util/alfg.h>
+
 /* The following function selects the name of the file to be used to
    store the shared file pointer. The shared-file-pointer file is a
    hidden file in the same directory as the real file being accessed.
@@ -35,12 +42,18 @@ void ADIOI_Shfp_fname(ADIO_File fd, int rank, int *error_code)
     int len;
     char *slash, *ptr, tmp[128];
     int pid = 0;
+    opal_rng_buff_t adio_rand_buff;
 
     fd->shared_fp_fname = (char *) ADIOI_Malloc(PATH_MAX);
 
     if (!rank) {
-        srand(time(NULL));
-        i = rand();
+        /*
+         * Open MPI: we have to use internal opal_random() instead of rand(3)
+         * to prevent pertubing user's randon seed
+         */
+	opal_srand(&adio_rand_buff,time(NULL));
+        i = opal_random();
+
 	pid = (int)getpid();
 
 	if (ADIOI_Strncpy(fd->shared_fp_fname, fd->filename, PATH_MAX)) {

--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -158,8 +158,13 @@ AC_DEFUN([MCA_opal_event_libevent2022_CONFIG],[
 
     AC_MSG_RESULT([$event_args])
 
+    # We define "random" to be "opal_random" so that Libevent will not
+    # use random(3) internally (and potentially unexpectedly perturb
+    # values returned by rand(3) to the application).
+
+    CPPFLAGS="$CPPFLAGS -Drandom=opal_random"
     OPAL_CONFIG_SUBDIR([$libevent_basedir/libevent],
-        [$event_args $opal_subdir_args],
+        [$event_args $opal_subdir_args 'CPPFLAGS=$CPPFLAGS'],
         [libevent_happy="yes"], [libevent_happy="no"])
     if test "$libevent_happy" = "no"; then
         AC_MSG_WARN([Event library failed to configure])

--- a/opal/util/alfg.c
+++ b/opal/util/alfg.c
@@ -10,6 +10,8 @@
 
 #include "opal_config.h"
 
+#include <string.h>
+
 #include "alfg.h"
 
 /* Mask corresponding to the primitive polynomial
@@ -52,6 +54,9 @@ static uint32_t galois(unsigned int *seed){
     return lsb;
 }
 
+/* OPAL global rng buffer */
+static opal_rng_buff_t alfg_buffer;
+
 /**
  * @brief   Routine to seed the ALFG register
  *
@@ -80,6 +85,8 @@ int opal_srand(opal_rng_buff_t *buff, uint32_t seed) {
             buff->alfg[j] = buff->alfg[j] ^ ((galois(&seed_cpy))<<i);
         }
     }
+    /* copy the ALFG to the global buffer */
+    memcpy(&alfg_buffer, buff, sizeof(alfg_buffer));
 
     return 1;
 
@@ -114,4 +121,12 @@ uint32_t opal_rand(opal_rng_buff_t *buff){
 
 }
 
-
+/**
+ * @brief      A wrapper for opal_rand() with our global ALFG buffer;
+ *
+ * @param[in]  none
+ * @param[out] int, the same as normal rand(3)
+ */
+int opal_random(void){
+    return (int)opal_rand(&alfg_buffer);
+}

--- a/opal/util/alfg.h
+++ b/opal/util/alfg.h
@@ -32,4 +32,6 @@ OPAL_DECLSPEC int opal_srand(opal_rng_buff_t *buff, uint32_t seed);
 
 OPAL_DECLSPEC uint32_t opal_rand(opal_rng_buff_t *buff);
 
+OPAL_DECLSPEC int opal_random(void);
+
 #endif /* OPAL_ALFG_H */


### PR DESCRIPTION
This commits changed rand(3) and family in libevent to use internal
random function provided in opal to prevent pertubing user's random seed.

Fixes open-mpi/ompi#1877

(cherry picked from commit open-mpi/ompi@b3e9dadff2762af4c947e224c15ebbf7d6c5b618)
