### PR TITLE
io/ompio: increase the ref counter on datatypes that are not duplicated.

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -44,6 +44,7 @@ static int datatype_duplicate  (ompi_datatype_t *oldtype, ompi_datatype_t **newt
 {
     ompi_datatype_t *type;
     if( ompi_datatype_is_predefined(oldtype) ) {
+        OBJ_RETAIN(oldtype);
         *newtype = oldtype;
         return OMPI_SUCCESS;
     }


### PR DESCRIPTION
this fixes the datatype reference count problem reported by @errich1

fixes issue #1875
bot:assign:@bosilca
bot:milestone:v2.0.1

George, would you mind reviewing this fix?
