### PR TITLE
v2.0.2: pkg-config: fix static linking

### DIFF
--- a/ompi/tools/wrappers/ompi-c.pc.in
+++ b/ompi/tools/wrappers/ompi-c.pc.in
@@ -15,6 +15,6 @@ libdir=@libdir@
 # dependencies), so only list these in Libs.private.
 #
 Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -lmpi
-Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
+Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 #
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_CFLAGS@

--- a/ompi/tools/wrappers/ompi-cxx.pc.in
+++ b/ompi/tools/wrappers/ompi-cxx.pc.in
@@ -15,6 +15,6 @@ libdir=@libdir@
 # dependencies), so only list these in Libs.private.
 #
 Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_WRAPPER_CXX_LIB@ -lmpi
-Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
+Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 #
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_CXXFLAGS@

--- a/ompi/tools/wrappers/ompi-fort.pc.in
+++ b/ompi/tools/wrappers/ompi-fort.pc.in
@@ -15,5 +15,5 @@ libdir=@libdir@
 # dependencies), so only list these in Libs.private.
 #
 Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi
-Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
+Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_FCFLAGS@

--- a/orte/tools/wrappers/orte.pc.in
+++ b/orte/tools/wrappers/orte.pc.in
@@ -15,7 +15,7 @@ libdir=@libdir@
 # dependencies), so only list these in Libs.private.
 #
 Libs: -L${libdir} @ORTE_PKG_CONFIG_LDFLAGS@ -lopen-rte
-Libs.private: @ORTE_WRAPPER_EXTRA_LIBS@
+Libs.private: -lopen-pal @ORTE_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because we
 # will not be installing this .pc file unless --enable-devel-headers is


### PR DESCRIPTION
We need to list all major project libraries in the private libraries
line to enable static linking to work properly.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

(cherry picked from commit open-mpi/ompi@fb894e6e3e839d0322043fc25c217b7cf2aa7e62)

@hjelmn please review
