### PR TITLE
v2.x: Eliminate the litter problem by moving the PMIx connection point

### DIFF
--- a/orte/util/session_dir.c
+++ b/orte/util/session_dir.c
@@ -73,10 +73,6 @@ static int orte_create_dir(char *directory);
 
 static bool orte_dir_check_file(const char *root, const char *path);
 
-static char *orte_build_job_session_dir(char *top_dir,
-                                        orte_process_name_t *proc,
-                                        orte_jobid_t jobid);
-
 #define OMPI_PRINTF_FIX_STRING(a) ((NULL == a) ? "(null)" : a)
 
 /****************************
@@ -674,9 +670,9 @@ orte_dir_check_file(const char *root, const char *path)
     return true;
 }
 
-static char *orte_build_job_session_dir(char *top_dir,
-                                        orte_process_name_t *proc,
-                                        orte_jobid_t jobid)
+char *orte_build_job_session_dir(char *top_dir,
+                                 orte_process_name_t *proc,
+                                 orte_jobid_t jobid)
 {
     char *jobfam = NULL;
     char *job_session_dir;

--- a/orte/util/session_dir.h
+++ b/orte/util/session_dir.h
@@ -162,6 +162,10 @@ ORTE_DECLSPEC int orte_session_dir_finalize(orte_process_name_t *proc);
  */
 ORTE_DECLSPEC int orte_session_dir_cleanup(orte_jobid_t jobid);
 
+ORTE_DECLSPEC char *orte_build_job_session_dir(char *top_dir,
+                                               orte_process_name_t *proc,
+                                               orte_jobid_t jobid);
+
 END_C_DECLS
 
 #endif  /* ORTE_SESSION_DIR_H_HAS_BEEN_INCLUDED */


### PR DESCRIPTION
Eliminate the litter problem by moving the PMIx connection point down under the mpirun job-family session directory, which is where it belongs. The directory being passed down was incorrectly set to the top-level tmp directory, thus littering /tmp on many systems
