### PR TITLE
Adds darwin headers directory with Darwin JDK

### DIFF
--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -186,6 +186,11 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
                           # too.  Ugh.
                           AS_IF([test -d "$with_jdk_headers/solaris"],
                                 [OPAL_JDK_CPPFLAGS="$OPAL_JDK_CPPFLAGS -I$with_jdk_headers/solaris"])
+                          # Darwin JDK also require -I<blah>/darwin.
+                          # See if that's there, and if so, add a -I for that,
+                          # too.  Ugh.
+                          AS_IF([test -d "$with_jdk_headers/darwin"],
+                                [OPAL_JDK_CPPFLAGS="$OPAL_JDK_CPPFLAGS -I$with_jdk_headers/darwin"])
 
                           CPPFLAGS="$CPPFLAGS $OPAL_JDK_CPPFLAGS"])
                    AC_CHECK_HEADER([jni.h], [],


### PR DESCRIPTION
(cherry picked from commit open-mpi/ompi@5e77bdeb2559a2f456ac09b48029e551c1e6a319)

Fixes an issue on mac - darwin where configure could not find java header files.

Thanks to @hppritcha for finding it.

Signed-off-by: Nathaniel Graham ngraham@lanl.gov
