### PR TITLE
configury/libevent: fix incorrect drop of OPAL_HAVE_WORKING_EVENTOPS

### DIFF
--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -189,13 +189,15 @@ AC_DEFUN([MCA_opal_event_libevent2022_CONFIG],[
 
     AS_IF([test "$with_libevent" != "internal" && test -n "$with_libevent" && test "$with_libevent" != "yes"],
           [AC_MSG_WARN([using an external libevent; disqualifying this component])
-           libevent_happy=no])
+           libevent_happy=no],
 
-    AS_IF([test "$libevent_happy" = "yes" && test -r $libevent_file],
-          [OPAL_HAVE_WORKING_EVENTOPS=`grep HAVE_WORKING_EVENTOPS $libevent_file | awk '{print [$]3 }'`
-           $1],
-          [$2
-           OPAL_HAVE_WORKING_EVENTOPS=0])
+          [AS_IF([test "$libevent_happy" = "yes" && test -r $libevent_file],
+            [OPAL_HAVE_WORKING_EVENTOPS=`grep HAVE_WORKING_EVENTOPS $libevent_file | awk '{print [$]3 }'`
+              $1],
+            [$2
+              OPAL_HAVE_WORKING_EVENTOPS=0])
+          ]
+    )
 
     OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
Fixes a bug introduced in PR https://github.com/open-mpi/ompi-release/pull/1258
The code that sets OPAL_HAVE_WORKING_EVENTOPS for internal libevent
was executed even if the external libevent component was configured.

As the result libevent progress wasn't called in opal_progress which
for example caused ring_c to hang when pml/ob1 was used.

(cherry-picked from open-mpi/ompi@9d6a4b3b2de99dc5a4efa4df3ea6da83e24396d2)
