### PR TITLE
opal_setup_wrappers.m4: fix fortran rpath detection

### DIFF
--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -181,7 +181,7 @@ EOF
 # (because if script A sources script B, and B calls "exit", then both
 # B and A will exit).  Instead, we have to send the output to a file
 # and then source that.
-$OPAL_TOP_BUILDDIR/libtool --tag=FC --config > $rpath_outfile
+$OMPI_TOP_BUILDDIR/libtool --tag=FC --config > $rpath_outfile
 
 chmod +x $rpath_outfile
 . ./$rpath_outfile
@@ -246,7 +246,7 @@ AC_DEFUN([OPAL_SETUP_RUNPATH],[
 # (because if script A sources script B, and B calls "exit", then both
 # B and A will exit).  Instead, we have to send the output to a file
 # and then source that.
-$OPAL_TOP_BUILDDIR/libtool --tag=FC--config > $rpath_outfile
+$OMPI_TOP_BUILDDIR/libtool --tag=FC --config > $rpath_outfile
 
 chmod +x $rpath_outfile
 . ./$rpath_outfile


### PR DESCRIPTION
s/OPAL/OMPI/ in the shell variable names.

Additionally, there was a typo (missing space) in one of the libtool commands.  Fixes open-mpi/ompi#2027.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

@rhc54 Please review.  This should fix the issues we've been seeing on the Cisco MTT v1.10 shared library failures.
