### PR TITLE
v1.10: libnbc fixes

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -250,6 +250,10 @@ static inline int red_sched_binomial (int rank, int p, int root, void *sendbuf, 
   RANK2VRANK(rank, vrank, vroot);
   maxr = (int)ceil((log((double)p)/LOG2));
 
+  if (rank != root) {
+    inplace = 0;
+  }
+
   /* ensure the result ends up in redbuf on vrank 0 */
   if (0 == (maxr%2)) {
     rbuf = (void *)(-gap);


### PR DESCRIPTION
Fixes open-mpi/ompi#2034
- fix NBC_Copy for predefined but non contiguous datatypes such as MPI_LONG_DOUBLE_INT
- fix nbc_ireduce when sendbuf == recvbuf on non root ranks

Thanks Valentin Petrov for the report
