### PR TITLE
v2.0.2: compiler warnings stomp

### DIFF
--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -441,42 +442,43 @@ int mqs_setup_process (mqs_process *process, const mqs_process_callbacks *pcb)
         {
             mqs_taddr_t typedefs_sizeof;
 
-            if(mqs_find_symbol (image, "MPIR_debug_typedefs_sizeof", &typedefs_sizeof) != mqs_ok)
-               return err_no_store;
-               p_info->sizes.short_size = ompi_fetch_int( process, /* sizeof (short) */
-                                                          typedefs_sizeof,
-                                                          p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.int_size = ompi_fetch_int( process, /* sizeof (int) */
-                                                        typedefs_sizeof,
-                                                        p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.long_size = ompi_fetch_int( process, /* sizeof (long) */
-                                                         typedefs_sizeof,
-                                                         p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.long_long_size = ompi_fetch_int( process, /* sizeof (long long) */
-                                                              typedefs_sizeof,
-                                                              p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.pointer_size = ompi_fetch_int( process, /* sizeof (void *) */
-                                                            typedefs_sizeof,
-                                                            p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.bool_size = ompi_fetch_int( process, /* sizeof (bool) */
-                                                         typedefs_sizeof,
-                                                         p_info );
-               typedefs_sizeof += p_info->sizes.int_size;
-               p_info->sizes.size_t_size = ompi_fetch_int( process, /* sizeof (size_t) */
+            if (mqs_find_symbol (image, "MPIR_debug_typedefs_sizeof", &typedefs_sizeof) != mqs_ok) {
+                return err_no_store;
+            }
+            p_info->sizes.short_size = ompi_fetch_int( process, /* sizeof (short) */
+                                                       typedefs_sizeof,
+                                                       p_info );
+            typedefs_sizeof += p_info->sizes.int_size;
+            p_info->sizes.int_size = ompi_fetch_int( process, /* sizeof (int) */
+                                                     typedefs_sizeof,
+                                                     p_info );
+            typedefs_sizeof += p_info->sizes.int_size;
+             p_info->sizes.long_size = ompi_fetch_int( process, /* sizeof (long) */
+                                                       typedefs_sizeof,
+                                                       p_info );
+            typedefs_sizeof += p_info->sizes.int_size;
+            p_info->sizes.long_long_size = ompi_fetch_int( process, /* sizeof (long long) */
                                                            typedefs_sizeof,
                                                            p_info );
-               DEBUG( VERBOSE_GENERAL,
-                      ("sizes short = %d int = %d long = %d long long = %d "
-                       "void* = %d bool = %d size_t = %d\n",
-                       p_info->sizes.short_size, p_info->sizes.int_size,
-                       p_info->sizes.long_size, p_info->sizes.long_long_size,
-                       p_info->sizes.pointer_size, p_info->sizes.bool_size,
-                       p_info->sizes.size_t_size) );
+            typedefs_sizeof += p_info->sizes.int_size;
+            p_info->sizes.pointer_size = ompi_fetch_int( process, /* sizeof (void *) */
+                                                         typedefs_sizeof,
+                                                         p_info );
+            typedefs_sizeof += p_info->sizes.int_size;
+            p_info->sizes.bool_size = ompi_fetch_int( process, /* sizeof (bool) */
+                                                      typedefs_sizeof,
+                                                      p_info );
+            typedefs_sizeof += p_info->sizes.int_size;
+            p_info->sizes.size_t_size = ompi_fetch_int( process, /* sizeof (size_t) */
+                                                        typedefs_sizeof,
+                                                        p_info );
+            DEBUG( VERBOSE_GENERAL,
+                   ("sizes short = %d int = %d long = %d long long = %d "
+                    "void* = %d bool = %d size_t = %d\n",
+                    p_info->sizes.short_size, p_info->sizes.int_size,
+                    p_info->sizes.long_size, p_info->sizes.long_long_size,
+                    p_info->sizes.pointer_size, p_info->sizes.bool_size,
+                    p_info->sizes.size_t_size) );
         }
 
         mqs_put_process_info (process, (mqs_process_info *)p_info);

--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -19,6 +19,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1709,7 +1709,7 @@ int ompi_osc_pt2pt_frag_start_receive (ompi_osc_pt2pt_module_t *module)
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    for (int i = 0 ; i < module->recv_frag_count ; ++i) {
+    for (unsigned int i = 0 ; i < module->recv_frag_count ; ++i) {
         OBJ_CONSTRUCT(module->recv_frags + i, ompi_osc_pt2pt_receive_t);
         module->recv_frags[i].module = module;
         module->recv_frags[i].buffer = malloc (mca_osc_pt2pt_component.buffer_size + sizeof (ompi_osc_pt2pt_frag_header_t));

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -94,7 +94,7 @@ int ompi_osc_pt2pt_free(ompi_win_t *win)
     OBJ_DESTRUCT(&module->peer_lock);
 
     if (NULL != module->recv_frags) {
-        for (int i = 0 ; i < module->recv_frag_count ; ++i) {
+        for (unsigned int i = 0 ; i < module->recv_frag_count ; ++i) {
             OBJ_DESTRUCT(module->recv_frags + i);
         }
 

--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -94,7 +95,7 @@ int mca_btl_tcp_add_procs( struct mca_btl_base_module_t* btl,
 
         OPAL_THREAD_LOCK(&tcp_proc->proc_lock);
 
-        for (uint32_t j = 0 ; j < (int)tcp_proc->proc_endpoint_count ; ++j) {
+        for (uint32_t j = 0 ; j < (uint32_t)tcp_proc->proc_endpoint_count ; ++j) {
             tcp_endpoint = tcp_proc->proc_endpoints[j];
             if (tcp_endpoint->endpoint_btl == tcp_btl) {
                 existing_found = true;
@@ -512,7 +513,7 @@ void mca_btl_tcp_dump(struct mca_btl_base_module_t* base_btl,
         opal_list_item_t *item;
 
         for(item =  opal_list_get_first(&btl->tcp_endpoints);
-            item != opal_list_get_end(&btl->tcp_endpoints); 
+            item != opal_list_get_end(&btl->tcp_endpoints);
             item = opal_list_get_next(item)) {
             MCA_BTL_TCP_ENDPOINT_DUMP(10, (mca_btl_base_endpoint_t*)item, false, "TCP");
         }

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -372,6 +372,18 @@ static int s1_init(void)
         goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
+    /* push this into the dstore for subsequent fetches */
+    OBJ_CONSTRUCT(&kv, opal_value_t);
+    kv.key = strdup(OPAL_PMIX_MAX_PROCS);
+    kv.type = OPAL_UINT32;
+    kv.data.uint32 = i;
+    if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
+        OPAL_ERROR_LOG(ret);
+        OBJ_DESTRUCT(&kv);
+        goto err_exit;
+    }
+    OBJ_DESTRUCT(&kv);
+
 
     /* get job size */
     ret = PMI_Get_size(&i);

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All
  *                         rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -284,6 +284,17 @@ static int s2_init(void)
     kv.data.uint32 = atoi(buf);
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
         OPAL_ERROR_LOG(rc);
+        OBJ_DESTRUCT(&kv);
+        goto err_exit;
+    }
+    OBJ_DESTRUCT(&kv);
+    /* push this into the dstore for subsequent fetches */
+    OBJ_CONSTRUCT(&kv, opal_value_t);
+    kv.key = strdup(OPAL_PMIX_MAX_PROCS);
+    kv.type = OPAL_UINT32;
+    kv.data.uint32 = i;
+    if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
+        OPAL_ERROR_LOG(ret);
         OBJ_DESTRUCT(&kv);
         goto err_exit;
     }


### PR DESCRIPTION
Fix some compiler warnings that were already done on master, but didn't come over to v2.x.

Master commits are noted in individual commit messages.

@rhc54 Are the pmix fixes necessary?  These were lumped into warnings fixes commits. 😦 
