### PR TITLE
opal/patcher: fix xlc support

### DIFF
--- a/opal/mca/patcher/base/patcher_base_patch.c
+++ b/opal/mca/patcher/base/patcher_base_patch.c
@@ -175,7 +175,10 @@ int mca_patcher_base_patch_hook (mca_patcher_base_module_t *module, uintptr_t ho
     }
 
     // generate code to restore TOC
-    register unsigned long toc asm("r2");
+    unsigned long toc;
+
+    asm volatile ("std 2, %0" : "=m" (toc));
+
     hook_patch->patch_data_size = PatchLoadImm((uintptr_t)hook_patch->patch_data, 2, toc);
 
     /* put the hook patch on the patch list so it will be undone on finalize */


### PR DESCRIPTION
The xlc compiler seems to behave in a different way that gcc when it
comes the inline asm. There were two problems with the code with xlc:
- The TOC read in mca_patcher_base_patch_hook used the syntax
  register unsigned long toc asm("r2") to read $r2 (the TOC
  pointer). With gcc this seems to behave as expected but with xlc
  the result in toc is not the same as $r2. I updated the code to use
  asm volatile ("std 2, %0" : "=m" (toc)) to load the TOC pointer.
- The OPAL_PATCHER_BEGIN macro is meant to be the first thing in a
  hook. On PPC64 it loads the correct TOC pointer (thanks to
  mca_patcher_base_patch_hook) and saves the old one. The
  OPAL_PATCHER_END macro restores the TOC pointer. Because we _need_
  the TOC to be correct before it is accessed in the hook the
  OPAL_PATCHER_BEGIN macro MUST come first. We did this and all was
  well with gcc. With xlc on the other hand there was a TOC access
  before the assembly inserted by OPAL_PATCHER_BEGIN. To fix this
  quickly I broke each hook into a pair of function with the
  OPAL_PATCHER_\* macros on the top level functions. This works around
  the issue but is not a clean way to fix this. In the future we
  should 1) either update overwrite to not need this, or 2) figure
  out why xlc is not inserting the asm before the first TOC read.

This fixes open-mpi/ompi#1854

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@a9bc692d99e645c1f3107746fefa96fe726b18cd)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
