### PR TITLE
Update PMIx to the latest 1.1.5rc to catch the strnlen abstraction support required for working on older Mac's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,6 +305,7 @@ opal/mca/pmix/pmix112/pmix/include/pmix/autogen/config.h.in
 opal/mca/pmix/pmix112/pmix/include/pmix/pmix_common.h
 opal/mca/pmix/pmix112/pmix/include/private/autogen/config.h
 opal/mca/pmix/pmix112/pmix/include/private/autogen/config.h.in
+opal/mca/pmix/pmix112/pmix/include/pmix/autogen/config.h.in
 
 opal/tools/opal-checkpoint/opal-checkpoint
 opal/tools/opal-checkpoint/opal-checkpoint.1

--- a/opal/mca/pmix/pmix112/pmix/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/Makefile.am
@@ -31,7 +31,6 @@ EXTRA_DIST =
 # Only install the valgrind suppressions file if we're building in
 # standalone mode
 dist_pmixdata_DATA =
-
 if ! PMIX_EMBEDDED_MODE
 dist_pmixdata_DATA += contrib/pmix-valgrind.supp
 
@@ -46,7 +45,6 @@ man_MANS = \
         man/man3/pmix_get.3 \
         man/man7/pmix.7 \
         man/man7/pmix_constants.7
-
 endif
 
 include config/Makefile.am
@@ -91,15 +89,12 @@ nroff:
 
 EXTRA_DIST += README INSTALL VERSION LICENSE autogen.sh \
              config/pmix_get_version.sh $(man_MANS) \
-             contrib/platform/optimized
+             contrib/platform/optimized \
+             test/test_common.h test/cli_stages.h \
+             test/server_callbacks.h test/test_fence.h \
+             test/test_publish.h test/test_resolve_peers.h \
+             test/test_spawn.h test/utils.h test/test_cd.h
 
-if ! PMIX_EMBEDDED_MODE
-
-EXTRA_DIST += test/test_common.h test/cli_stages.h \
-              test/server_callbacks.h test/test_fence.h \
-              test/test_publish.h test/test_resolve_peers.h \
-              test/test_spawn.h test/utils.h test/test_cd.h
-endif
 
 dist-hook:
 	env LS_COLORS= sh "$(top_srcdir)/config/distscript.sh" "$(top_srcdir)" "$(distdir)" "$(PMIX_VERSION)" "$(PMIX_REPO_REV)"

--- a/opal/mca/pmix/pmix112/pmix/VERSION
+++ b/opal/mca/pmix/pmix112/pmix/VERSION
@@ -15,7 +15,7 @@
 
 major=1
 minor=1
-release=4
+release=5
 
 # greek is used for alpha or beta release tags.  If it is non-empty,
 # it will be appended to the version number.  It does not have to be
@@ -23,14 +23,14 @@ release=4
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=git4695e45
+repo_rev=git9ae61b8
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Jun 01, 2016"
+date="Aug 23, 2016"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix112/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix112/pmix/config/pmix.m4
@@ -17,9 +17,8 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
-dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -496,7 +495,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep getpeereid getpeerucred])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep getpeereid getpeerucred strnlen])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/opal/mca/pmix/pmix112/pmix/src/server/pmix_server_listener.c
+++ b/opal/mca/pmix/pmix112/pmix/src/server/pmix_server_listener.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
@@ -56,6 +56,7 @@
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/progress_threads.h"
+#include "src/util/strnlen.h"
 #include "src/usock/usock.h"
 #include "src/sec/pmix_sec.h"
 
@@ -315,31 +316,41 @@ static pmix_status_t parse_connect_ack (char *msg, int len,
                                         char **nspace, int *rank,
                                         char **version, char **cred)
 {
-    if ((int)strnlen (msg, len) < len) {
+    int msglen;
+
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len) {
         *nspace = msg;
         msg += strlen(*nspace) + 1;
         len -= strlen(*nspace) + 1;
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)sizeof(int) <= len) {
-        *rank = *(int *)msg;
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen <= len) {
+        memcpy(rank, msg, sizeof(int));
         msg += sizeof(int);
         len -= sizeof(int);
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)strnlen (msg, len) < len) {
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len) {
         *version = msg;
         msg += strlen(*version) + 1;
         len -= strlen(*version) + 1;
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)strnlen (msg, len) < len)
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len)
         *cred = msg;
-    else
+    else {
         *cred = NULL;
+    }
 
     return PMIX_SUCCESS;
 }

--- a/opal/mca/pmix/pmix112/pmix/src/util/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/src/util/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Intel, Inc. All rights reserved
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +34,8 @@ headers += \
         src/util/timings.h \
         src/util/os_path.h \
         src/util/basename.h \
-        src/util/hash.h
+        src/util/hash.h \
+        src/util/strnlen.h
 
 sources += \
         src/util/argv.c \

--- a/opal/mca/pmix/pmix112/pmix/src/util/strnlen.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/strnlen.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file
+ *
+ * Buffer strnlen function for portability to archaic platforms.
+ */
+
+#ifndef PMIX_STRNLEN_H
+#define PMIX_STRNLEN_H
+
+#include <src/include/pmix_config.h>
+
+#if defined(HAVE_STRNLEN)
+#define PMIX_STRNLEN(c, a, b)       \
+    (c) = (int)strnlen(a, b)
+#else
+#define PMIX_STRNLEN(c, a, b)           \
+    do {                                \
+        int _x;                         \
+        (c) = 0;                        \
+        for (_x=0; _x < (b); _x++) {    \
+            if ('\0' == (a)[_x]) {      \
+                break;                  \
+            }                           \
+            ++(c);                      \
+        }                               \
+    } while(0)
+#endif
+
+#endif /* PMIX_STRNLEN_H */
+


### PR DESCRIPTION
@hppritcha @jsquyres  This is the rest of the PMIx update required for 2.0.1
