### PR TITLE
Fix typo - initialize stdin_target to zero for jobs

### DIFF
--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -632,7 +632,7 @@ static void orte_job_construct(orte_job_t* job)
                             ORTE_GLOBAL_ARRAY_MAX_SIZE,
                             2);
     job->num_apps = 0;
-    job->stdin_target = ORTE_VPID_INVALID;
+    job->stdin_target = 0;
     job->total_slots_alloc = 0;
     job->num_procs = 0;
     job->procs = OBJ_NEW(opal_pointer_array_t);


### PR DESCRIPTION
Totally trivial fix - can you please include it?
