### PR TITLE
osc/rdma: fix typo in compare-and-swap

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -703,7 +703,7 @@ int ompi_osc_rdma_compare_and_swap (const void *origin_addr, const void *compare
         return OMPI_ERR_RMA_SYNC;
     }
 
-    ret = osc_rdma_get_remote_segment (module, peer, target_disp, 8, &target_address, &target_handle);
+    ret = osc_rdma_get_remote_segment (module, peer, target_disp, dt->super.size, &target_address, &target_handle);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
         return ret;
     }


### PR DESCRIPTION
This commit fixes a typo in compare-and-swap when retrieving the
memory region associated with a displacement. It was erroneously 8
bytes instead of the datatype size. This can cause an incorrect RMA
range error when the compare-and-swap is less than 4 bytes from the
end of the region.

Fixed open-mpi/ompi#2080

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

(cherry picked from commit open-mpi/ompi@59bae1a330b32681ce956d4e4e003c6f0be13f07)

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov

:bot:label:bug
:bot:milestone:v2.0.2
:bot:assign: @nrgraham23 
