### PR TITLE
Fixed Javadoc generated warnings

### DIFF
--- a/ompi/mpi/java/java/CartComm.java
+++ b/ompi/mpi/java/java/CartComm.java
@@ -90,7 +90,7 @@ protected CartComm(long[] commRequest)
  * Duplicates this communicator.
  * <p>Java binding of {@code MPI_COMM_DUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public CartComm dup() throws MPIException
 {
@@ -104,7 +104,7 @@ protected CartComm(long[] commRequest)
  * <p>The new communicator can't be used before the operation completes.
  * The request object must be obtained calling {@link #getRequest}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public CartComm iDup() throws MPIException
 {
@@ -119,7 +119,7 @@ protected CartComm(long[] commRequest)
  * <p>The number of dimensions can be obtained from the size of (eg)
  * {@code dims} field of the returned object.
  * @return object containing dimensions, periods and local coordinates
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public CartParms getTopo() throws MPIException
 {
@@ -134,7 +134,7 @@ private native CartParms getTopo(long comm) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_CART_RANK}.
  * @param coords Cartesian coordinates of a process
  * @return rank of the specified process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getRank(int[] coords) throws MPIException
 {
@@ -149,7 +149,7 @@ private native int getRank(long comm, int[] coords) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_CART_COORDS}.
  * @param rank rank of a process
  * @return Cartesian coordinates of the specified process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int[] getCoords(int rank) throws MPIException
 {
@@ -165,7 +165,7 @@ private native int[] getCoords(long comm, int rank) throws MPIException;
  * @param direction coordinate dimension of shift
  * @param disp      displacement
  * @return object containing ranks of source and destination processes
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public ShiftParms shift(int direction, int disp) throws MPIException
 {
@@ -182,7 +182,7 @@ private native ShiftParms shift(long comm, int direction, int disp)
  * @param remainDims by dimension, {@code true} if dimension is to be kept,
  *                   {@code false} otherwise
  * @return communicator containing subgrid including this process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public CartComm sub(boolean[] remainDims) throws MPIException
 {
@@ -200,7 +200,7 @@ private native long sub(long comm, boolean[] remainDims) throws MPIException;
  * @param periods {@code true} if grid is periodic,
  *                {@code false} if not, in each dimension
  * @return reordered rank of calling process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int map(int[] dims, boolean[] periods) throws MPIException
 {
@@ -216,7 +216,7 @@ private native int map(long comm, int[] dims, boolean[] periods)
  * <p>Java binding of the MPI operation {@code MPI_DIMS_CREATE}.
  * @param nnodes number of nodes in a grid
  * @param dims   array specifying the number of nodes in each dimension
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void createDims(int nnodes, int[] dims) throws MPIException
 {

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -122,7 +122,7 @@ private native void getComm(int type);
  * Duplicates this communicator.
  * <p>Java binding of {@code MPI_COMM_DUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Comm dup() throws MPIException
 {
@@ -138,7 +138,7 @@ protected final native long dup(long comm) throws MPIException;
  * <p>The new communicator can't be used before the operation completes.
  * The request object must be obtained calling {@link #getRequest}.
  * @return copy of this communicator
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Comm iDup() throws MPIException
 {
@@ -163,7 +163,7 @@ public final Request getRequest()
  * Size of group of this communicator.
  * <p>Java binding of the MPI operation {@code MPI_COMM_SIZE}.
  * @return number of processors in the group of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int getSize() throws MPIException
 {
@@ -177,7 +177,7 @@ private native int getSize(long comm) throws MPIException;
  * Rank of this process in group of this communicator.
  * <p>Java binding of the MPI operation {@code MPI_COMM_RANK}.
  * @return rank of the calling process in the group of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int getRank() throws MPIException
 {
@@ -200,7 +200,7 @@ private native int getRank(long comm) throws MPIException;
  * {@code MPI.SIMILAR} results if the underlying groups are similar
  * but the communicators differ by context.<br>
  * {@code MPI.UNEQUAL} results otherwise.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static int compare(Comm comm1, Comm comm2) throws MPIException
 {
@@ -212,7 +212,7 @@ private static native int compare(long comm1, long comm2) throws MPIException;
 
 /**
  * Java binding of the MPI operation {@code MPI_COMM_FREE}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override final public void free() throws MPIException
 {
@@ -234,7 +234,7 @@ public final boolean isNull()
 /**
  * Java binding of {@code MPI_COMM_SET_INFO}.
  * @param info info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final void setInfo(Info info) throws MPIException
 {
@@ -247,7 +247,7 @@ private native void setInfo(long fh, long info) throws MPIException;
 /**
  * Java binding of {@code MPI_COMM_GET_INFO}.
  * @return new info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Info getInfo() throws MPIException
 {
@@ -259,7 +259,7 @@ private native long getInfo(long fh) throws MPIException;
 
 /**
  * Java binding of the MPI operation {@code MPI_COMM_DISCONNECT}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final void disconnect() throws MPIException
 {
@@ -273,7 +273,7 @@ private native long disconnect(long comm) throws MPIException;
  * Return group associated with a communicator.
  * <p>Java binding of the MPI operation {@code MPI_COMM_GROUP}.
  * @return group corresponding to this communicator group
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Group getGroup() throws MPIException
 {
@@ -290,7 +290,7 @@ private native long getGroup(long comm);
  * <p>Java binding of the MPI operation {@code MPI_COMM_TEST_INTER}.
  * @return {@code true} if this is an inter-communicator,
  *         {@code false} otherwise
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final boolean isInter() throws MPIException
 {
@@ -313,7 +313,7 @@ private native boolean isInter(long comm) throws MPIException;
  * @param remoteLeader rank of remote group leader in this communicator
  * @param tag          "safe" tag
  * @return new inter-communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intercomm createIntercomm(Comm localComm, int localLeader,
                                        int remoteLeader, int tag)
@@ -339,7 +339,7 @@ private native long createIntercomm(
  * @param type  datatype of each item in send buffer
  * @param dest  rank of destination
  * @param tag   message tag
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void send(Object buf, int count, Datatype type, int dest, int tag)
         throws MPIException
@@ -370,7 +370,7 @@ private native void send(
  * @param source rank of source
  * @param tag    message tag
  * @return status object
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Status recv(Object buf, int count,
                          Datatype type, int source, int tag)
@@ -415,7 +415,7 @@ private native void recv(
  * @param source    rank of source
  * @param recvtag   receive tag
  * @return status object
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  * @see mpi.Comm#recv(Object, int, Datatype, int, int)
  */
@@ -473,7 +473,7 @@ private native void sendRecv(
  * @param source  rank of source
  * @param recvtag receive tag
  * @return status object
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  * @see mpi.Comm#recv(Object, int, Datatype, int, int)
  */
@@ -515,7 +515,7 @@ private native void sendRecvReplace(
  * @param type  datatype of each item in send buffer
  * @param dest  rank of destination
  * @param tag   message tag
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final void bSend(Object buf, int count, Datatype type, int dest, int tag)
@@ -546,7 +546,7 @@ private native void bSend(
  * @param type  datatype of each item in send buffer
  * @param dest  rank of destination
  * @param tag   message tag
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final void sSend(Object buf, int count, Datatype type, int dest, int tag)
@@ -577,7 +577,7 @@ private native void sSend(
  * @param type  datatype of each item in send buffer
  * @param dest  rank of destination
  * @param tag   message tag
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final void rSend(Object buf, int count, Datatype type, int dest, int tag)
@@ -611,7 +611,7 @@ private native void rSend(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Request iSend(Buffer buf, int count,
@@ -638,7 +638,7 @@ private native long iSend(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Request ibSend(Buffer buf, int count,
@@ -665,7 +665,7 @@ private native long ibSend(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Request isSend(Buffer buf, int count,
@@ -692,7 +692,7 @@ private native long isSend(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Request irSend(Buffer buf, int count,
@@ -719,7 +719,7 @@ private native long irSend(
  * @param source rank of source
  * @param tag    message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#recv(Object, int, Datatype, int, int)
  */
 public final Request iRecv(Buffer buf, int count,
@@ -749,7 +749,7 @@ private native long iRecv(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return persistent communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Prequest sendInit(Buffer buf, int count,
@@ -776,7 +776,7 @@ private native long sendInit(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return persistent communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Prequest bSendInit(Buffer buf, int count,
@@ -803,7 +803,7 @@ private native long bSendInit(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return persistent communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Prequest sSendInit(Buffer buf, int count,
@@ -830,7 +830,7 @@ private native long sSendInit(
  * @param dest  rank of destination
  * @param tag   message tag
  * @return persistent communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#send(Object, int, Datatype, int, int)
  */
 public final Prequest rSendInit(Buffer buf, int count,
@@ -857,7 +857,7 @@ private native long rSendInit(
  * @param source rank of source
  * @param tag    message tag
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  * @see mpi.Comm#recv(Object, int, Datatype, int, int)
  */
 public final Prequest recvInit(Buffer buf, int count,
@@ -891,7 +891,7 @@ private native long recvInit(
  * @param outbuf   output buffer
  * @param position initial position in output buffer
  * @return final position in output buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int pack(Object inbuf, int incount, Datatype type,
                       byte[] outbuf, int position)
@@ -929,7 +929,7 @@ private native int pack(
  * @param outcount number of items in output buffer
  * @param type     datatype of each item in output buffer
  * @return final position in input buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int unpack(byte[] inbuf, int position,
                         Object outbuf, int outcount, Datatype type)
@@ -960,7 +960,7 @@ private native int unpack(
  * @param incount number of items in input buffer
  * @param type    datatype of each item in input buffer
  * @return upper bound on size of packed message
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int packSize(int incount, Datatype type) throws MPIException
 {
@@ -982,7 +982,7 @@ private native int packSize(long comm, int incount, long type)
  * @param tag    message tag
  * @return status object if such a message is currently available,
  *         {@code null} otherwise.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Status iProbe(int source, int tag) throws MPIException
 {
@@ -1001,7 +1001,7 @@ private native Status iProbe(long comm, int source, int tag)
  * @param source rank of source
  * @param tag    message tag
  * @return status object
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Status probe(int source, int tag) throws MPIException
 {
@@ -1020,7 +1020,7 @@ private native void probe(long comm, int source, int tag, long[] stat)
  * Create a new attribute key.
  * <p>Java binding of the MPI operation {@code MPI_COMM_CREATE_KEYVAL}.
  * @return attribute key for future access
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static int createKeyval() throws MPIException
 {
@@ -1034,7 +1034,7 @@ private static native int createKeyval_jni() throws MPIException;
  * Frees an attribute key for communicators.
  * <p>Java binding of the MPI operation {@code MPI_COMM_FREE_KEYVAL}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void freeKeyval(int keyval) throws MPIException
 {
@@ -1049,7 +1049,7 @@ private static native void freeKeyval_jni(int keyval) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_COMM_SET_ATTR}.
  * @param keyval attribute key
  * @param value  attribute value
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void setAttr(int keyval, Object value) throws MPIException
 {
@@ -1065,7 +1065,7 @@ private native void setAttr(long comm, int keyval, byte[] value)
  * <p>Java binding of the MPI operation {@code MPI_COMM_GET_ATTR}.
  * @param keyval attribute key
  * @return attribute value or null if no attribute is associated with the key.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Object getAttr(int keyval) throws MPIException
 {
@@ -1100,7 +1100,7 @@ private native byte[] getAttr(long comm, int keyval) throws MPIException;
  * Deletes an attribute value associated with a key on a communicator.
  * <p>Java binding of the MPI operation {@code MPI_COMM_DELETE_ATTR}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void deleteAttr(int keyval) throws MPIException
 {
@@ -1118,7 +1118,7 @@ private native void deleteAttr(long comm, int keyval) throws MPIException;
  * <p>The return value will be one of {@code MPI.GRAPH}, {@code MPI.CART}
  * or {@code MPI.UNDEFINED}.
  * @return topology type of communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int getTopology() throws MPIException
 {
@@ -1134,7 +1134,7 @@ private native int getTopology(long comm) throws MPIException;
  * Abort MPI.
  * <p>Java binding of the MPI operation {@code MPI_ABORT}.
  * @param errorcode error code for Unix or POSIX environments
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void abort(int errorcode) throws MPIException
 {
@@ -1150,7 +1150,7 @@ private native void abort(long comm, int errorcode) throws MPIException;
  * Associates a new error handler with communicator at the calling process.
  * <p>Java binding of the MPI operation {@code MPI_ERRHANDLER_SET}.
  * @param errhandler new MPI error handler for communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void setErrhandler(Errhandler errhandler) throws MPIException
 {
@@ -1165,7 +1165,7 @@ private native void setErrhandler(long comm, long errhandler)
  * Returns the error handler currently associated with the communicator.
  * <p>Java binding of the MPI operation {@code MPI_ERRHANDLER_GET}.
  * @return MPI error handler currently associated with communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Errhandler getErrhandler() throws MPIException
 {
@@ -1181,7 +1181,7 @@ private native long getErrhandler(long comm);
  * A call to {@code barrier} blocks the caller until all process
  * in the group have called it.
  * <p>Java binding of the MPI operation {@code MPI_BARRIER}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void barrier() throws MPIException
 {
@@ -1195,7 +1195,7 @@ private native void barrier(long comm) throws MPIException;
  * Nonblocking barrier sinchronization.
  * <p>Java binding of the MPI operation {@code MPI_IBARRIER}.
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iBarrier() throws MPIException
 {
@@ -1213,7 +1213,7 @@ private native long iBarrier(long comm) throws MPIException;
  * @param count number of items in buffer
  * @param type  datatype of each item in buffer
  * @param root  rank of broadcast root
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void bcast(Object buf, int count, Datatype type, int root)
     throws MPIException
@@ -1244,7 +1244,7 @@ private native void bcast(
  * @param type  datatype of each item in buffer
  * @param root  rank of broadcast root
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iBcast(Buffer buf, int count, Datatype type, int root)
     throws MPIException
@@ -1270,7 +1270,7 @@ private native long iBcast(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void gather(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -1313,7 +1313,7 @@ public final void gather(
  * @param count number of items to send/receive
  * @param type  datatype of each item in buffer
  * @param root  rank of receiving process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void gather(Object buf, int count, Datatype type, int root)
     throws MPIException
@@ -1350,7 +1350,7 @@ private native void gather(
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iGather(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -1377,7 +1377,7 @@ public final Request iGather(
  * @param type  datatype of each item in buffer
  * @param root  rank of receiving process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iGather(Buffer buf, int count, Datatype type, int root)
     throws MPIException
@@ -1407,7 +1407,7 @@ private native long iGather(
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void gatherv(Object sendbuf, int sendcount, Datatype sendtype,
                           Object recvbuf, int[] recvcount, int[] displs,
@@ -1451,7 +1451,7 @@ public final void gatherv(Object sendbuf, int sendcount, Datatype sendtype,
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void gatherv(Object recvbuf, int[] recvcount, int[] displs,
                           Datatype recvtype, int root)
@@ -1481,7 +1481,7 @@ public final void gatherv(Object recvbuf, int[] recvcount, int[] displs,
  * @param sendcount number of items to send
  * @param sendtype  datatype of each item in send buffer
  * @param root      rank of receiving process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void gatherv(Object sendbuf, int sendcount,
                           Datatype sendtype, int root)
@@ -1522,7 +1522,7 @@ private native void gatherv(
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iGatherv(
         Buffer sendbuf, int sendcount, Datatype sendtype, Buffer recvbuf,
@@ -1551,7 +1551,7 @@ public final Request iGatherv(
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of receiving process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iGatherv(Buffer recvbuf, int[] recvcount, int[] displs,
                               Datatype recvtype, int root)
@@ -1576,7 +1576,7 @@ public final Request iGatherv(Buffer recvbuf, int[] recvcount, int[] displs,
  * @param sendtype  datatype of each item in send buffer
  * @param root      rank of receiving process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iGatherv(Buffer sendbuf, int sendcount,
                               Datatype sendtype, int root)
@@ -1606,7 +1606,7 @@ private native long iGatherv(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scatter(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -1649,7 +1649,7 @@ public final void scatter(
  * @param count number of items to send/receive
  * @param type  datatype of each item in buffer
  * @param root  rank of sending process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scatter(Object buf, int count, Datatype type, int root)
     throws MPIException
@@ -1685,7 +1685,7 @@ private native void scatter(
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScatter(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -1712,7 +1712,7 @@ public final Request iScatter(
  * @param type  datatype of each item in buffer
  * @param root  rank of sending process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScatter(Buffer buf, int count, Datatype type, int root)
     throws MPIException
@@ -1741,7 +1741,7 @@ private native long iScatter(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scatterv(
         Object sendbuf, int[] sendcount, int[] displs, Datatype sendtype,
@@ -1784,7 +1784,7 @@ public final void scatterv(
  * @param displs    displacements from which to take outgoing data
  * @param sendtype  datatype of each item in send buffer
  * @param root      rank of sending process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scatterv(Object sendbuf, int[] sendcount, int[] displs,
                            Datatype sendtype, int root)
@@ -1814,7 +1814,7 @@ public final void scatterv(Object sendbuf, int[] sendcount, int[] displs,
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scatterv(Object recvbuf, int recvcount,
                            Datatype recvtype, int root)
@@ -1854,7 +1854,7 @@ private native void scatterv(
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScatterv(
         Buffer sendbuf, int[] sendcount, int[] displs,  Datatype sendtype,
@@ -1882,7 +1882,7 @@ public final Request iScatterv(
  * @param sendtype  datatype of each item in send buffer
  * @param root      rank of sending process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScatterv(Buffer sendbuf, int[] sendcount, int[] displs,
                                Datatype sendtype, int root)
@@ -1906,7 +1906,7 @@ public final Request iScatterv(Buffer sendbuf, int[] sendcount, int[] displs,
  * @param recvtype  datatype of each item in receive buffer
  * @param root      rank of sending process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScatterv(Buffer recvbuf, int recvcount,
                                Datatype recvtype, int root)
@@ -1934,7 +1934,7 @@ private native long iScatterv(
  * @param recvbuf   receive buffer
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allGather(Object sendbuf, int sendcount, Datatype sendtype,
                             Object recvbuf, int recvcount, Datatype recvtype)
@@ -1973,7 +1973,7 @@ public final void allGather(Object sendbuf, int sendcount, Datatype sendtype,
  * @param buf   receive buffer
  * @param count number of items to receive
  * @param type  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allGather(Object buf, int count, Datatype type)
     throws MPIException
@@ -2008,7 +2008,7 @@ private native void allGather(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllGather(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -2032,7 +2032,7 @@ public final Request iAllGather(
  * @param count number of items to receive
  * @param type  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllGather(Buffer buf, int count, Datatype type)
     throws MPIException
@@ -2058,7 +2058,7 @@ private native long iAllGather(
  * @param recvcount number of elements received from each process
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allGatherv(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -2099,7 +2099,7 @@ public final void allGatherv(
  * @param recvcount number of elements received from each process
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allGatherv(Object recvbuf, int[] recvcount,
                              int[] displs, Datatype recvtype)
@@ -2137,7 +2137,7 @@ private native void allGatherv(
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllGatherv(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -2163,7 +2163,7 @@ public final Request iAllGatherv(
  * @param displs displacements at which to place incoming data
  * @param type   datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllGatherv(
         Buffer buf, int[] count, int[] displs, Datatype type)
@@ -2192,7 +2192,7 @@ private native long iAllGatherv(
  * @param recvbuf   receive buffer
  * @param recvcount number of items received from any process
  * @param recvtype  datatype of receive buffer items
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allToAll(Object sendbuf, int sendcount, Datatype sendtype,
                            Object recvbuf, int recvcount, Datatype recvtype)
@@ -2241,7 +2241,7 @@ private native void allToAll(
  * @param recvcount number of items received from any process
  * @param recvtype  datatype of receive buffer items
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllToAll(Buffer sendbuf, int sendcount, Datatype sendtype,
                                Buffer recvbuf, int recvcount, Datatype recvtype)
@@ -2273,7 +2273,7 @@ private native long iAllToAll(
  * @param recvcount number of elements received from each process
  * @param rdispls   displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allToAllv(
         Object sendbuf, int[] sendcount, int[] sdispls, Datatype sendtype,
@@ -2327,7 +2327,7 @@ private native void allToAllv(
  * @param rdispls   displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllToAllv(
         Buffer sendbuf, int[] sendcount, int[] sdispls, Datatype sendtype,
@@ -2357,7 +2357,7 @@ private native long iAllToAllv(long comm,
  * @param recvbuf   receive buffer
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final void neighborAllGather(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -2406,7 +2406,7 @@ private native void neighborAllGather(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iNeighborAllGather(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -2437,7 +2437,7 @@ private native long iNeighborAllGather(
  * @param recvcount number of elements that are received from each neighbor
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of receive buffer elements
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void neighborAllGatherv(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -2486,7 +2486,7 @@ private native void neighborAllGatherv(
  * @param displs    displacements at which to place incoming data
  * @param recvtype  datatype of receive buffer elements
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iNeighborAllGatherv(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -2516,7 +2516,7 @@ private native long iNeighborAllGatherv(
  * @param recvbuf   receive buffer
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void neighborAllToAll(
         Object sendbuf, int sendcount, Datatype sendtype,
@@ -2565,7 +2565,7 @@ private native void neighborAllToAll(
  * @param recvcount number of items to receive
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iNeighborAllToAll(
         Buffer sendbuf, int sendcount, Datatype sendtype,
@@ -2596,7 +2596,7 @@ private native long iNeighborAllToAll(
  * @param recvcount number of elements received from each process
  * @param rdispls   displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void neighborAllToAllv(
         Object sendbuf, int[] sendcount, int[] sdispls, Datatype sendtype,
@@ -2648,7 +2648,7 @@ private native void neighborAllToAllv(
  * @param rdispls   displacements at which to place incoming data
  * @param recvtype  datatype of each item in receive buffer
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iNeighborAllToAllv(
         Buffer sendbuf, int[] sendcount, int[] sdispls, Datatype sendtype,
@@ -2687,7 +2687,7 @@ private native long iNeighborAllToAllv(
  * @param type    data type of each item in send buffer
  * @param op      reduce operation
  * @param root    rank of root process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduce(Object sendbuf, Object recvbuf, int count,
                          Datatype type, Op op, int root)
@@ -2729,7 +2729,7 @@ public final void reduce(Object sendbuf, Object recvbuf, int count,
  * @param type  data type of each item in buffer
  * @param op    reduce operation
  * @param root  rank of root process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduce(Object buf, int count, Datatype type, Op op, int root)
     throws MPIException
@@ -2767,7 +2767,7 @@ private native void reduce(
  * @param op      reduce operation
  * @param root    rank of root process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduce(Buffer sendbuf, Buffer recvbuf,
                              int count, Datatype type, Op op, int root)
@@ -2796,7 +2796,7 @@ public final Request iReduce(Buffer sendbuf, Buffer recvbuf,
  * @param op    reduce operation
  * @param root  rank of root process
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduce(Buffer buf, int count,
                              Datatype type, Op op, int root)
@@ -2826,7 +2826,7 @@ private native long iReduce(
  * @param count   number of items in send buffer
  * @param type    data type of each item in send buffer
  * @param op      reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allReduce(Object sendbuf, Object recvbuf,
                             int count, Datatype type, Op op)
@@ -2866,7 +2866,7 @@ public final void allReduce(Object sendbuf, Object recvbuf,
  * @param count number of items in send buffer
  * @param type  data type of each item in send buffer
  * @param op    reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void allReduce(Object buf, int count, Datatype type, Op op)
     throws MPIException
@@ -2901,7 +2901,7 @@ private native void allReduce(
  * @param type    data type of each item in send buffer
  * @param op      reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllReduce(Buffer sendbuf, Buffer recvbuf,
                                 int count, Datatype type, Op op)
@@ -2927,7 +2927,7 @@ public final Request iAllReduce(Buffer sendbuf, Buffer recvbuf,
  * @param type  data type of each item in send buffer
  * @param op    reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iAllReduce(Buffer buf, int count, Datatype type, Op op)
     throws MPIException
@@ -2956,7 +2956,7 @@ private native long iAllReduce(
  * @param recvcounts numbers of result elements distributed to each process
  * @param type       data type of each item in send buffer
  * @param op         reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduceScatter(Object sendbuf, Object recvbuf,
                                 int[] recvcounts, Datatype type, Op op)
@@ -2997,7 +2997,7 @@ public final void reduceScatter(Object sendbuf, Object recvbuf,
  * @param counts numbers of result elements distributed to each process
  * @param type   data type of each item in send buffer
  * @param op     reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduceScatter(Object buf, int[] counts, Datatype type, Op op)
     throws MPIException
@@ -3033,7 +3033,7 @@ private native void reduceScatter(
  * @param type       data type of each item in send buffer
  * @param op         reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduceScatter(Buffer sendbuf, Buffer recvbuf,
                                     int[] recvcounts, Datatype type, Op op)
@@ -3061,7 +3061,7 @@ public final Request iReduceScatter(Buffer sendbuf, Buffer recvbuf,
  * @param type   data type of each item in send buffer
  * @param op     reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduceScatter(
         Buffer buf, int[] counts, Datatype type, Op op)
@@ -3089,7 +3089,7 @@ private native long iReduceScatter(
  * @param recvcount element count per block
  * @param type      data type of each item in send buffer
  * @param op        reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduceScatterBlock(Object sendbuf, Object recvbuf,
                                      int recvcount, Datatype type, Op op)
@@ -3128,7 +3128,7 @@ public final void reduceScatterBlock(Object sendbuf, Object recvbuf,
  * @param count element count per block
  * @param type  data type of each item in send buffer
  * @param op    reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void reduceScatterBlock(
         Object buf, int count, Datatype type, Op op)
@@ -3163,7 +3163,7 @@ private native void reduceScatterBlock(
  * @param type      data type of each item in send buffer
  * @param op        reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduceScatterBlock(
         Buffer sendbuf, Buffer recvbuf, int recvcount, Datatype type, Op op)
@@ -3189,7 +3189,7 @@ public final Request iReduceScatterBlock(
  * @param type  data type of each item in send buffer
  * @param op    reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iReduceScatterBlock(
         Buffer buf, int count, Datatype type, Op op)
@@ -3219,7 +3219,7 @@ private native long iReduceScatterBlock(
  * @param count    number of elements
  * @param type     data type of each item
  * @param op       reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void reduceLocal(
         Object inBuf, Object inOutBuf, int count, Datatype type, Op op)
@@ -3271,7 +3271,7 @@ private static native void reduceLocalUf(
 /**
  * Sets the print name for the communicator.
  * @param name name for the communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void setName(String name) throws MPIException
 {
@@ -3284,7 +3284,7 @@ private native void setName(long handle, String name) throws MPIException;
 /**
  * Return the print name from the communicator.
  * @return name of the communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final String getName() throws MPIException
 {

--- a/ompi/mpi/java/java/Datatype.java
+++ b/ompi/mpi/java/java/Datatype.java
@@ -137,7 +137,7 @@ private Datatype(int baseType, int baseSize, long handle)
  * Returns the lower bound of a datatype.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_GET_EXTENT}.
  * @return lower bound of datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getLb() throws MPIException
 {
@@ -151,7 +151,7 @@ public int getLb() throws MPIException
  * Returns the extent of a datatype.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_GET_EXTENT}.
  * @return datatype extent
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getExtent() throws MPIException
 {
@@ -176,7 +176,7 @@ private native void getLbExtent(long handle, int[] lbExt);
  * Returns the true lower bound of a datatype.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_GET_TRUE_EXTENT}.
  * @return lower bound of datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getTrueLb() throws MPIException
 {
@@ -190,7 +190,7 @@ public int getTrueLb() throws MPIException
  * Returns the true extent of a datatype.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_GET_TRUE_EXTENT}.
  * @return datatype true extent
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getTrueExtent() throws MPIException
 {
@@ -216,7 +216,7 @@ private native void getTrueLbExtent(long handle, int[] lbExt);
  * elements it represents.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_SIZE}.
  * @return datatype size
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getSize() throws MPIException
 {
@@ -229,7 +229,7 @@ private native int getSize(long type);
 /**
  * Commits a derived datatype.
  * Java binding of the MPI operation {@code MPI_TYPE_COMMIT}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void commit() throws MPIException
 {
@@ -242,7 +242,7 @@ private native void commit(long type);
 /**
  * Frees the datatype.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_FREE}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public void free() throws MPIException
 {
@@ -282,7 +282,7 @@ public boolean isNull()
 /**
  * Java binding of {@code MPI_TYPE_DUP}.
  * @return new datatype
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Datatype dup() throws MPIException
 {
@@ -301,7 +301,7 @@ private native long dup(long type) throws MPIException;
  * @param count   replication count
  * @param oldType old datatype
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createContiguous(int count, Datatype oldType)
         throws MPIException
@@ -323,7 +323,7 @@ private static native long getContiguous(int count, long oldType);
  * @param stride      number of elements between start of each block
  * @param oldType     old datatype
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createVector(int count, int blockLength,
                                     int stride, Datatype oldType)
@@ -348,7 +348,7 @@ private static native long getVector(
  * @param stride      number of bytes between start of each block
  * @param oldType     old datatype
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createHVector(int count, int blockLength,
                                      int stride, Datatype oldType)
@@ -376,7 +376,7 @@ private static native long getHVector(
  * @param displacements displacement of each block in units of old type
  * @param oldType       old datatype
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createIndexed(int[] blockLengths,
                                      int[] displacements, Datatype oldType)
@@ -400,7 +400,7 @@ private static native long getIndexed(
  * @param displacements byte displacement in buffer for each block
  * @param oldType       old datatype
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createHIndexed(int[] blockLengths,
                                       int[] displacements, Datatype oldType)
@@ -425,7 +425,7 @@ private static native long getHIndexed(
  * @param displacements byte displacement of each block
  * @param types         type of elements in each block
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createStruct(int[] blockLengths,
                                     int[] displacements, Datatype[] types)
@@ -452,7 +452,7 @@ private static native long getStruct(
  * @param lb      new lower bound of datatype (address integer)
  * @param extent  new extent of datatype (address integer)
  * @return new datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Datatype createResized(Datatype oldType, int lb, int extent)
         throws MPIException
@@ -467,7 +467,7 @@ private static native long getResized(long oldType, int lb, int extent);
 /**
  * Sets the print name for the datatype.
  * @param name name for the datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void setName(String name) throws MPIException
 {
@@ -480,7 +480,7 @@ private native void setName(long handle, String name) throws MPIException;
 /**
  * Return the print name from the datatype.
  * @return name of the datatype
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public String getName() throws MPIException
 {
@@ -494,7 +494,7 @@ private native String getName(long handle) throws MPIException;
  * Create a new attribute key.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_CREATE_KEYVAL}.
  * @return attribute key for future access
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static int createKeyval() throws MPIException
 {
@@ -508,7 +508,7 @@ private static native int createKeyval_jni() throws MPIException;
  * Frees an attribute key.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_FREE_KEYVAL}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void freeKeyval(int keyval) throws MPIException
 {
@@ -523,7 +523,7 @@ private static native void freeKeyval_jni(int keyval) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_TYPE_SET_ATTR}.
  * @param keyval attribute key
  * @param value  attribute value
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void setAttr(int keyval, Object value) throws MPIException
 {
@@ -539,7 +539,7 @@ private native void setAttr(long type, int keyval, byte[] value)
  * <p>Java binding of the MPI operation {@code MPI_TYPE_GET_ATTR}.
  * @param keyval attribute key
  * @return attribute value or null if no attribute is associated with the key.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Object getAttr(int keyval) throws MPIException
 {
@@ -554,7 +554,7 @@ private native Object getAttr(long type, int keyval) throws MPIException;
  * Deletes an attribute value associated with a key.
  * <p>Java binding of the MPI operation {@code MPI_TYPE_DELETE_ATTR}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void deleteAttr(int keyval) throws MPIException
 {

--- a/ompi/mpi/java/java/DoubleInt.java
+++ b/ompi/mpi/java/java/DoubleInt.java
@@ -27,6 +27,8 @@ private final int iOff, iSize;
 
 /**
  * The struct object will be created only in MPI class.
+ * @param intOff        int offset
+ * @param intSize       int size
  * @see MPI#doubleInt
  */
 protected DoubleInt(int intOff, int intSize)

--- a/ompi/mpi/java/java/File.java
+++ b/ompi/mpi/java/java/File.java
@@ -45,7 +45,7 @@ private Status beginStatus;
  * @param comm     communicator
  * @param filename name of the file to open
  * @param amode    file access mode
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public File(Comm comm, String filename, int amode) throws MPIException
 {
@@ -59,7 +59,7 @@ public File(Comm comm, String filename, int amode) throws MPIException
  * @param filename name of the file to open
  * @param amode    file access mode
  * @param info     info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public File(Comm comm, String filename, int amode, Info info)
     throws MPIException
@@ -73,7 +73,7 @@ private native long open(long comm, String filename, int amode, long info)
 
 /**
  * Java binding of {@code MPI_FILE_CLOSE}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void close() throws MPIException
 {
@@ -86,7 +86,7 @@ private native long close(long fh) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_DELETE} using {@code MPI_INFO_NULL}.
  * @param filename name of the file to delete
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static void delete(String filename) throws MPIException
 {
@@ -98,7 +98,7 @@ public static void delete(String filename) throws MPIException
  * Java binding of {@code MPI_FILE_DELETE}.
  * @param filename name of the file to delete
  * @param info     info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static void delete(String filename, Info info) throws MPIException
 {
@@ -112,7 +112,7 @@ private static native void delete(String filename, long info)
 /**
  * Java binding of {@code MPI_FILE_SET_SIZE}.
  * @param size size to truncate or expand file
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void setSize(long size) throws MPIException
 {
@@ -125,7 +125,7 @@ private native void setSize(long fh, long size) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_PREALLOCATE}.
  * @param size size to preallocate file
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void preallocate(long size) throws MPIException
 {
@@ -138,7 +138,7 @@ private native void preallocate(long fh, long size) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_GET_SIZE}.
  * @return size of file in bytes
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public long getSize() throws MPIException
 {
@@ -151,7 +151,7 @@ private native long getSize(long fh) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_GET_GROUP}.
  * @return group wich opened the file
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group getGroup() throws MPIException
 {
@@ -164,7 +164,7 @@ private native long getGroup(long fh) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_GET_AMODE}.
  * @return file access mode to open the file
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int getAMode() throws MPIException
 {
@@ -177,7 +177,7 @@ private native int getAMode(long fh) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_SET_INFO}.
  * @param info info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void setInfo(Info info) throws MPIException
 {
@@ -190,7 +190,7 @@ private native void setInfo(long fh, long info) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_GET_INFO}.
  * @return new info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Info getInfo() throws MPIException
 {
@@ -206,7 +206,7 @@ private native long getInfo(long fh) throws MPIException;
  * @param etype    elementary datatype
  * @param filetype filetype
  * @param datarep  data representation
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void setView(long disp, Datatype etype,
                     Datatype filetype, String datarep)
@@ -224,7 +224,7 @@ public void setView(long disp, Datatype etype,
  * @param filetype filetype
  * @param datarep  data representation
  * @param info     info object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void setView(long disp, Datatype etype,
                     Datatype filetype, String datarep, Info info)
@@ -255,7 +255,7 @@ public FileView getView()
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readAt(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -288,7 +288,7 @@ private native void readAt(
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readAtAll(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -321,7 +321,7 @@ private native void readAtAll(
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeAt(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -354,7 +354,7 @@ private native void writeAt(
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeAtAll(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -387,7 +387,7 @@ private native void writeAtAll(
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iReadAt(long offset, Buffer buf, int count, Datatype type)
     throws MPIException
@@ -410,7 +410,7 @@ private native long iReadAt(
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iWriteAt(long offset, Buffer buf, int count, Datatype type)
     throws MPIException
@@ -432,7 +432,7 @@ private native long iWriteAt(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status read(Object buf, int count, Datatype type) throws MPIException
 {
@@ -461,7 +461,7 @@ private native void read(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readAll(Object buf, int count, Datatype type) throws MPIException
 {
@@ -490,7 +490,7 @@ private native void readAll(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status write(Object buf, int count, Datatype type) throws MPIException
 {
@@ -519,7 +519,7 @@ private native void write(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeAll(Object buf, int count, Datatype type) throws MPIException
 {
@@ -548,7 +548,7 @@ private native void writeAll(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iRead(Buffer buf, int count, Datatype type) throws MPIException
 {
@@ -568,7 +568,7 @@ private native long iRead(long fh, Buffer buf, int count, long type)
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iWrite(Buffer buf, int count, Datatype type) throws MPIException
 {
@@ -586,7 +586,7 @@ private native long iWrite(long fh, Buffer buf, int count, long type)
  * Java binding of {@code MPI_FILE_SEEK}.
  * @param offset file offset
  * @param whence update mode
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void seek(long offset, int whence) throws MPIException
 {
@@ -599,7 +599,7 @@ private native void seek(long fh, long offset, int whence) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_GET_POSITION}.
  * @return offset of individual pointer
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public long getPosition() throws MPIException
 {
@@ -613,7 +613,7 @@ private native long getPosition(long fh) throws MPIException;
  * Java binding of {@code MPI_FILE_GET_BYTE_OFFSET}.
  * @param offset offset
  * @return absolute byte position of offset
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public long getByteOffset(long offset) throws MPIException
 {
@@ -629,7 +629,7 @@ private native long getByteOffset(long fh, long offset) throws MPIException;
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readShared(Object buf, int count, Datatype type)
     throws MPIException
@@ -661,7 +661,7 @@ private native void readShared(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeShared(Object buf, int count, Datatype type)
     throws MPIException
@@ -693,7 +693,7 @@ private native void writeShared(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iReadShared(Buffer buf, int count, Datatype type)
     throws MPIException
@@ -714,7 +714,7 @@ private native long iReadShared(long fh, Buffer buf, int count, long type)
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request iWriteShared(Buffer buf, int count, Datatype type)
     throws MPIException
@@ -735,7 +735,7 @@ private native long iWriteShared(long fh, Buffer buf, int count, long type)
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readOrdered(Object buf, int count, Datatype type)
     throws MPIException
@@ -767,7 +767,7 @@ private native void readOrdered(
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeOrdered(Object buf, int count, Datatype type)
     throws MPIException
@@ -797,7 +797,7 @@ private native void writeOrdered(
  * Java binding of {@code MPI_FILE_SEEK_SHARED}.
  * @param offset file offset
  * @param whence update mode
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void seekShared(long offset, int whence) throws MPIException
 {
@@ -811,7 +811,7 @@ private native void seekShared(long fh, long offset, int whence)
 /**
  * Java binding of {@code MPI_FILE_GET_POSITION_SHARED}.
  * @return offset of individual pointer
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public long getPositionShared() throws MPIException
 {
@@ -827,7 +827,7 @@ private native long getPositionShared(long fh) throws MPIException;
  * @param buf    buffer
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void readAtAllBegin(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -864,7 +864,7 @@ private native void readAtAllBegin(
  * Java binding of {@code MPI_FILE_READ_AT_ALL_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readAtAllEnd(Object buf) throws MPIException
 {
@@ -891,7 +891,7 @@ private native void readAtAllEnd(long fh, Object buf, long[] stat)
  * @param buf    buffer
  * @param count  number of items in buffer
  * @param type   datatype of each buffer element
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void writeAtAllBegin(long offset, Object buf, int count, Datatype type)
     throws MPIException
@@ -928,7 +928,7 @@ private native void writeAtAllBegin(
  * Java binding of {@code MPI_FILE_WRITE_AT_ALL_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeAtAllEnd(Object buf) throws MPIException
 {
@@ -954,7 +954,7 @@ private native void writeAtAllEnd(long fh, Object buf, long[] stat)
  * @param buf   buffer
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void readAllBegin(Object buf, int count, Datatype type)
     throws MPIException
@@ -990,7 +990,7 @@ private native void readAllBegin(long fh, Object buf, int count, long type)
  * Java binding of {@code MPI_FILE_READ_ALL_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readAllEnd(Object buf) throws MPIException
 {
@@ -1016,7 +1016,7 @@ private native void readAllEnd(long fh, Object buf, long[] stat)
  * @param buf   buffer
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void writeAllBegin(Object buf, int count, Datatype type)
     throws MPIException
@@ -1052,7 +1052,7 @@ private native void writeAllBegin(long fh, Object buf, int count, long type)
  * Java binding of {@code MPI_FILE_WRITE_ALL_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeAllEnd(Object buf) throws MPIException
 {
@@ -1078,7 +1078,7 @@ private native void writeAllEnd(long fh, Object buf, long[] stat)
  * @param buf   buffer
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void readOrderedBegin(Object buf, int count, Datatype type)
     throws MPIException
@@ -1114,7 +1114,7 @@ private native void readOrderedBegin(long fh, Object buf, int count, long type)
  * Java binding of {@code MPI_FILE_READ_ORDERED_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status readOrderedEnd(Object buf) throws MPIException
 {
@@ -1140,7 +1140,7 @@ private native void readOrderedEnd(long fh, Object buf, long[] stat)
  * @param buf   buffer
  * @param count number of items in buffer
  * @param type  datatype of each buffer element
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void writeOrderedBegin(Object buf, int count, Datatype type)
     throws MPIException
@@ -1176,7 +1176,7 @@ private native void writeOrderedBegin(long fh, Object buf, int count, long type)
  * Java binding of {@code MPI_FILE_WRITE_ORDERED_END}.
  * @param buf buffer
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status writeOrderedEnd(Object buf) throws MPIException
 {
@@ -1206,9 +1206,9 @@ private Status getBeginStatus()
 
 /**
  * Java binding of {@code MPI_FILE_GET_TYPE_EXTENT}.
- * @param type
+ * @param type	type of data
  * @return datatype extent
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int getTypeExtent(Datatype type) throws MPIException
 {
@@ -1221,7 +1221,7 @@ private native int getTypeExtent(long fh, long type) throws MPIException;
 /**
  * Java binding of {@code MPI_FILE_SET_ATOMICITY}.
  * @param atomicity true to set atomic mode, false to set nonatomic mode
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void setAtomicity(boolean atomicity) throws MPIException
 {
@@ -1234,7 +1234,7 @@ private native void setAtomicity(long fh, boolean atomicity)
 
 /**
  * Java binding of {@code MPI_FILE_SYNC}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void sync() throws MPIException
 {

--- a/ompi/mpi/java/java/FloatInt.java
+++ b/ompi/mpi/java/java/FloatInt.java
@@ -27,6 +27,8 @@ private final int iOff, iSize;
 
 /**
  * The struct object will be created only in MPI class.
+ * @param intOff	int offset
+ * @param intSize	int size
  * @see MPI#floatInt
  */
 protected FloatInt(int intOff, int intSize)

--- a/ompi/mpi/java/java/Freeable.java
+++ b/ompi/mpi/java/java/Freeable.java
@@ -50,7 +50,7 @@ public interface Freeable
 {
     /**
      * Frees a freeable object.
-     * @throws MPIException 
+     * @throws MPIException Signals that an MPI exception of some sort has occurred. 
      */
     void free() throws MPIException;
 }

--- a/ompi/mpi/java/java/GraphComm.java
+++ b/ompi/mpi/java/java/GraphComm.java
@@ -90,7 +90,7 @@ protected GraphComm(long[] commRequest)
  * Duplicates this communicator.
  * <p>Java binding of {@code MPI_COMM_DUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public GraphComm dup() throws MPIException
 {
@@ -104,7 +104,7 @@ protected GraphComm(long[] commRequest)
  * The request object must be obtained calling {@link #getRequest}.
  * <p>Java binding of {@code MPI_COMM_IDUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public GraphComm iDup() throws MPIException
 {
@@ -120,7 +120,7 @@ protected GraphComm(long[] commRequest)
  * from the sizes of the {@code index} and {@code edges} fields
  * of the returned object.
  * @return object defining node degress and edges of graph
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public GraphParms getDims() throws MPIException
 {
@@ -137,7 +137,7 @@ private native GraphParms getDims(long comm) throws MPIException;
  * <p>The number of neighbors can be extracted from the size of the result.
  * @param rank rank of a process in the group of this communicator
  * @return array of ranks of neighbouring processes to one specified
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int[] getNeighbors(int rank) throws MPIException
 {
@@ -150,7 +150,7 @@ private native int[] getNeighbors(long comm, int rank) throws MPIException;
 /**
  * Gets the adjacency information for a distributed graph topology.
  * @return adjacency information for a distributed graph topology
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public DistGraphNeighbors getDistGraphNeighbors() throws MPIException
 {
@@ -168,7 +168,7 @@ private native DistGraphNeighbors getDistGraphNeighbors(long comm)
  * @param index node degrees
  * @param edges graph edges
  * @return reordered rank of calling process
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int map(int[] index, int[] edges) throws MPIException
 {

--- a/ompi/mpi/java/java/Group.java
+++ b/ompi/mpi/java/java/Group.java
@@ -70,7 +70,7 @@ protected Group(long handle)
 /**
  * Java binding of the MPI operation {@code MPI_GROUP_SIZE}.
  * @return number of processes in the group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int getSize() throws MPIException
 {
@@ -85,7 +85,7 @@ private native int getSize(long group) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_GROUP_RANK}.
  * @return rank of this process in the group, or {@code MPI.UNDEFINED}
  *         if this process is not a member of the group.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getRank() throws MPIException
 {
@@ -123,7 +123,7 @@ public boolean isNull()
  * @param ranks1 array of valid ranks in group1
  * @param group2 another group
  * @return array of corresponding ranks in group2
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int[] translateRanks(Group group1, int[] ranks1, Group group2)
     throws MPIException
@@ -143,7 +143,7 @@ private static native int[] translateRanks(
  * @return {@code MPI.IDENT} if the group members and group order are exactly
  *         the same in both groups, {@code MPI.SIMILAR} if the group members are
  *         the same but the order is different, {@code MPI.UNEQUAL} otherwise.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int compare(Group group1, Group group2) throws MPIException
 {
@@ -159,7 +159,7 @@ private static native int compare(long group1, long group2) throws MPIException;
  * @param group1 first group
  * @param group2 second group
  * @return union group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Group union(Group group1, Group group2) throws MPIException
 {
@@ -175,7 +175,7 @@ private static native long union(long group1, long group2);
  * @param group1 first group
  * @param group2 second group
  * @return intersection group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Group intersection(Group group1, Group group2) throws MPIException
 {
@@ -191,7 +191,7 @@ private static native long intersection(long group1, long group2);
  * @param group1 first group
  * @param group2 second group
  * @return difference group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Group difference(Group group1, Group group2) throws MPIException
 {
@@ -206,7 +206,7 @@ private static native long difference(long group1, long group2);
  * <p>Java binding of the MPI operation {@code MPI_GROUP_INCL}.
  * @param ranks ranks from this group to appear in new group
  * @return new group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group incl(int[] ranks) throws MPIException
 {
@@ -221,7 +221,7 @@ private native long incl(long group, int[] ranks);
  * <p>Java binding of the MPI operation {@code MPI_GROUP_EXCL}.
  * @param ranks ranks from this group <em>not</em> to appear in new group
  * @return new group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group excl(int[] ranks) throws MPIException
 {
@@ -241,7 +241,7 @@ private native long excl(long group, int[] ranks);
  * of triplets.  The size of the second dimension is 3.
  * @param ranges array of integer triplets
  * @return new group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group rangeIncl(int[][] ranges) throws MPIException
 {
@@ -259,7 +259,7 @@ private native long rangeIncl(long group, int[][] ranges);
  * indicating ranks in this group to be excluded from the new group.
  * @param ranges array of integer triplets
  * @return new group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group rangeExcl(int[][] ranges) throws MPIException
 {

--- a/ompi/mpi/java/java/Info.java
+++ b/ompi/mpi/java/java/Info.java
@@ -28,6 +28,7 @@ protected static final long NULL = getNull();
 
 /**
  * Java binding of the MPI operation {@code MPI_INFO_CREATE}.
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Info() throws MPIException
 {
@@ -54,7 +55,7 @@ private native static long getNull();
  * Java binding of the MPI operation {@code MPI_INFO_SET}.
  * @param key   key
  * @param value value
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void set(String key, String value) throws MPIException
 {
@@ -69,7 +70,7 @@ private native void set(long handle, String key, String value)
  * Java binding of the MPI operation {@code MPI_INFO_SET}.
  * @param key key
  * @return value or {@code null} if key is not defined
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public String get(String key) throws MPIException
 {
@@ -82,7 +83,7 @@ private native String get(long handle, String key) throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_INFO_SET}.
  * @param key key
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void delete(String key) throws MPIException
 {
@@ -95,7 +96,7 @@ private native void delete(long handle, String key) throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_INFO_GET_NKEYS}.
  * @return number of defined keys
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int size() throws MPIException
 {
@@ -109,7 +110,7 @@ private native int size(long handle) throws MPIException;
  * Java binding of the MPI operation {@code MPI_INFO_GET_NTHKEY}.
  * @param i key number
  * @return key
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public String getKey(int i) throws MPIException
 {
@@ -140,7 +141,7 @@ private native String getKey(long handle, int i) throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_INFO_DUP}.
  * @return info object
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Info dup() throws MPIException
 {
@@ -152,7 +153,7 @@ private native long dup(long handle) throws MPIException;
 
 /**
  * Java binding of the MPI operation {@code MPI_INFO_FREE}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 @Override public void free() throws MPIException
 {

--- a/ompi/mpi/java/java/Int2.java
+++ b/ompi/mpi/java/java/Int2.java
@@ -27,6 +27,8 @@ private final int iOff, iSize;
 
 /**
  * The struct object will be created only in MPI class.
+ * @param intOff	int offset
+ * @param intSize	int size
  * @see MPI#int2
  */
 protected Int2(int intOff, int intSize)

--- a/ompi/mpi/java/java/Intercomm.java
+++ b/ompi/mpi/java/java/Intercomm.java
@@ -83,7 +83,7 @@ protected Intercomm(long[] commRequest)
  * Duplicates this communicator.
  * <p>Java binding of {@code MPI_COMM_DUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public Intercomm dup() throws MPIException
 {
@@ -97,7 +97,7 @@ protected Intercomm(long[] commRequest)
  * <p>The new communicator can't be used before the operation completes.
  * The request object must be obtained calling {@link #getRequest}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public Intercomm iDup() throws MPIException
 {
@@ -111,7 +111,7 @@ protected Intercomm(long[] commRequest)
  * Size of remote group.
  * <p>Java binding of the MPI operation {@code MPI_COMM_REMOTE_SIZE}.
  * @return number of process in remote group of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public int getRemoteSize() throws MPIException
 {
@@ -125,7 +125,7 @@ private native int getRemoteSize_jni() throws MPIException;
  * Return the remote group.
  * <p>Java binding of the MPI operation {@code MPI_COMM_REMOTE_GROUP}.
  * @return remote group of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Group getRemoteGroup() throws MPIException
 {
@@ -140,7 +140,7 @@ private native long getRemoteGroup_jni();
  * <p>Java binding of the MPI operation {@code MPI_INTERCOMM_MERGE}.
  * @param high true if the local group has higher ranks in combined group
  * @return new intra-communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Intracomm merge(boolean high) throws MPIException
 {
@@ -153,7 +153,7 @@ private native long merge_jni(boolean high);
 /**
  * Java binding of {@code MPI_COMM_GET_PARENT}.
  * @return the parent communicator
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Intercomm getParent() throws MPIException
 {

--- a/ompi/mpi/java/java/Intracomm.java
+++ b/ompi/mpi/java/java/Intracomm.java
@@ -100,7 +100,7 @@ protected Intracomm(long[] commRequest)
  * Duplicates this communicator.
  * <p>Java binding of {@code MPI_COMM_DUP}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public Intracomm dup() throws MPIException
 {
@@ -114,7 +114,7 @@ protected Intracomm(long[] commRequest)
  * <p>The new communicator can't be used before the operation completes.
  * The request object must be obtained calling {@link #getRequest}.
  * @return copy of this communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public Intracomm iDup() throws MPIException
 {
@@ -129,7 +129,7 @@ protected Intracomm(long[] commRequest)
  * @param colour control of subset assignment
  * @param key    control of rank assignment
  * @return new communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intracomm split(int colour, int key) throws MPIException
 {
@@ -144,7 +144,7 @@ private native long split(long comm, int colour, int key) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_COMM_CREATE}.
  * @param group group which is a subset of the group of this communicator
  * @return new communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intracomm create(Group group) throws MPIException
 {
@@ -171,7 +171,7 @@ private native long create(long comm, long group);
  * @param reorder {@code true}  if ranking may be reordered,
  *                {@code false} if not
  * @return new cartesian topology communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final CartComm createCart(int[] dims, boolean[] periods, boolean reorder)
     throws MPIException
@@ -194,7 +194,7 @@ private native long createCart(
  * @param reorder {@code true} if ranking may be reordered,
  *                {@code false} if not
  * @return new graph topology communicator
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final GraphComm createGraph(int[] index, int[] edges, boolean reorder)
     throws MPIException
@@ -219,7 +219,7 @@ private native long createGraph(
  * @param info         hints on optimization and interpretation of weights
  * @param reorder      the process may be reordered (true) or not (false)
  * @return communicator with distributed graph topology
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final GraphComm createDistGraph(
         int[] sources, int[] degrees, int[] destinations,
@@ -245,7 +245,7 @@ public final GraphComm createDistGraph(
  * @param info         hints on optimization and interpretation of weights
  * @param reorder      the process may be reordered (true) or not (false)
  * @return communicator with distributed graph topology
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final GraphComm createDistGraph(
         int[] sources, int[] degrees, int[] destinations,
@@ -280,7 +280,7 @@ private native long createDistGraph(
  * @param info          hints on optimization and interpretation of weights
  * @param reorder       the process may be reordered (true) or not (false)
  * @return communicator with distributed graph topology
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final GraphComm createDistGraphAdjacent(
         int[] sources, int[] sourceWeights,
@@ -308,7 +308,7 @@ public final GraphComm createDistGraphAdjacent(
  * @param info         hints on optimization and interpretation of weights
  * @param reorder      the process may be reordered (true) or not (false)
  * @return communicator with distributed graph topology
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final GraphComm createDistGraphAdjacent(
         int[] sources, int[] destinations, Info info, boolean reorder)
@@ -335,7 +335,7 @@ private native long createDistGraphAdjacent(
  * @param count   number of items in input buffer
  * @param type    data type of each item in input buffer
  * @param op      reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scan(Object sendbuf, Object recvbuf,
                        int count, Datatype type, Op op)
@@ -375,7 +375,7 @@ public final void scan(Object sendbuf, Object recvbuf,
  * @param count   number of items in input buffer
  * @param type    data type of each item in input buffer
  * @param op      reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void scan(Object recvbuf, int count, Datatype type, Op op)
     throws MPIException
@@ -410,7 +410,7 @@ private native void scan(
  * @param type    data type of each item in input buffer
  * @param op      reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScan(Buffer sendbuf, Buffer recvbuf,
                            int count, Datatype type, Op op)
@@ -435,7 +435,7 @@ public final Request iScan(Buffer sendbuf, Buffer recvbuf,
  * @param type  data type of each item in buffer
  * @param op    reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iScan(Buffer buf, int count, Datatype type, Op op)
     throws MPIException
@@ -462,7 +462,7 @@ private native long iScan(
  * @param count   number of items in input buffer
  * @param type    data type of each item in input buffer
  * @param op      reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void exScan(Object sendbuf, Object recvbuf,
                          int count, Datatype type, Op op)
@@ -502,7 +502,7 @@ public final void exScan(Object sendbuf, Object recvbuf,
  * @param count number of items in input buffer
  * @param type  data type of each item in input buffer
  * @param op    reduce operation
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final void exScan(Object buf, int count, Datatype type, Op op)
     throws MPIException
@@ -537,7 +537,7 @@ private native void exScan(
  * @param type    data type of each item in input buffer
  * @param op      reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iExScan(Buffer sendbuf, Buffer recvbuf,
                              int count, Datatype type, Op op)
@@ -562,7 +562,7 @@ public final Request iExScan(Buffer sendbuf, Buffer recvbuf,
  * @param type  data type of each item in input buffer
  * @param op    reduce operation
  * @return communication request
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Request iExScan(Buffer buf, int count, Datatype type, Op op)
     throws MPIException
@@ -584,7 +584,7 @@ private native long iExScan(
 /**
  * Java binding of {@code MPI_OPEN_PORT} using {@code MPI_INFO_NULL}.
  * @return port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static String openPort() throws MPIException
 {
@@ -596,7 +596,7 @@ public static String openPort() throws MPIException
  * Java binding of {@code MPI_OPEN_PORT}.
  * @param info implementation-specific information
  * @return port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static String openPort(Info info) throws MPIException
 {
@@ -609,7 +609,7 @@ private native static String openPort(long info) throws MPIException;
 /**
  * Java binding of {@code MPI_CLOSE_PORT}.
  * @param name port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void closePort(String name) throws MPIException
 {
@@ -624,6 +624,7 @@ private native static void closePort_jni(String name) throws MPIException;
  * @param port port name
  * @param root rank in comm of root node
  * @return intercommunicator with client as remote group
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intercomm accept(String port, int root) throws MPIException
 {
@@ -637,7 +638,7 @@ public final Intercomm accept(String port, int root) throws MPIException
  * @param info implementation-specific information
  * @param root rank in comm of root node
  * @return intercommunicator with client as remote group
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intercomm accept(String port, Info info, int root)
     throws MPIException
@@ -654,7 +655,7 @@ private native long accept(long comm, String port, long info, int root)
  * @param port port name
  * @param root rank in comm of root node
  * @return intercommunicator with server as remote group
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intercomm connect(String port, int root) throws MPIException
 {
@@ -668,7 +669,7 @@ public final Intercomm connect(String port, int root) throws MPIException
  * @param info implementation-specific information
  * @param root rank in comm of root node
  * @return intercommunicator with server as remote group
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final Intercomm connect(String port, Info info, int root)
     throws MPIException
@@ -684,7 +685,7 @@ private native long connect(long comm, String port, long info, int root)
  * Java binding of {@code MPI_PUBLISH_NAME} using {@code MPI_INFO_NULL}.
  * @param service service name
  * @param port    port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void publishName(String service, String port)
     throws MPIException
@@ -698,7 +699,7 @@ public static void publishName(String service, String port)
  * @param service service name
  * @param info    implementation-specific information
  * @param port    port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void publishName(String service, Info info, String port)
     throws MPIException
@@ -714,7 +715,7 @@ private native static void publishName(String service, long info, String port)
  * Java binding of {@code MPI_UNPUBLISH_NAME} using {@code MPI_INFO_NULL}.
  * @param service service name
  * @param port    port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void unpublishName(String service, String port)
     throws MPIException
@@ -728,7 +729,7 @@ public static void unpublishName(String service, String port)
  * @param service service name
  * @param info    implementation-specific information
  * @param port    port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void unpublishName(String service, Info info, String port)
     throws MPIException
@@ -744,7 +745,7 @@ private native static void unpublishName(String service, long info, String port)
  * Java binding of {@code MPI_LOOKUP_NAME} using {@code MPI_INFO_NULL}.
  * @param service service name
  * @return port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static String lookupName(String service) throws MPIException
 {
@@ -757,7 +758,7 @@ public static String lookupName(String service) throws MPIException
  * @param service service name
  * @param info    mplementation-specific information
  * @return port name
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static String lookupName(String service, Info info) throws MPIException
 {
@@ -781,7 +782,7 @@ private native static String lookupName(String service, long info)
  * @param errcodes one code per process; if this parameter is null,
  *                 {@code MPI_ERRCODES_IGNORE} will be used.
  * @return intercommunicator between original group and the newly spawned group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Intercomm spawn(String command, String[] argv, int maxprocs,
                              Info info, int root, int[] errcodes)
@@ -810,7 +811,7 @@ private native long spawn(long comm, String command, String[] argv,
  * @param errcodes one code per process; if this parameter is null,
  *                 {@code MPI_ERRCODES_IGNORE} will be used.
  * @return intercommunicator between original group and the newly spawned group
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Intercomm spawnMultiple(
         String[] commands, String[][] argv, int[] maxprocs,

--- a/ompi/mpi/java/java/LongInt.java
+++ b/ompi/mpi/java/java/LongInt.java
@@ -27,6 +27,9 @@ private final int lSize, iOff, iSize;
 
 /**
  * The struct object will be created only in MPI class.
+ * @param longSize	size of long
+ * @param intOff	int offset
+ * @param intSize	int size
  * @see MPI#longInt
  */
 protected LongInt(int longSize, int intOff, int intSize)

--- a/ompi/mpi/java/java/MPI.java
+++ b/ompi/mpi/java/java/MPI.java
@@ -431,7 +431,7 @@ private static void initCommon() throws MPIException
  * <p>Java binding of the MPI operation {@code MPI_INIT}.
  * @param args arguments to the {@code main} method.
  * @return arguments
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static String[] Init(String[] args) throws MPIException
 {
@@ -451,7 +451,7 @@ private static native String [] Init_jni(String[] args);
  * @param args     arguments to the {@code main} method.
  * @param required desired level of thread support
  * @return provided level of thread support
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int InitThread(String[] args, int required) throws MPIException
 {
@@ -469,7 +469,7 @@ private static native int InitThread_jni(String[] args, int required)
 /**
  * Java binding of the MPI operation {@code MPI_QUERY_THREAD}.
  * @return provided level of thread support
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int queryThread() throws MPIException
 {
@@ -482,7 +482,7 @@ private static native int queryThread_jni() throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_IS_THREAD_MAIN}.
  * @return true if it is the main thread
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static boolean isThreadMain() throws MPIException
 {
@@ -495,7 +495,7 @@ private static native boolean isThreadMain_jni() throws MPIException;
 /**
  * Finalize MPI.
  * <p>Java binding of the MPI operation {@code MPI_FINALIZE}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void Finalize() throws MPIException
 {
@@ -510,7 +510,7 @@ private static native void Finalize_jni() throws MPIException;
  * Returns an elapsed time on the calling processor.
  * <p>Java binding of the MPI operation {@code MPI_WTIME}.
  * @return time in seconds since an arbitrary time in the past.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static double wtime() throws MPIException
 {
@@ -524,7 +524,7 @@ private static native double wtime_jni();
  * Returns resolution of timer.
  * <p>Java binding of the MPI operation {MPI_WTICK}.
  * @return resolution of {@code wtime} in seconds.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static double wtick() throws MPIException
 {
@@ -538,7 +538,7 @@ private static native double wtick_jni();
  * Returns the name of the processor on which it is called.
  * <p>Java binding of the MPI operation {@code MPI_GET_PROCESSOR_NAME}.
  * @return A unique specifier for the actual node.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 static public String getProcessorName() throws MPIException
 {
@@ -555,7 +555,7 @@ static private native int getProcessorName(byte[] buf);
  * <p>Java binding of the MPI operation {@code MPI_INITIALIZED}.
  * @return {@code true} if {@code Init} has been called,
  *         {@code false} otherwise.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 static public native boolean isInitialized() throws MPIException;
 
@@ -564,7 +564,7 @@ static public native boolean isInitialized() throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_FINALIZED}.
  * @return {@code true} if {@code Finalize} has been called,
  *         {@code false} otherwise.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 static public native boolean isFinalized() throws MPIException;
 
@@ -572,7 +572,7 @@ static public native boolean isFinalized() throws MPIException;
  * Attaches a user-provided buffer for sending.
  * <p>Java binding of the MPI operation {@code MPI_BUFFER_ATTACH}.
  * @param buffer initial buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 static public void attachBuffer(byte[] buffer) throws MPIException
 {
@@ -587,7 +587,7 @@ static private native void attachBuffer_jni(byte[] buffer);
  * Removes an existing buffer (for use in sending).
  * <p>Java binding of the MPI operation {@code MPI_BUFFER_DETACH}.
  * @return initial buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 static public byte[] detachBuffer() throws MPIException
 {
@@ -614,7 +614,7 @@ public static void pControl(int level, Object obj)
 
 /**
  * Check if MPI has been initialized and hasn't been finalized.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 protected static void check() throws MPIException
 {
@@ -768,8 +768,8 @@ protected static void assertDirectBuffer(Buffer buf)
 
 /**
  * Asserts that buffers are direct.
- * @param sendbuf
- * @param recvbuf 
+ * @param sendbuf	The send buffer
+ * @param recvbuf 	The receive buffer
  */
 protected static void assertDirectBuffer(Buffer sendbuf, Buffer recvbuf)
 {

--- a/ompi/mpi/java/java/Message.java
+++ b/ompi/mpi/java/java/Message.java
@@ -76,7 +76,7 @@ public boolean isNoProc()
  * @param tag    message tag
  * @param comm   communicator
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status mProbe(int source, int tag, Comm comm) throws MPIException
 {
@@ -95,7 +95,7 @@ private native long mProbe(int source, int tag, long comm, long[] status)
  * @param tag    message tag
  * @param comm   communicator
  * @return status object if there is a message, {@code null} otherwise
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Status imProbe(int source, int tag, Comm comm) throws MPIException
 {
@@ -112,6 +112,7 @@ private native Status imProbe(int source, int tag, long comm)
  * @param count number of elements in receve buffer
  * @param type  datatype of each receive buffer element
  * @return status object
+ * @throws MPIException	Signals that an MPI exception of some sort has occurred.
  */
 public Status mRecv(Object buf, int count, Datatype type) throws MPIException
 {
@@ -142,7 +143,7 @@ private native long mRecv(
  * @param count number of elements in receve buffer
  * @param type  datatype of each receive buffer element
  * @return request object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Request imRecv(Buffer buf, int count, Datatype type)
     throws MPIException

--- a/ompi/mpi/java/java/Op.java
+++ b/ompi/mpi/java/java/Op.java
@@ -118,7 +118,7 @@ public boolean isCommutative()
 
 /**
  * Java binding of the MPI operation {@code MPI_OP_FREE}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 @Override public native void free() throws MPIException;
 

--- a/ompi/mpi/java/java/Prequest.java
+++ b/ompi/mpi/java/java/Prequest.java
@@ -52,6 +52,7 @@ public final class Prequest extends Request
 {
 /**
  * Constructor used by {@code sendInit}, etc.
+ * @param handle	Handle for the Prequest object
  */
 protected Prequest(long handle)
 {
@@ -65,6 +66,7 @@ protected Prequest(long handle)
  * one of the {@code wait} or {@code test} operations.
  * On successful completion the request becomes inactive again.
  * It can be reactivated by a further call to {@code Start}.
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void start() throws MPIException
 {
@@ -77,7 +79,7 @@ private native long start(long request) throws MPIException;
  * Activate a list of communication requests.
  * <p>Java binding of the MPI operation {@code MPI_STARTALL}.
  * @param requests array of requests
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static void startAll(Prequest[] requests) throws MPIException
 {

--- a/ompi/mpi/java/java/Request.java
+++ b/ompi/mpi/java/java/Request.java
@@ -104,6 +104,7 @@ private native long free(long req) throws MPIException;
 /**
  * Mark a pending nonblocking communication for cancellation.
  * Java binding of the MPI operation {@code MPI_CANCEL}.
+ * @throws MPIException	Signals that an MPI exception of some sort has occurred.
  */
 public final void cancel() throws MPIException
 {
@@ -153,7 +154,7 @@ public final boolean isNull()
  * <p>Java binding of the MPI operation {@code MPI_WAIT}.
  * <p>After the call returns, the request object becomes inactive.
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Status waitStatus() throws MPIException
 {
@@ -169,7 +170,7 @@ private native long waitStatus(long request, long[] stat) throws MPIException;
  * Blocks until the operation identified by the request is complete.
  * <p>Java binding of the MPI operation {@code MPI_WAIT}.
  * <p>After the call returns, the request object becomes inactive.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final void waitFor() throws MPIException
 {
@@ -186,7 +187,7 @@ private native long waitFor(long request) throws MPIException;
  * <p>After the call, if the operation is complete (ie, if the return
  * value is non-null), the request object becomes inactive.
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Status testStatus() throws MPIException
 {
@@ -203,7 +204,7 @@ private native Status testStatus(long request) throws MPIException;
  * <p>After the call, if the operation is complete (ie, if the return
  * value is true), the request object becomes inactive.
  * @return true if the operation identified by the request, false otherwise
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final boolean test() throws MPIException
 {
@@ -223,7 +224,7 @@ private native boolean test(long handle) throws MPIException;
  * of array of {@code requests} becomes inactive.
  * @param requests array of requests
  * @return status object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Status waitAnyStatus(Request[] requests) throws MPIException
 {
@@ -247,7 +248,7 @@ private static native void waitAnyStatus(long[] requests, long[] status)
  * @return The index in array of {@code requests} for the request that
  * completed. If all of the requests are MPI_REQUEST_NULL, then index
  * is returned as {@code MPI.UNDEFINED}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int waitAny(Request[] requests) throws MPIException
 {
@@ -270,7 +271,7 @@ private static native int waitAny(long[] requests) throws MPIException;
  * If no request completed, {testAny} returns {@code null}.
  * @param requests array of requests
  * @return status object if one request completed, {@code null} otherwise.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Status testAnyStatus(Request[] requests) throws MPIException
 {
@@ -291,7 +292,7 @@ private static native Status testAnyStatus(long[] requests) throws MPIException;
  * @param requests array of requests
  * @return index of operation that completed, or {@code MPI.UNDEFINED}
  * if none completed.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int testAny(Request[] requests) throws MPIException
 {
@@ -313,7 +314,7 @@ private static native int testAny(long[] requests) throws MPIException;
  * elements of the status array will contain null status references.
  * @param requests array of requests
  * @return array of statuses
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Status[] waitAllStatus(Request[] requests) throws MPIException
 {
@@ -332,7 +333,7 @@ private static native Status[] waitAllStatus(long[] requests)
  * requests in the array have completed.
  * <p>Java binding of the MPI operation {@code MPI_WAITALL}.
  * @param requests array of requests
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static void waitAll(Request[] requests) throws MPIException
 {
@@ -353,7 +354,7 @@ private static native void waitAll(long[] requests) throws MPIException;
  * @param requests array of requests
  * @return array of statuses if all operations have completed,
  *         {@code null} otherwise.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Status[] testAllStatus(Request[] requests) throws MPIException
 {
@@ -374,7 +375,7 @@ private static native Status[] testAllStatus(long[] requests)
  * @param requests array of requests
  * @return {@code true} if all operations have completed,
  *         {@code false} otherwise.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static boolean testAll(Request[] requests) throws MPIException
 {
@@ -399,7 +400,7 @@ private static native boolean testAll(long[] requests) throws MPIException;
  * @param requests array of requests
  * @return array of statuses or {@code null} if the number of operations
  *         completed is {@code MPI_UNDEFINED}.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static Status[] waitSomeStatus(Request[] requests) throws MPIException
 {
@@ -423,7 +424,7 @@ private static native Status[] waitSomeStatus(long[] requests)
  * @param requests array of requests
  * @return array of indexes of {@code requests} that completed or {@code null}
  *         if the number of operations completed is {@code MPI_UNDEFINED}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int[] waitSome(Request[] requests) throws MPIException
 {
@@ -443,7 +444,7 @@ private static native int[] waitSome(long[] requests) throws MPIException;
  * length zero, otherwise the return value are as for {@code waitSome}.
  * @param requests array of requests
  * @return array of statuses
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static Status[] testSomeStatus(Request[] requests) throws MPIException
 {
@@ -464,7 +465,7 @@ private static native Status[] testSomeStatus(long[] requests)
  * length zero, otherwise the return value are as for {@code waitSome}.
  * @param requests array of requests
  * @return array of indexes of {@code requests} that completed.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public static int[] testSome(Request[] requests) throws MPIException
 {

--- a/ompi/mpi/java/java/ShortInt.java
+++ b/ompi/mpi/java/java/ShortInt.java
@@ -27,6 +27,9 @@ private final int sSize, iOff, iSize;
 
 /**
  * The struct object will be created only in MPI class.
+ * @param shortSize	short size
+ * @param intOff	int offset
+ * @param intSize	int size
  * @see MPI#shortInt
  */
 protected ShortInt(int shortSize, int intOff, int intSize)

--- a/ompi/mpi/java/java/Status.java
+++ b/ompi/mpi/java/java/Status.java
@@ -72,7 +72,7 @@ protected Status()
  * <p>Java binding of the MPI operation {@code MPI_GET_COUNT}.
  * @param datatype datatype of each item in receive buffer
  * @return number of received entries
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int getCount(Datatype datatype) throws MPIException
 {
@@ -94,7 +94,7 @@ private native int getCount(
  * Tests if the communication was cancelled.
  * <p>Java binding of the MPI operation {@code MPI_TEST_CANCELLED}.
  * @return true if the operation was succesfully cancelled, false otherwise
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public boolean isCancelled() throws MPIException
 {
@@ -117,7 +117,7 @@ private native boolean isCancelled(
  * <p>Java binding of the MPI operation {@code MPI_GET_ELEMENTS}.
  * @param datatype datatype used by receive operation
  * @return number of received basic elements
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public int getElements(Datatype datatype) throws MPIException
 {

--- a/ompi/mpi/java/java/Struct.java
+++ b/ompi/mpi/java/java/Struct.java
@@ -64,7 +64,7 @@ private void createStruct() throws MPIException
 /**
  * Returns the extent of the struct data type.
  * @return Extent of the struct data type.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final int getExtent() throws MPIException
 {
@@ -75,7 +75,7 @@ public final int getExtent() throws MPIException
 /**
  * Returns the data type of the struct.
  * @return The data type of the struct.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final Datatype getType() throws MPIException
 {
@@ -98,11 +98,12 @@ private <T extends Data> T newData(ByteBuffer buffer, int offset)
     return (T)d;
 }
 
+@SuppressWarnings("javadoc")
 /**
  * Gets a Data object in order to access to the buffer.
  * @param buffer the Data object will read/write on this buffer.
  * @return Data object
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final <T extends Data> T getData(ByteBuffer buffer) throws MPIException
 {
@@ -110,13 +111,14 @@ public final <T extends Data> T getData(ByteBuffer buffer) throws MPIException
     return newData(buffer, 0);
 }
 
+@SuppressWarnings("javadoc")
 /**
  * Gets a Data object in order to access to the struct at the
  * specified position of a struct array stored in a Buffer.
  * @param buffer The Data object will read/write on this buffer.
  * @param index  Index of the struct in the buffer.
  * @return Data object.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final <T extends Data> T getData(ByteBuffer buffer, int index)
     throws MPIException
@@ -125,11 +127,12 @@ public final <T extends Data> T getData(ByteBuffer buffer, int index)
     return newData(buffer, index * extent);
 }
 
+@SuppressWarnings("javadoc")
 /**
  * Gets a Data object in order to access to the byte array.
  * @param array The Data object will read/write on this byte array.
  * @return Data object.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final <T extends Data> T getData(byte[] array) throws MPIException
 {
@@ -138,13 +141,14 @@ public final <T extends Data> T getData(byte[] array) throws MPIException
     return getData(buffer);
 }
 
+@SuppressWarnings("javadoc")
 /**
  * Gets a Data object in order to access to the struct at the
  * specified position of a struct array stored in a byte array.
  * @param array The Data object will read/write on this byte array.
  * @param index Index of the struct in the array.
  * @return Data object.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final <T extends Data> T getData(byte[] array, int index)
     throws MPIException
@@ -323,7 +327,7 @@ public final int addDouble(int length)
  * Adds a struct field to this struct.
  * @param struct Type of the field.
  * @return Offset of the new field.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public final int addStruct(Struct struct) throws MPIException
 {
@@ -335,7 +339,7 @@ public final int addStruct(Struct struct) throws MPIException
  * @param struct Type of the array.
  * @param length Length of the array.
  * @return Offset of the new field.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final int addStruct(Struct struct, int length) throws MPIException
 {
@@ -347,7 +351,7 @@ public final int addStruct(Struct struct, int length) throws MPIException
  * Adds a field of the specified data type.
  * @param type Data type.
  * @return Offset of the new field.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final int addData(Datatype type) throws MPIException
 {
@@ -359,7 +363,7 @@ public final int addData(Datatype type) throws MPIException
  * @param type Data type.
  * @param length Length of the array.
  * @return Offset of the new field.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public final int addData(Datatype type, int length) throws MPIException
 {
@@ -726,6 +730,7 @@ public abstract class Data
         buffer.putDouble(offset + field + index * 8, v);
     }
 
+    @SuppressWarnings("javadoc")
     /**
      * Gets the struct data of a field.
      * @param struct Struct type.
@@ -740,6 +745,7 @@ public abstract class Data
         return s.newData(buffer, offset + field);
     }
 
+    @SuppressWarnings("javadoc")
     /**
      * Gets the struct data at the specified position of a struct array.
      * @param struct Struct type.
@@ -776,7 +782,7 @@ public abstract class Data
      * @param field Offset of the buffer array.
      * @param index Index of the buffer in the array.
      * @return Buffer object.
-     * @throws MPIException 
+     * @throws MPIException Signals that an MPI exception of some sort has occurred. 
      */
     protected final ByteBuffer getBuffer(Datatype type, int field, int index)
         throws MPIException

--- a/ompi/mpi/java/java/UserFunction.java
+++ b/ompi/mpi/java/java/UserFunction.java
@@ -58,6 +58,7 @@ public abstract class UserFunction
  * @param inOutVec in-out array of accumulator locations
  * @param count    number of items in arrays 
  * @param datatype type of each item
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void call(Object inVec, Object inOutVec, int count, Datatype datatype)
         throws MPIException
@@ -71,6 +72,7 @@ public void call(Object inVec, Object inOutVec, int count, Datatype datatype)
  * @param inOut    in-out direct byte buffer of accumulator locations
  * @param count    number of items in buffers
  * @param datatype type of each item
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void call(ByteBuffer in, ByteBuffer inOut, int count, Datatype datatype)
         throws MPIException

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -34,7 +34,7 @@ private long handle;
  * @param dispUnit local unit size for displacements (buffer elements)
  * @param info     info object
  * @param comm     communicator
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Win(Buffer base, int size, int dispUnit, Info info, Comm comm)
     throws MPIException
@@ -82,7 +82,7 @@ private int getBaseType(Datatype orgType, Datatype targetType)
 /**
  * Java binding of the MPI operation {@code MPI_GET_GROUP}.
  * @return group of processes which share access to the window
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public Group getGroup() throws MPIException
 {
@@ -101,7 +101,7 @@ private native long getGroup(long win) throws MPIException;
  * @param targetDisp  displacement from start of window to target buffer
  * @param targetCount number of entries in target buffer
  * @param targetType  datatype of each entry in target buffer
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void put(Buffer origin, int orgCount, Datatype orgType,
                 int targetRank, int targetDisp, int targetCount,
@@ -132,6 +132,7 @@ private native void put(
  * @param targetDisp  displacement from start of window to target buffer
  * @param targetCount number of entries in target buffer
  * @param targetType  datatype of each entry in target buffer
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void get(Buffer origin, int orgCount, Datatype orgType,
                 int targetRank, int targetDisp, int targetCount,
@@ -163,6 +164,7 @@ private native void get(
  * @param targetCount number of entries in target buffer
  * @param targetType  datatype of each entry in target buffer
  * @param op          reduce operation
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void accumulate(Buffer origin, int orgCount, Datatype orgType,
                        int targetRank, int targetDisp, int targetCount,
@@ -187,6 +189,7 @@ private native void accumulate(
 /**
  * Java binding of {@code MPI_WIN_FENCE}.
  * @param assertion program assertion
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void fence(int assertion) throws MPIException
 {
@@ -200,7 +203,7 @@ private native void fence(long win, int assertion) throws MPIException;
  * Java binding of the MPI operation {@code MPI_WIN_START}.
  * @param group     group of target processes
  * @param assertion program assertion
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void start(Group group, int assertion) throws MPIException
 {
@@ -213,7 +216,7 @@ private native void start(long win, long group, int assertion)
 
 /**
  * Java binding of the MPI operation {@code MPI_WIN_COMPLETE}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void complete() throws MPIException
 {
@@ -227,7 +230,7 @@ private native void complete(long win) throws MPIException;
  * Java binding of the MPI operation {@code MPI_WIN_POST}.
  * @param group     group of origin processes
  * @param assertion program assertion
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void post(Group group, int assertion) throws MPIException
 {
@@ -240,7 +243,7 @@ private native void post(long win, long group, int assertion)
 
 /**
  * Java binding of the MPI operation {@code MPI_WIN_WAIT}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void waitFor() throws MPIException
 {
@@ -253,7 +256,7 @@ private native void waitFor(long win) throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_WIN_TEST}.
  * @return true if success
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public boolean test() throws MPIException
 {
@@ -268,7 +271,7 @@ private native boolean test(long win) throws MPIException;
  * @param lockType  either MPI.LOCK_EXCLUSIVE or MPI.LOCK_SHARED
  * @param rank      rank of locked window
  * @param assertion program assertion
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void lock(int lockType, int rank, int assertion) throws MPIException
 {
@@ -282,7 +285,7 @@ private native void lock(long win, int lockType, int rank, int assertion)
 /**
  * Java binding of the MPI operation {@code MPI_WIN_UNLOCK}.
  * @param rank rank of window
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void unlock(int rank) throws MPIException
 {
@@ -295,7 +298,7 @@ private native void unlock(long win, int rank) throws MPIException;
 /**
  * Java binding of the MPI operation {@code MPI_WIN_SET_ERRHANDLER}.
  * @param errhandler new MPI error handler for window
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void setErrhandler(Errhandler errhandler) throws MPIException
 {
@@ -309,7 +312,7 @@ private native void setErrhandler(long win, long errhandler)
 /**
  * Java binding of the MPI operation {@code MPI_WIN_CALL_ERRHANDLER}.
  * @param errorCode error code
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 public void callErrhandler(int errorCode) throws MPIException
 {
@@ -323,7 +326,7 @@ private native void callErrhandler(long handle, int errorCode)
  * Create a new attribute key.
  * <p>Java binding of the MPI operation {@code MPI_WIN_CREATE_KEYVAL}.
  * @return attribute key for future access
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static int createKeyval() throws MPIException
 {
@@ -337,7 +340,7 @@ private static native int createKeyval_jni() throws MPIException;
  * Frees an attribute key.
  * <p>Java binding of the MPI operation {@code MPI_WIN_FREE_KEYVAL}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public static void freeKeyval(int keyval) throws MPIException
 {
@@ -352,7 +355,7 @@ private static native void freeKeyval_jni(int keyval) throws MPIException;
  * <p>Java binding of the MPI operation {@code MPI_WIN_SET_ATTR}.
  * @param keyval attribute key
  * @param value  attribute value
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void setAttr(int keyval, Object value) throws MPIException
 {
@@ -368,7 +371,7 @@ private native void setAttr(long win, int keyval, byte[] value)
  * <p>Java binding of the MPI operation {@code MPI_WIN_GET_ATTR}.
  * @param keyval attribute key
  * @return attribute value or null if no attribute is associated with the key.
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public Object getAttr(int keyval) throws MPIException
 {
@@ -383,7 +386,7 @@ private native Object getAttr(long win, int keyval) throws MPIException;
  * Deletes an attribute value associated with a key.
  * <p>Java binding of the MPI operation {@code MPI_WIN_DELETE_ATTR}.
  * @param keyval attribute key
- * @throws MPIException
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
  */
 public void deleteAttr(int keyval) throws MPIException
 {
@@ -395,7 +398,7 @@ private native void deleteAttr(long win, int keyval) throws MPIException;
 
 /**
  * Java binding of {@code MPI_WIN_FREE}.
- * @throws MPIException 
+ * @throws MPIException Signals that an MPI exception of some sort has occurred. 
  */
 @Override public void free() throws MPIException
 {


### PR DESCRIPTION
Manual cherry-pick from 580251e and 6bca748.

Note: Documentation changes only

Fixes open-mpi/ompi#2040

Signed-off-by: Nathaniel Graham ngraham@lanl.gov

@rhc54 
