### PR TITLE
Correct the binding algorithm to decouple it from oversubscribe. 

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -242,17 +242,14 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
      * already (e.g., during the call to comm_spawn), then we don't
      * override it */
     if (!OPAL_BINDING_POLICY_IS_SET(jdata->map->binding)) {
-        /* if the user specified that we allow oversubscription, then do not bind.
-         * otherwise, if the user explicitly mapped-by some object, then we default
-         * to binding to that object */
-        if ((ORTE_MAPPING_SUBSCRIBE_GIVEN & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping)) &&
-            !(ORTE_MAPPING_NO_OVERSUBSCRIBE & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping))) {
-            OPAL_SET_BINDING_POLICY(jdata->map->binding, OPAL_BIND_TO_NONE);
-        } else if (OPAL_BINDING_POLICY_IS_SET(opal_hwloc_binding_policy)) {
+        if (OPAL_BINDING_POLICY_IS_SET(opal_hwloc_binding_policy)) {
             /* if the user specified a default binding policy via
-             * MCA param, then we use it */
+             * MCA param, then we use it - this can include a directive
+             * to overload */
             jdata->map->binding = opal_hwloc_binding_policy;
         } else {
+            /* if the user explicitly mapped-by some object, then we default
+             * to binding to that object */
             orte_mapping_policy_t mpol;
             mpol = ORTE_GET_MAPPING_POLICY(orte_rmaps_base.mapping);
             if (ORTE_MAPPING_POLICY_IS_SET(jdata->map->mapping) &&


### PR DESCRIPTION
Oversubscribe stipulates that we allow more procs on the node than assigned slots - it has nothing to do with the number of available pe's. Let overload directives handle the pe situation.

@hppritcha @jsquyres Timing of this is up to you - it fixes a user-reported problem in 2.0.0, but it is coming rather late.
