### PR TITLE
spml/yoda: MCA_PML(add_procs) all procs from oshmem_comm_world

### DIFF
--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2013-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -636,6 +636,12 @@ int mca_spml_yoda_add_procs(oshmem_proc_t** procs, size_t nprocs)
     }
 
     rc = mca_bml.bml_register_error(mca_spml_yoda_error_handler);
+    if (OMPI_SUCCESS != rc) {
+        goto cleanup_and_return;
+    }
+
+    /* create_btl_idx requires the proc was add_proc'ed, so do it now */
+    rc = MCA_PML_CALL(add_procs(procs, nprocs));
     if (OMPI_SUCCESS != rc) {
         goto cleanup_and_return;
     }

--- a/oshmem/proc/proc.c
+++ b/oshmem/proc/proc.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      ARM, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -79,8 +79,7 @@ int oshmem_proc_group_init(void)
             == (oshmem_group_all =
                     oshmem_proc_group_create(0,
                                              1,
-					     oshmem_num_procs()))) {
-        oshmem_proc_group_destroy(oshmem_group_all);
+					     ompi_comm_size(oshmem_comm_world)))) {
         return OSHMEM_ERROR;
     }
 
@@ -151,7 +150,7 @@ oshmem_group_t* oshmem_proc_group_create(int pe_start,
 
         group->my_pe = oshmem_proc_pe(oshmem_proc_local());
         group->is_member = 0;
-        for (i = 0 ; i < oshmem_num_procs() ; i++) {
+        for (i = 0 ; i < ompi_comm_size(oshmem_comm_world) ; i++) {
             proc = oshmem_proc_find(i);
             if (NULL == proc) {
                 opal_output(0,


### PR DESCRIPTION
and fix oshmem_group_proc_{init,create} so they use the number of procs in oshmem_comm_world

Thanks Debendra Das for the report and Josh Ladd for the guidance

Fixes open-mpi/ompi#1966

(cherry picked from commit open-mpi/ompi@6b7bc6410168f162be930f93e0b6fa18753bcdb4)
