### PR TITLE
btl/ugni: protect against re-entry and races in connections

### DIFF
--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -457,7 +457,14 @@ mca_btl_ugni_progress_datagram (mca_btl_ugni_module_t *ugni_module)
                  data, (void *) ep, remote_id));
 
     /* NTH: TODO -- error handling */
+    opal_mutex_lock (&ep->lock);
+    if (handle != ugni_module->wildcard_ep) {
+        /* directed post complete */
+        ep->dg_posted = false;
+    }
+
     (void) mca_btl_ugni_ep_connect_progress (ep);
+    opal_mutex_unlock (&ep->lock);
 
     if (MCA_BTL_UGNI_EP_STATE_CONNECTED == ep->state) {
         /*  process messages waiting in the endpoint's smsg mailbox */

--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -398,8 +398,8 @@ mca_btl_ugni_progress_datagram (mca_btl_ugni_module_t *ugni_module)
     /* check for datagram completion */
     OPAL_THREAD_LOCK(&ugni_module->device->dev_lock);  /* TODO: may not need lock for this function */
     grc = GNI_PostDataProbeById (ugni_module->device->dev_handle, &datagram_id);
-    OPAL_THREAD_UNLOCK(&ugni_module->device->dev_lock);
     if (OPAL_LIKELY(GNI_RC_SUCCESS != grc)) {
+        OPAL_THREAD_UNLOCK(&ugni_module->device->dev_lock);
         return 0;
     }
 
@@ -415,7 +415,6 @@ mca_btl_ugni_progress_datagram (mca_btl_ugni_module_t *ugni_module)
     }
 
     /* wait for the incoming datagram to complete (in case it isn't) */
-    OPAL_THREAD_LOCK(&ugni_module->device->dev_lock);  /* TODO: may not need lock for this function */
     grc = GNI_EpPostDataWaitById (handle, datagram_id, -1, &post_state,
                                   &remote_addr, &remote_id);
     OPAL_THREAD_UNLOCK(&ugni_module->device->dev_lock);

--- a/opal/mca/btl/ugni/btl_ugni_endpoint.c
+++ b/opal/mca/btl/ugni/btl_ugni_endpoint.c
@@ -200,11 +200,14 @@ int mca_btl_ugni_ep_connect_progress (mca_btl_base_endpoint_t *ep) {
 
     if (GNI_SMSG_TYPE_INVALID == ep->remote_attr.smsg_attr.msg_type) {
         /* use datagram to exchange connection information with the remote peer */
-        rc = mca_btl_ugni_directed_ep_post (ep);
-        if (OPAL_SUCCESS == rc) {
-            rc = OPAL_ERR_RESOURCE_BUSY;
+        if (!ep->dg_posted) {
+            rc = mca_btl_ugni_directed_ep_post (ep);
+            if (OPAL_SUCCESS == rc) {
+                ep->dg_posted = true;
+                rc = OPAL_ERR_RESOURCE_BUSY;
+            }
+            return rc;
         }
-        return rc;
     }
 
     return mca_btl_ugni_ep_connect_finish (ep);


### PR DESCRIPTION
This commit fixes two issues that can occur during a connection:
- Re-entry to connection progress from modex lookup. Added an
  additional endpoint state that will keep the code from re-entering
  the common endpoint create.
- Fixed a race between a process posting a directed datagram through
  a send and a connection being progressed through opal_progress().
  The progress code was not obtaining the endpoint lock before
  attempting to update the endpoint. To limit the amount of code
  changed for 2.0.1 this commit makes the endpoint lock recursive. In
  a future update this may be changed.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@14b36d4503f16826a16db1893279677d91eaeb84)
