### PR TITLE
Patchs on coll portals4

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -65,6 +65,7 @@ struct mca_coll_portals4_component_t {
     opal_free_list_t requests; /* request free list for the i collectives */
 
     ptl_ni_limits_t ni_limits;
+    ptl_size_t portals_max_msg_size;
 
     int use_binomial_gather_algorithm;
 

--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -314,7 +314,7 @@ is_reduce_optimizable(struct ompi_datatype_t *dtype, size_t length, struct ompi_
     }
 
     *ptl_dtype = ompi_coll_portals4_atomic_datatype[dtype->id];
-    if (*ptl_dtype == COLL_PORTALS4_NO_DTYPE){
+    if (*ptl_dtype == COLL_PORTALS4_NO_DTYPE) {
         opal_output_verbose(50, ompi_coll_base_framework.framework_output,
                 "datatype %d not supported\n",
                 dtype->id);

--- a/ompi/mca/coll/portals4/coll_portals4_allreduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_allreduce.c
@@ -265,7 +265,7 @@ allreduce_kary_tree_top(const void *sendbuf, void *recvbuf, int count,
                             ompi_coll_portals4_get_peer(comm, child[i]),
                             mca_coll_portals4_component.pt_idx,
                             match_bits_rtr, 0, NULL, 0)) != PTL_OK)
-                        return opal_stderr("Put RTR failed", __FILE__, __LINE__, ret);
+                        return opal_stderr("Put RTR failed %d", __FILE__, __LINE__, ret);
                 }
             }
         }
@@ -408,7 +408,7 @@ int ompi_coll_portals4_iallreduce_intra(const void* sendbuf, void* recvbuf, int 
     allreduce_kary_tree_top(sendbuf, recvbuf, count,
             dtype, op, comm, request, portals4_module);
 
-    puts("iallreduce");
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output, "iallreduce");
     return (OMPI_SUCCESS);
 }
 

--- a/ompi/mca/coll/portals4/coll_portals4_bcast.c
+++ b/ompi/mca/coll/portals4/coll_portals4_bcast.c
@@ -409,9 +409,9 @@ bcast_kary_tree_top(void *buff, int count,
          */
 
         if (rank != root) {
-            ack_thr = segment_nb;
+            trig_thr = segment_nb;
             if (is_sync) {
-                if ((ret = PtlCTWait(request->u.bcast.trig_ct_h, ack_thr, &ct)) != 0) {
+                if ((ret = PtlCTWait(request->u.bcast.trig_ct_h, trig_thr, &ct)) != 0) {
                     opal_stderr("PtlCTWait failed", __FILE__, __LINE__, ret);
                 }
             }
@@ -421,7 +421,7 @@ bcast_kary_tree_top(void *buff, int count,
                         mca_coll_portals4_component.finish_pt_idx,
                         0, 0, NULL, (uintptr_t) request,
                         request->u.bcast.trig_ct_h,
-                        ack_thr)) != 0) {
+                        trig_thr)) != 0) {
                     return opal_stderr("PtlTriggeredPut failed", __FILE__, __LINE__, ret);
                 }
 
@@ -696,8 +696,9 @@ bcast_pipeline_top(void *buff, int count,
          */
 
         if (rank != root) {
+            trig_thr = segment_nb;
             if (is_sync) {
-                if ((ret = PtlCTWait(request->u.bcast.trig_ct_h, segment_nb, &ct)) != 0) {
+                if ((ret = PtlCTWait(request->u.bcast.trig_ct_h, trig_thr, &ct)) != 0) {
                     opal_stderr("PtlCTWait failed", __FILE__, __LINE__, ret);
                 }
             }
@@ -707,7 +708,7 @@ bcast_pipeline_top(void *buff, int count,
                         mca_coll_portals4_component.finish_pt_idx,
                         0, 0, NULL, (uintptr_t) request,
                         request->u.bcast.trig_ct_h,
-                        segment_nb)) != 0) {
+                        trig_thr)) != 0) {
                     return opal_stderr("PtlTriggeredPut failed", __FILE__, __LINE__, ret);
                 }
             }
@@ -831,7 +832,7 @@ ompi_coll_portals4_ibcast_intra(void *buff, int count,
         return OMPI_ERROR;
     }
 
-    puts("ibcast");
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output, "ibcast_intra");
     return (OMPI_SUCCESS);
 }
 
@@ -860,5 +861,6 @@ ompi_coll_portals4_ibcast_intra_fini(ompi_coll_portals4_request_t *request)
     ompi_request_complete(&request->super, true);
     OPAL_THREAD_UNLOCK(&ompi_request_lock);
 
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output, "ibcast_intra_fini");
     return (OMPI_SUCCESS);
 }

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -211,6 +211,16 @@ portals4_register(void)
             MCA_BASE_VAR_SCOPE_READONLY,
             &mca_coll_portals4_component.use_binomial_gather_algorithm);
 
+    mca_coll_portals4_component.portals_max_msg_size = PTL_SIZE_MAX;
+    (void) mca_base_component_var_register(&mca_coll_portals4_component.super.collm_version,
+            "max_msg_size",
+            "Max size supported by portals4 (above that, a message is cut into messages less than that size)",
+            MCA_BASE_VAR_TYPE_UNSIGNED_LONG,
+            NULL, 0, 0,
+            OPAL_INFO_LVL_9,
+            MCA_BASE_VAR_SCOPE_READONLY,
+            &mca_coll_portals4_component.portals_max_msg_size);
+
     return OMPI_SUCCESS;
 }
 
@@ -369,7 +379,13 @@ portals4_init_query(bool enable_progress_threads,
                 __FILE__, __LINE__, ret);
         return OMPI_ERROR;
     }
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output,
+        "ni_limits.max_atomic_size=%ld", mca_coll_portals4_component.ni_limits.max_atomic_size);
 
+    if (mca_coll_portals4_component.portals_max_msg_size < mca_coll_portals4_component.ni_limits.max_msg_size)
+        mca_coll_portals4_component.ni_limits.max_msg_size = mca_coll_portals4_component.portals_max_msg_size;
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output,
+        "ni_limits.max_msg_size=%lu", mca_coll_portals4_component.ni_limits.max_msg_size);
 
     ret = PtlGetId(mca_coll_portals4_component.ni_h, &mca_coll_portals4_component.id);
     if (PTL_OK != ret) {

--- a/ompi/mca/coll/portals4/coll_portals4_reduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_reduce.c
@@ -428,7 +428,7 @@ ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, int count,
         OMPI_COLL_PORTALS4_REQUEST_RETURN(request);
     }
 
-    puts("ireduce");
+    opal_output_verbose(10, ompi_coll_base_framework.framework_output, "ireduce");
     return (OMPI_SUCCESS);
 }
 

--- a/ompi/mca/coll/portals4/coll_portals4_reduce.c
+++ b/ompi/mca/coll/portals4/coll_portals4_reduce.c
@@ -385,10 +385,10 @@ ompi_coll_portals4_reduce_intra(const void *sendbuf, void *recvbuf, int count,
     ret = reduce_kary_tree_top(sendbuf, recvbuf, count,
             dtype, op, root, comm,  request,  portals4_module);
     if (OMPI_SUCCESS != ret)
-	return ret;
+        return ret;
     ret = reduce_kary_tree_bottom(request);
     if (OMPI_SUCCESS != ret)
-	return ret;
+        return ret;
 
     OMPI_COLL_PORTALS4_REQUEST_RETURN(request);
     return (OMPI_SUCCESS);
@@ -422,7 +422,7 @@ ompi_coll_portals4_ireduce_intra(const void* sendbuf, void* recvbuf, int count,
     ret = reduce_kary_tree_top(sendbuf, recvbuf, count,
             dtype, op, root, comm,  request,  portals4_module);
     if (OMPI_SUCCESS != ret)
-	return ret;
+        return ret;
 
     if (!request->u.reduce.is_optim) {
         OMPI_COLL_PORTALS4_REQUEST_RETURN(request);
@@ -439,7 +439,7 @@ ompi_coll_portals4_ireduce_intra_fini(ompi_coll_portals4_request_t *request)
 
     ret = reduce_kary_tree_bottom(request);
     if (OMPI_SUCCESS != ret)
-	return ret;
+        return ret;
 
     OPAL_THREAD_LOCK(&ompi_request_lock);
     ompi_request_complete(&request->super, true);

--- a/ompi/mca/coll/portals4/coll_portals4_scatter.c
+++ b/ompi/mca/coll/portals4/coll_portals4_scatter.c
@@ -127,7 +127,7 @@ setup_scatter_handles(struct ompi_communicator_t   *comm,
 
     ptl_me_t  me;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_scatter_handles enter rank %d", request->u.scatter.my_rank));
 
     /**********************************/
@@ -136,7 +136,7 @@ setup_scatter_handles(struct ompi_communicator_t   *comm,
     COLL_PORTALS4_SET_BITS(request->u.scatter.scatter_match_bits, ompi_comm_get_cid(comm),
             0, 0, COLL_PORTALS4_SCATTER, 0, request->u.scatter.coll_count);
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_scatter_handles rank(%d) scatter_match_bits(0x%016lX)",
                  request->u.scatter.my_rank, request->u.scatter.scatter_match_bits));
 
@@ -166,7 +166,7 @@ setup_scatter_handles(struct ompi_communicator_t   *comm,
                       &request->u.scatter.scatter_meh);
     if (PTL_OK != ret) { ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_scatter_handles exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -188,7 +188,7 @@ setup_sync_handles(struct ompi_communicator_t   *comm,
 
     ptl_me_t  me;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_sync_handles enter rank %d", request->u.scatter.my_rank));
 
     /**********************************/
@@ -197,7 +197,7 @@ setup_sync_handles(struct ompi_communicator_t   *comm,
     COLL_PORTALS4_SET_BITS(request->u.scatter.sync_match_bits, ompi_comm_get_cid(comm),
             0, 1, COLL_PORTALS4_SCATTER, 0, request->u.scatter.coll_count);
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_sync_handles rank(%d) sync_match_bits(0x%016lX)",
                  request->u.scatter.my_rank, request->u.scatter.sync_match_bits));
 
@@ -227,7 +227,7 @@ setup_sync_handles(struct ompi_communicator_t   *comm,
                       &request->u.scatter.sync_meh);
     if (PTL_OK != ret) { ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:setup_sync_handles exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -245,7 +245,7 @@ cleanup_scatter_handles(ompi_coll_portals4_request_t *request)
 {
     int ret, line;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:cleanup_scatter_handles enter rank %d", request->u.scatter.my_rank));
 
     /**********************************/
@@ -265,7 +265,7 @@ cleanup_scatter_handles(ompi_coll_portals4_request_t *request)
     ret = PtlCTFree(request->u.scatter.scatter_cth);
     if (PTL_OK != ret) { ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:cleanup_scatter_handles exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -284,7 +284,7 @@ cleanup_sync_handles(ompi_coll_portals4_request_t *request)
     int ret, line;
     int ptl_ret;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:cleanup_sync_handles enter rank %d", request->u.scatter.my_rank));
 
     /**********************************/
@@ -304,7 +304,7 @@ cleanup_sync_handles(ompi_coll_portals4_request_t *request)
     ret = PtlCTFree(request->u.scatter.sync_cth);
     if (PTL_OK != ret) { ptl_ret = ret; ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:cleanup_sync_handles exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -341,8 +341,9 @@ ompi_coll_portals4_scatter_intra_linear_top(const void *sbuf, int scount, struct
     int32_t expected_chained_rtrs = 0;
     int32_t expected_chained_acks = 0;
 
+    ptl_size_t number_of_fragment = 1;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra_linear_top enter rank %d", request->u.scatter.my_rank));
 
     request->type                   = OMPI_COLL_PORTALS4_TYPE_SCATTER;
@@ -409,6 +410,13 @@ ompi_coll_portals4_scatter_intra_linear_top(const void *sbuf, int scount, struct
     ret = setup_sync_handles(comm, request, portals4_module);
     if (MPI_SUCCESS != ret) { line = __LINE__; goto err_hdlr; }
 
+    number_of_fragment = (request->u.scatter.packed_size > mca_coll_portals4_component.ni_limits.max_msg_size) ?
+        (request->u.scatter.packed_size + mca_coll_portals4_component.ni_limits.max_msg_size - 1) / mca_coll_portals4_component.ni_limits.max_msg_size :
+        1;
+    opal_output_verbose(90, ompi_coll_base_framework.framework_output,
+        "%s:%d:rank %d:number_of_fragment = %lu",
+        __FILE__, __LINE__, request->u.scatter.my_rank, number_of_fragment);
+
     /**********************************/
     /* do the scatter                 */
     /**********************************/
@@ -445,25 +453,42 @@ ompi_coll_portals4_scatter_intra_linear_top(const void *sbuf, int scount, struct
             }
 
             ptl_size_t offset = request->u.scatter.packed_size * i;
+            ptl_size_t size_sent = 0;
+            ptl_size_t size_left = request->u.scatter.packed_size;
 
-            opal_output_verbose(30, ompi_coll_base_framework.framework_output,
+            opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                                 "%s:%d:rank(%d): offset(%lu)=rank(%d) * packed_size(%ld)",
                                 __FILE__, __LINE__, request->u.scatter.my_rank,
                                 offset, i, request->u.scatter.packed_size);
 
-            ret = PtlTriggeredPut(request->u.scatter.scatter_mdh,
-                                  (ptl_size_t)request->u.scatter.scatter_buf + offset,
-                                  request->u.scatter.packed_size,
-                                  PTL_NO_ACK_REQ,
-                                  ompi_coll_portals4_get_peer(comm, i),
-                                  mca_coll_portals4_component.pt_idx,
-                                  request->u.scatter.scatter_match_bits,
-                                  0,
-                                  NULL,
-                                  0,
-                                  request->u.scatter.scatter_cth,
-                                  expected_chained_rtrs);
-            if (PTL_OK != ret) { ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
+            for (ptl_size_t j=0; j<number_of_fragment; j++) {
+
+                ptl_size_t frag_size = (size_left >  mca_coll_portals4_component.ni_limits.max_msg_size) ?
+                    mca_coll_portals4_component.ni_limits.max_msg_size :
+                    size_left;
+
+                OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
+                                     "%s:%d:rank(%d): frag(%lu),offset_frag (%lu) frag_size(%lu)",
+                                     __FILE__, __LINE__, request->u.scatter.my_rank,
+                                     j, size_sent, frag_size));
+
+                ret = PtlTriggeredPut(request->u.scatter.scatter_mdh,
+                                      (ptl_size_t)request->u.scatter.scatter_buf + offset + size_sent,
+                                      frag_size,
+                                      PTL_NO_ACK_REQ,
+                                      ompi_coll_portals4_get_peer(comm, i),
+                                      mca_coll_portals4_component.pt_idx,
+                                      request->u.scatter.scatter_match_bits,
+                                      size_sent,
+                                      NULL,
+                                      0,
+                                      request->u.scatter.scatter_cth,
+                                      expected_chained_rtrs);
+                if (PTL_OK != ret) { ret = OMPI_ERROR; line = __LINE__; goto err_hdlr; }
+
+                size_left -= frag_size;
+                size_sent += frag_size;
+            }
         }
     } else {
         /* non-root, so do nothing */
@@ -473,7 +498,7 @@ ompi_coll_portals4_scatter_intra_linear_top(const void *sbuf, int scount, struct
         expected_acks = 0;
 
         /* operations on the scatter counter */
-        expected_puts         = 1;  /* scatter put from root */
+        expected_puts         = number_of_fragment;  /* scatter put from root */
         expected_chained_rtrs = 0;
         expected_chained_acks = 0;
     }
@@ -552,7 +577,7 @@ ompi_coll_portals4_scatter_intra_linear_top(const void *sbuf, int scount, struct
                 "completed CTWait(expected_ops=%d)\n", expected_ops);
     }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra_linear_top exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -574,7 +599,7 @@ ompi_coll_portals4_scatter_intra_linear_bottom(struct ompi_communicator_t *comm,
 {
     int ret, line;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra_linear_bottom enter rank %d", request->u.scatter.my_rank));
 
     ret = cleanup_scatter_handles(request);
@@ -616,7 +641,7 @@ ompi_coll_portals4_scatter_intra_linear_bottom(struct ompi_communicator_t *comm,
     ompi_request_complete(&request->super, true);
     OPAL_THREAD_UNLOCK(&ompi_request_lock);
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra_linear_bottom exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -645,7 +670,7 @@ ompi_coll_portals4_scatter_intra(const void *sbuf, int scount, struct ompi_datat
 
     ompi_coll_portals4_request_t *request;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra enter rank %d", ompi_comm_rank(comm)));
 
     /*
@@ -679,7 +704,7 @@ ompi_coll_portals4_scatter_intra(const void *sbuf, int scount, struct ompi_datat
      */
     OMPI_COLL_PORTALS4_REQUEST_RETURN(request);
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:scatter_intra exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -705,7 +730,7 @@ ompi_coll_portals4_iscatter_intra(const void *sbuf, int scount, struct ompi_data
 
     ompi_coll_portals4_request_t *request;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:iscatter_intra enter rank %d", ompi_comm_rank(comm)));
 
     /*
@@ -732,7 +757,7 @@ ompi_coll_portals4_iscatter_intra(const void *sbuf, int scount, struct ompi_data
                                                       module);
     if (MPI_SUCCESS != ret) { line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:iscatter_intra exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;
@@ -751,7 +776,7 @@ ompi_coll_portals4_iscatter_intra_fini(ompi_coll_portals4_request_t *request)
 {
     int ret, line;
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:iscatter_intra_fini enter rank %d", request->u.scatter.my_rank));
 
     /*
@@ -760,7 +785,7 @@ ompi_coll_portals4_iscatter_intra_fini(ompi_coll_portals4_request_t *request)
     ret = ompi_coll_portals4_scatter_intra_linear_bottom(request->super.req_mpi_object.comm, request);
     if (MPI_SUCCESS != ret) { line = __LINE__; goto err_hdlr; }
 
-    OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
+    OPAL_OUTPUT_VERBOSE((10, ompi_coll_base_framework.framework_output,
                  "coll:portals4:iscatter_intra_fini exit rank %d", request->u.scatter.my_rank));
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
This patch splits messages bigger than the maximum size supported by 
portals4 (according to max_msg_size returned by PtlNIInit). It also 
assures that all pending PtlTriggeredPut are triggered before 
calling PtlCTWait. For bcast, it corrects and simplifies how the 
data are split in different segments. And finally, it just modifies 
output format.

(cherry picked from commit open-mpi/ompi@a7e3de6)
(cherry picked from commit open-mpi/ompi@175e6aa)
(cherry picked from commit open-mpi/ompi@df59d6c)
(cherry picked from commit open-mpi/ompi@274f8d6)
(cherry picked from commit open-mpi/ompi@c86d403)
