### PR TITLE
Fixes opal_atomic_ll_64. 

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -236,7 +236,7 @@ static inline int64_t opal_atomic_ll_64(volatile int64_t *addr)
    __asm__ __volatile__ ("ldarx   %0, 0, %1  \n\t"
                          : "=&r" (ret)
                          : "r" (addr)
-                         :);
+                         );
    return ret;
 }
 


### PR DESCRIPTION
Thanks to Paul Hargrove for the report and his patch.

This is a cherry-pick of open-mpi/ompi@a6d515b
